### PR TITLE
Return version in circuit builder crate

### DIFF
--- a/wormhole/circuit-builder/Cargo.toml
+++ b/wormhole/circuit-builder/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 qp-plonky2 = { workspace = true, features = ["default"] }
-wormhole-circuit = { package = "qp-wormhole-circuit", path = "../circuit", default-features = false, features = [
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "0.1.6", path = "../circuit", default-features = false, features = [
 	"std",
 ] }
-zk-circuits-common = { package = "qp-zk-circuits-common", path = "../../common" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "0.1.6", path = "../../common" }


### PR DESCRIPTION
found out the hard way that it's necessary for crates.io publishing
