### PR TITLE
feat: aggregator batch size

### DIFF
--- a/aggregator/benches/aggregator.rs
+++ b/aggregator/benches/aggregator.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use plonky2::plonk::circuit_data::{CircuitConfig, CommonCircuitData};
-use wormhole_aggregator::{aggregator::WormholeProofAggregator, MAX_NUM_PROOFS_TO_AGGREGATE};
+use wormhole_aggregator::{aggregator::WormholeProofAggregator, DEFAULT_NUM_PROOFS_TO_AGGREGATE};
 use wormhole_circuit::circuit::{C, D, F};
 use wormhole_verifier::ProofWithPublicInputs;
 
@@ -11,7 +11,7 @@ const DUMMY_PROOF_BYTES: &[u8] = include_bytes!("../data/dummy_proof_zk.bin");
 
 fn deserialize_proofs(
     common_data: &CommonCircuitData<F, D>,
-) -> [ProofWithPublicInputs<F, C, D>; MAX_NUM_PROOFS_TO_AGGREGATE] {
+) -> [ProofWithPublicInputs<F, C, D>; DEFAULT_NUM_PROOFS_TO_AGGREGATE] {
     let proof = ProofWithPublicInputs::from_bytes(DUMMY_PROOF_BYTES.to_vec(), common_data).unwrap();
     std::array::from_fn(|_| proof.clone())
 }
@@ -21,7 +21,8 @@ fn aggregate_proofs_benchmark(c: &mut Criterion) {
     c.bench_function("aggregator_aggregate_proofs", |b| {
         b.iter(|| {
             let config = CircuitConfig::standard_recursion_zk_config();
-            let mut aggregator = WormholeProofAggregator::new(config);
+            let mut aggregator =
+                WormholeProofAggregator::<{ DEFAULT_NUM_PROOFS_TO_AGGREGATE }>::new(config);
 
             let proofs = deserialize_proofs(&aggregator.inner.inner_verifier.circuit_data.common);
 

--- a/aggregator/src/lib.rs
+++ b/aggregator/src/lib.rs
@@ -2,4 +2,4 @@ pub mod aggregator;
 pub mod circuit;
 
 /// The maximum numbers of proofs to aggregate into a composite proof.
-pub const MAX_NUM_PROOFS_TO_AGGREGATE: usize = 10;
+pub const DEFAULT_NUM_PROOFS_TO_AGGREGATE: usize = 10;

--- a/tests/src/aggregator/aggregator_tests.rs
+++ b/tests/src/aggregator/aggregator_tests.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-use wormhole_aggregator::{aggregator::WormholeProofAggregator, MAX_NUM_PROOFS_TO_AGGREGATE};
+use wormhole_aggregator::{aggregator::WormholeProofAggregator, DEFAULT_NUM_PROOFS_TO_AGGREGATE};
 use wormhole_circuit::inputs::CircuitInputs;
 use wormhole_prover::WormholeProver;
 
@@ -13,7 +13,8 @@ fn push_proof_to_buffer() {
     let inputs = CircuitInputs::test_inputs();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
-    let mut aggregator = WormholeProofAggregator::new(circuit_config());
+    let mut aggregator =
+        WormholeProofAggregator::<{ DEFAULT_NUM_PROOFS_TO_AGGREGATE }>::new(circuit_config());
     aggregator.push_proof(proof).unwrap();
 
     let proofs_buffer = aggregator.proofs_buffer.unwrap();
@@ -27,10 +28,11 @@ fn push_proof_to_full_buffer() {
     let inputs = CircuitInputs::test_inputs();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
-    let mut aggregator = WormholeProofAggregator::new(circuit_config());
+    let mut aggregator =
+        WormholeProofAggregator::<{ DEFAULT_NUM_PROOFS_TO_AGGREGATE }>::new(circuit_config());
 
     // Fill up the proof buffer.
-    for _ in 0..MAX_NUM_PROOFS_TO_AGGREGATE {
+    for _ in 0..DEFAULT_NUM_PROOFS_TO_AGGREGATE {
         aggregator.push_proof(proof.clone()).unwrap();
     }
 
@@ -38,7 +40,7 @@ fn push_proof_to_full_buffer() {
     assert!(result.is_err());
 
     let proofs_buffer = aggregator.proofs_buffer.unwrap();
-    assert_eq!(proofs_buffer.len(), MAX_NUM_PROOFS_TO_AGGREGATE);
+    assert_eq!(proofs_buffer.len(), DEFAULT_NUM_PROOFS_TO_AGGREGATE);
 }
 
 #[test]
@@ -48,7 +50,8 @@ fn aggregate_single_proof() {
     let inputs = CircuitInputs::test_inputs();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
-    let mut aggregator = WormholeProofAggregator::new(circuit_config());
+    let mut aggregator =
+        WormholeProofAggregator::<{ DEFAULT_NUM_PROOFS_TO_AGGREGATE }>::new(circuit_config());
     aggregator.push_proof(proof).unwrap();
 
     aggregator.aggregate().unwrap();

--- a/tests/src/aggregator/circuit_tests.rs
+++ b/tests/src/aggregator/circuit_tests.rs
@@ -3,7 +3,7 @@ use crate::aggregator::circuit_config;
 use crate::circuit_helpers::{build_and_prove_test, setup_test_builder_and_witness};
 use test_helpers::storage_proof::TestInputs;
 use wormhole_aggregator::circuit::{WormholeProofAggregatorInner, WormholeProofAggregatorTargets};
-use wormhole_aggregator::MAX_NUM_PROOFS_TO_AGGREGATE;
+use wormhole_aggregator::DEFAULT_NUM_PROOFS_TO_AGGREGATE;
 use wormhole_circuit::circuit::{CircuitFragment, C, D, F};
 use wormhole_circuit::inputs::CircuitInputs;
 use wormhole_prover::WormholeProver;
@@ -13,7 +13,10 @@ fn run_test(
     proofs: Vec<ProofWithPublicInputs<F, C, D>>,
 ) -> anyhow::Result<plonky2::plonk::proof::ProofWithPublicInputs<F, C, D>> {
     let (mut builder, mut pw) = setup_test_builder_and_witness(false);
-    let targets = WormholeProofAggregatorTargets::new(&mut builder, circuit_config());
+    let targets = WormholeProofAggregatorTargets::<{ DEFAULT_NUM_PROOFS_TO_AGGREGATE }>::new(
+        &mut builder,
+        circuit_config(),
+    );
     WormholeProofAggregatorInner::circuit(&targets, &mut builder);
 
     let mut aggregator = WormholeProofAggregatorInner::new(circuit_config());
@@ -25,8 +28,8 @@ fn run_test(
 #[test]
 fn build_and_verify_proof() {
     // Create proofs.
-    let mut proofs = Vec::with_capacity(MAX_NUM_PROOFS_TO_AGGREGATE);
-    for _ in 0..MAX_NUM_PROOFS_TO_AGGREGATE {
+    let mut proofs = Vec::with_capacity(DEFAULT_NUM_PROOFS_TO_AGGREGATE);
+    for _ in 0..DEFAULT_NUM_PROOFS_TO_AGGREGATE {
         let prover = WormholeProver::new(circuit_config());
         let inputs = CircuitInputs::test_inputs();
         let proof = prover.commit(&inputs).unwrap().prove().unwrap();
@@ -38,8 +41,8 @@ fn build_and_verify_proof() {
 #[test]
 fn few_proofs_pass() {
     // Create proofs.
-    let mut proofs = Vec::with_capacity(MAX_NUM_PROOFS_TO_AGGREGATE);
-    for _ in 0..(MAX_NUM_PROOFS_TO_AGGREGATE / 2) {
+    let mut proofs = Vec::with_capacity(DEFAULT_NUM_PROOFS_TO_AGGREGATE);
+    for _ in 0..(DEFAULT_NUM_PROOFS_TO_AGGREGATE / 2) {
         let prover = WormholeProver::new(circuit_config());
         let inputs = CircuitInputs::test_inputs();
         let proof = prover.commit(&inputs).unwrap().prove().unwrap();


### PR DESCRIPTION
Makes the aggregator batch size configurable via a generic constant, `N`.

Depends on changes introduces in #20.