### PR TITLE
feat: miner aggregation support 

### DIFF
--- a/wormhole/aggregator/examples/generate_l1_fixture.rs
+++ b/wormhole/aggregator/examples/generate_l1_fixture.rs
@@ -124,6 +124,10 @@ fn write_hex_file(path: &Path, bytes: &[u8]) -> Result<()> {
         .with_context(|| format!("failed to write {}", path.display()))
 }
 
+fn write_bin_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    fs::write(path, bytes).with_context(|| format!("failed to write {}", path.display()))
+}
+
 fn digest_hex(digest: &BytesDigest) -> String {
     hex::encode(digest.as_ref())
 }
@@ -141,8 +145,6 @@ fn parse_l1_inputs(
 
 fn main() -> Result<()> {
     let args = parse_args()?;
-    fs::create_dir_all(&args.out)
-        .with_context(|| format!("failed to create {}", args.out.display()))?;
 
     let mut aggregator = Layer1Aggregator::new(
         &args.bins_dir,
@@ -160,7 +162,7 @@ fn main() -> Result<()> {
     let layer0_common = aggregator
         .load_common_data(CircuitType::Leaf)
         .context("failed to load layer-0 common data")?;
-    let mut l0_candidate_files = Vec::new();
+    let mut l0_candidates = Vec::new();
 
     for (index, path) in args.l0_proofs.iter().enumerate() {
         let proof_bytes = read_hex_file(path)?;
@@ -172,8 +174,7 @@ fn main() -> Result<()> {
             .with_context(|| format!("failed to add {}", path.display()))?;
 
         let file_name = format!("l0_candidate_{}.hex", index);
-        write_hex_file(&args.out.join(&file_name), &proof_bytes)?;
-        l0_candidate_files.push(file_name);
+        l0_candidates.push((file_name, proof_bytes));
     }
 
     let l1_proof = aggregator
@@ -185,10 +186,20 @@ fn main() -> Result<()> {
 
     let l1_inputs = parse_l1_inputs(&l1_proof).context("failed to parse layer-1 public inputs")?;
     let l1_proof_bytes = l1_proof.to_bytes();
+
+    fs::create_dir_all(&args.out)
+        .with_context(|| format!("failed to create {}", args.out.display()))?;
+    for (file_name, proof_bytes) in &l0_candidates {
+        write_hex_file(&args.out.join(file_name), proof_bytes)?;
+    }
     write_hex_file(&args.out.join("l1_aggregate.hex"), &l1_proof_bytes)?;
+    write_bin_file(&args.out.join("l1_aggregate.bin"), &l1_proof_bytes)?;
 
     let expected = ExpectedBundle {
-        l0_candidates: l0_candidate_files,
+        l0_candidates: l0_candidates
+            .iter()
+            .map(|(file_name, _)| file_name.clone())
+            .collect(),
         l1_aggregate: "l1_aggregate.hex".to_string(),
         aggregator_address: digest_hex(&l1_inputs.aggregator_address),
         asset_id: l1_inputs.asset_id,

--- a/wormhole/aggregator/examples/generate_l1_fixture.rs
+++ b/wormhole/aggregator/examples/generate_l1_fixture.rs
@@ -1,0 +1,226 @@
+use anyhow::{anyhow, bail, Context, Result};
+use plonky2::{field::types::PrimeField64, plonk::proof::ProofWithPublicInputs};
+use qp_wormhole_aggregator::aggregator::{AggregationBackend, CircuitType, Layer1Aggregator};
+use qp_wormhole_inputs::{BytesDigest, Layer1AggregatedPublicCircuitInputs};
+use serde::Serialize;
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+use zk_circuits_common::circuit::{C, D, F};
+
+#[derive(Debug)]
+struct Args {
+    bins_dir: PathBuf,
+    out: PathBuf,
+    aggregator_address: [u8; 32],
+    l0_proofs: Vec<PathBuf>,
+}
+
+#[derive(Serialize)]
+struct ExpectedExit {
+    summed_output_amount: u32,
+    exit_account: String,
+}
+
+#[derive(Serialize)]
+struct ExpectedBundle {
+    l0_candidates: Vec<String>,
+    l1_aggregate: String,
+    aggregator_address: String,
+    asset_id: u32,
+    volume_fee_bps: u32,
+    block_hash: String,
+    block_number: u32,
+    total_exit_slots: u32,
+    exits: Vec<ExpectedExit>,
+    nullifiers: Vec<String>,
+}
+
+fn default_aggregator_address() -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    bytes[..8].copy_from_slice(&2u64.to_le_bytes());
+    bytes
+}
+
+fn usage() -> &'static str {
+    "Usage: cargo run --release -p qp-wormhole-aggregator --example generate_l1_fixture -- \\
+        --bins-dir <generated-bins> --out <test-data-dir> --l0-proof <proof.hex> \\
+        [--l0-proof <proof.hex> ...] [--aggregator-address <32-byte-hex>]"
+}
+
+fn parse_hex_digest(value: &str) -> Result<[u8; 32]> {
+    let value = value.strip_prefix("0x").unwrap_or(value);
+    let bytes = hex::decode(value).context("failed to decode aggregator address hex")?;
+    bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("aggregator address must be exactly 32 bytes"))
+}
+
+fn parse_args() -> Result<Args> {
+    let mut raw = env::args().skip(1);
+    let mut bins_dir = None;
+    let mut out = None;
+    let mut aggregator_address = default_aggregator_address();
+    let mut l0_proofs = Vec::new();
+
+    while let Some(arg) = raw.next() {
+        match arg.as_str() {
+            "--bins-dir" => {
+                bins_dir = Some(PathBuf::from(
+                    raw.next()
+                        .ok_or_else(|| anyhow!("--bins-dir requires a value"))?,
+                ));
+            }
+            "--out" => {
+                out = Some(PathBuf::from(
+                    raw.next()
+                        .ok_or_else(|| anyhow!("--out requires a value"))?,
+                ));
+            }
+            "--aggregator-address" => {
+                aggregator_address = parse_hex_digest(
+                    &raw.next()
+                        .ok_or_else(|| anyhow!("--aggregator-address requires a value"))?,
+                )?;
+            }
+            "--l0-proof" => {
+                l0_proofs.push(PathBuf::from(
+                    raw.next()
+                        .ok_or_else(|| anyhow!("--l0-proof requires a value"))?,
+                ));
+            }
+            "--help" | "-h" => {
+                println!("{}", usage());
+                std::process::exit(0);
+            }
+            other => bail!("unknown argument `{}`\n{}", other, usage()),
+        }
+    }
+
+    let bins_dir = bins_dir.ok_or_else(|| anyhow!("missing --bins-dir\n{}", usage()))?;
+    let out = out.ok_or_else(|| anyhow!("missing --out\n{}", usage()))?;
+    if l0_proofs.is_empty() {
+        bail!("at least one --l0-proof is required\n{}", usage());
+    }
+
+    Ok(Args {
+        bins_dir,
+        out,
+        aggregator_address,
+        l0_proofs,
+    })
+}
+
+fn read_hex_file(path: &Path) -> Result<Vec<u8>> {
+    let hex =
+        fs::read_to_string(path).with_context(|| format!("failed to read {}", path.display()))?;
+    hex::decode(hex.trim()).with_context(|| format!("failed to decode {}", path.display()))
+}
+
+fn write_hex_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    fs::write(path, format!("{}\n", hex::encode(bytes)))
+        .with_context(|| format!("failed to write {}", path.display()))
+}
+
+fn digest_hex(digest: &BytesDigest) -> String {
+    hex::encode(digest.as_ref())
+}
+
+fn parse_l1_inputs(
+    proof: &ProofWithPublicInputs<F, C, D>,
+) -> Result<Layer1AggregatedPublicCircuitInputs> {
+    let public_inputs = proof
+        .public_inputs
+        .iter()
+        .map(|felt| felt.to_canonical_u64())
+        .collect::<Vec<_>>();
+    Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&public_inputs)
+}
+
+fn main() -> Result<()> {
+    let args = parse_args()?;
+    fs::create_dir_all(&args.out)
+        .with_context(|| format!("failed to create {}", args.out.display()))?;
+
+    let mut aggregator = Layer1Aggregator::new(
+        &args.bins_dir,
+        BytesDigest::new_unchecked(args.aggregator_address),
+    )
+    .context("failed to create layer-1 aggregator")?;
+    if args.l0_proofs.len() != aggregator.batch_size() {
+        bail!(
+            "expected {} L0 proofs for generated binaries, got {}",
+            aggregator.batch_size(),
+            args.l0_proofs.len()
+        );
+    }
+
+    let layer0_common = aggregator
+        .load_common_data(CircuitType::Leaf)
+        .context("failed to load layer-0 common data")?;
+    let mut l0_candidate_files = Vec::new();
+
+    for (index, path) in args.l0_proofs.iter().enumerate() {
+        let proof_bytes = read_hex_file(path)?;
+        let proof =
+            ProofWithPublicInputs::<F, C, D>::from_bytes(proof_bytes.clone(), &layer0_common)
+                .map_err(|err| anyhow!("failed to deserialize {}: {}", path.display(), err))?;
+        aggregator
+            .push_proof(proof)
+            .with_context(|| format!("failed to add {}", path.display()))?;
+
+        let file_name = format!("l0_candidate_{}.hex", index);
+        write_hex_file(&args.out.join(&file_name), &proof_bytes)?;
+        l0_candidate_files.push(file_name);
+    }
+
+    let l1_proof = aggregator
+        .aggregate()
+        .context("failed to prove layer-1 aggregate")?;
+    aggregator
+        .verify(l1_proof.clone())
+        .context("generated layer-1 proof did not verify")?;
+
+    let l1_inputs = parse_l1_inputs(&l1_proof).context("failed to parse layer-1 public inputs")?;
+    let l1_proof_bytes = l1_proof.to_bytes();
+    write_hex_file(&args.out.join("l1_aggregate.hex"), &l1_proof_bytes)?;
+
+    let expected = ExpectedBundle {
+        l0_candidates: l0_candidate_files,
+        l1_aggregate: "l1_aggregate.hex".to_string(),
+        aggregator_address: digest_hex(&l1_inputs.aggregator_address),
+        asset_id: l1_inputs.asset_id,
+        volume_fee_bps: l1_inputs.volume_fee_bps,
+        block_hash: digest_hex(&l1_inputs.block_data.block_hash),
+        block_number: l1_inputs.block_data.block_number,
+        total_exit_slots: l1_inputs.total_exit_slots,
+        exits: l1_inputs
+            .account_data
+            .iter()
+            .map(|exit| ExpectedExit {
+                summed_output_amount: exit.summed_output_amount,
+                exit_account: digest_hex(&exit.exit_account),
+            })
+            .collect(),
+        nullifiers: l1_inputs.nullifiers.iter().map(digest_hex).collect(),
+    };
+    fs::write(
+        args.out.join("expected_bundle.json"),
+        serde_json::to_string_pretty(&expected)?,
+    )
+    .with_context(|| {
+        format!(
+            "failed to write {}",
+            args.out.join("expected_bundle.json").display()
+        )
+    })?;
+
+    println!(
+        "Wrote {} L0 candidate(s) and one L1 aggregate to {}",
+        expected.l0_candidates.len(),
+        args.out.display()
+    );
+    Ok(())
+}

--- a/wormhole/aggregator/src/layer1/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/layer1/circuit/circuit_logic.rs
@@ -189,10 +189,11 @@ fn build_layer1_wrapper_constraints(
         builder.connect(pis_i[l1c::L0_ASSET_ID_OFFSET], asset_ref);
         builder.connect(pis_i[l1c::L0_VOLUME_FEE_BPS_OFFSET], fee_ref);
 
-        // block hash must match ref
+        // block hash and block number must match ref
         let block_i: [Target; 4] = core::array::from_fn(|j| pis_i[l1c::L0_BLOCK_HASH_OFFSET + j]);
         let matches_ref = bytes_digest_eq(builder, block_i, block_ref);
         builder.connect(matches_ref.target, one);
+        builder.connect(pis_i[l1c::L0_BLOCK_NUMBER_OFFSET], block_number_ref);
     }
 
     // Output block reference + number
@@ -710,6 +711,118 @@ mod tests {
         assert!(
             res.is_err(),
             "expected layer-1 proving to fail for mismatched blocks"
+        );
+    }
+
+    /// Negative test: if two layer-0 proofs use different block numbers, layer-1 proving must fail.
+    #[test]
+    fn layer1_mismatched_block_numbers_fails() {
+        let block_hash: [u64; 4] = [0xAA01, 0xAA02, 0xAA03, 0xAA04];
+
+        let (leaf_data, leaf_targets) = build_fake_leaf_circuit();
+
+        let a0 = prove_fake_leaf(
+            &leaf_data,
+            &leaf_targets,
+            make_leaf_pi(
+                100,
+                0,
+                [1, 2, 3, 4],
+                [0, 0, 0, 0],
+                [1, 2, 3, 4],
+                block_hash,
+                42,
+            ),
+        );
+        let a1 = prove_fake_leaf(
+            &leaf_data,
+            &leaf_targets,
+            make_leaf_pi(
+                200,
+                0,
+                [5, 6, 7, 8],
+                [0, 0, 0, 0],
+                [5, 6, 7, 8],
+                block_hash,
+                42,
+            ),
+        );
+
+        let b0 = prove_fake_leaf(
+            &leaf_data,
+            &leaf_targets,
+            make_leaf_pi(
+                300,
+                0,
+                [9, 10, 11, 12],
+                [0, 0, 0, 0],
+                [9, 10, 11, 12],
+                block_hash,
+                43,
+            ),
+        );
+        let b1 = prove_fake_leaf(
+            &leaf_data,
+            &leaf_targets,
+            make_leaf_pi(
+                400,
+                0,
+                [13, 14, 15, 16],
+                [0, 0, 0, 0],
+                [13, 14, 15, 16],
+                block_hash,
+                43,
+            ),
+        );
+
+        let l0_circuit = Layer0AggregationCircuit::new(
+            CircuitConfig::standard_recursion_config(),
+            leaf_data.common.clone(),
+            NUM_LEAVES,
+        );
+        let l0_targets = l0_circuit.targets();
+        let l0_data = l0_circuit.build_circuit();
+
+        let l0_a = prove_layer0_batch(
+            &l0_data,
+            &l0_targets,
+            &leaf_data.verifier_only,
+            vec![a0, a1],
+        );
+        let l0_b = prove_layer0_batch(
+            &l0_data,
+            &l0_targets,
+            &leaf_data.verifier_only,
+            vec![b0, b1],
+        );
+
+        let l1_circuit = Layer1AggregationCircuit::new(
+            CircuitConfig::standard_recursion_config(),
+            l0_data.common.clone(),
+            N_INNER,
+            NUM_LEAVES,
+        );
+        let l1_targets = l1_circuit.targets();
+        let l1_data = l1_circuit.build_circuit();
+
+        let agg_addr = [
+            F::from_canonical_u64(1),
+            F::from_canonical_u64(2),
+            F::from_canonical_u64(3),
+            F::from_canonical_u64(4),
+        ];
+
+        let res = prove_layer1(
+            &l1_data,
+            &l1_targets,
+            &l0_data.verifier_only,
+            vec![l0_a, l0_b],
+            agg_addr,
+        );
+
+        assert!(
+            res.is_err(),
+            "expected layer-1 proving to fail for mismatched block numbers"
         );
     }
 }

--- a/wormhole/inputs/src/lib.rs
+++ b/wormhole/inputs/src/lib.rs
@@ -32,6 +32,12 @@ const GOLDILOCKS_ORDER: u64 = 0xFFFFFFFF00000001;
 /// but is not exposed as a public input since block_hash already commits to it.
 pub const PUBLIC_INPUTS_FELTS_LEN: usize = 21;
 
+/// Current public-input layout version for layer-0 aggregated proofs.
+pub const L0_AGGREGATED_PUBLIC_INPUT_LAYOUT_VERSION: u32 = 1;
+
+/// Current public-input layout version for layer-1 aggregated proofs.
+pub const L1_AGGREGATED_PUBLIC_INPUT_LAYOUT_VERSION: u32 = 1;
+
 // Index constants for parsing public inputs
 pub const ASSET_ID_INDEX: usize = 0;
 pub const OUTPUT_AMOUNT_1_INDEX: usize = 1;
@@ -46,6 +52,30 @@ pub const EXIT_ACCOUNT_2_END_INDEX: usize = 16;
 pub const BLOCK_HASH_START_INDEX: usize = 16;
 pub const BLOCK_HASH_END_INDEX: usize = 20;
 pub const BLOCK_NUMBER_INDEX: usize = 20;
+
+// Layer-1 aggregated public input layout.
+//
+// [aggregator_address(4),
+//  asset_id(1),
+//  volume_fee_bps(1),
+//  block_hash(4),
+//  block_number(1),
+//  total_exit_slots(1),
+//  [sum(1), exit_account(4)] * total_exit_slots,
+//  nullifier(4) * (total_exit_slots / 2)]
+pub const L1_AGGREGATOR_ADDRESS_LEN: usize = 4;
+pub const L1_AGGREGATOR_ADDRESS_START_INDEX: usize = 0;
+pub const L1_AGGREGATOR_ADDRESS_END_INDEX: usize =
+    L1_AGGREGATOR_ADDRESS_START_INDEX + L1_AGGREGATOR_ADDRESS_LEN;
+pub const L1_ASSET_ID_INDEX: usize = L1_AGGREGATOR_ADDRESS_END_INDEX;
+pub const L1_VOLUME_FEE_BPS_INDEX: usize = L1_ASSET_ID_INDEX + 1;
+pub const L1_BLOCK_HASH_START_INDEX: usize = L1_VOLUME_FEE_BPS_INDEX + 1;
+pub const L1_BLOCK_HASH_END_INDEX: usize = L1_BLOCK_HASH_START_INDEX + 4;
+pub const L1_BLOCK_NUMBER_INDEX: usize = L1_BLOCK_HASH_END_INDEX;
+pub const L1_TOTAL_EXIT_SLOTS_INDEX: usize = L1_BLOCK_NUMBER_INDEX + 1;
+pub const L1_HEADER_FELTS_LEN: usize = L1_TOTAL_EXIT_SLOTS_INDEX + 1;
+pub const L1_EXIT_SLOT_FELTS_LEN: usize = 5;
+pub const L1_NULLIFIER_FELTS_LEN: usize = 4;
 
 /// A 32-byte digest that can be converted to/from field elements.
 #[derive(Hash, Default, Clone, Copy, PartialEq, Eq, Ord, PartialOrd)]
@@ -218,6 +248,31 @@ pub struct AggregatedPublicCircuitInputs {
     pub account_data: Vec<PublicInputsByAccount>,
     /// The nullifiers of each individual transfer proof.
     pub nullifiers: Vec<BytesDigest>,
+}
+
+/// Layer-1 aggregated public inputs from multiple layer-0 aggregated proofs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Layer1AggregatedPublicCircuitInputs {
+    /// Aggregation reward address committed by the delegated layer-1 proof.
+    pub aggregator_address: BytesDigest,
+    /// The asset ID of the set (0 for native token).
+    pub asset_id: u32,
+    /// Volume fee rate in basis points (1 basis point = 0.01%).
+    pub volume_fee_bps: u32,
+    /// The block data (block_hash, block_number) shared by all child layer-0 proofs.
+    pub block_data: BlockData,
+    /// Number of exit slots forwarded by the layer-1 circuit.
+    pub total_exit_slots: u32,
+    /// Forwarded exit account data from all child layer-0 proofs.
+    pub account_data: Vec<PublicInputsByAccount>,
+    /// Forwarded nullifiers from all child layer-0 proofs.
+    pub nullifiers: Vec<BytesDigest>,
+    /// Reserved for the future constrained bundle-root public input.
+    pub bundle_root: Option<BytesDigest>,
+    /// Reserved for an explicit circuit identifier public input.
+    pub circuit_id: Option<BytesDigest>,
+    /// Reserved for an explicit in-circuit layout version public input.
+    pub layout_version: Option<u32>,
 }
 
 /// Helper to convert 4 u64 values (hash output) to a BytesDigest.
@@ -443,9 +498,163 @@ impl AggregatedPublicCircuitInputs {
     }
 }
 
+impl Layer1AggregatedPublicCircuitInputs {
+    /// Parse layer-1 aggregated public inputs from a slice of u64 values.
+    pub fn try_from_u64_slice(pis: &[u64]) -> anyhow::Result<Self> {
+        if pis.len() < L1_HEADER_FELTS_LEN {
+            bail!(
+                "Layer1AggregatedPI: too few elements, need at least {} for header, got {}",
+                L1_HEADER_FELTS_LEN,
+                pis.len()
+            );
+        }
+
+        let aggregator_address = hash_u64s_to_bytes_digest(
+            &pis[L1_AGGREGATOR_ADDRESS_START_INDEX..L1_AGGREGATOR_ADDRESS_END_INDEX],
+        )
+        .context("Layer1AggregatedPI: parsing aggregator_address")?;
+
+        let asset_id: u32 = pis[L1_ASSET_ID_INDEX]
+            .try_into()
+            .context("Layer1AggregatedPI: asset_id exceeds u32 range")?;
+        let volume_fee_bps: u32 = pis[L1_VOLUME_FEE_BPS_INDEX]
+            .try_into()
+            .context("Layer1AggregatedPI: volume_fee_bps exceeds u32 range")?;
+        let block_hash =
+            hash_u64s_to_bytes_digest(&pis[L1_BLOCK_HASH_START_INDEX..L1_BLOCK_HASH_END_INDEX])
+                .context("Layer1AggregatedPI: parsing block_hash")?;
+        let block_number: u32 = pis[L1_BLOCK_NUMBER_INDEX]
+            .try_into()
+            .context("Layer1AggregatedPI: block_number exceeds u32 range")?;
+        let total_exit_slots: u32 = pis[L1_TOTAL_EXIT_SLOTS_INDEX]
+            .try_into()
+            .context("Layer1AggregatedPI: total_exit_slots exceeds u32 range")?;
+
+        let total_exit_slots_usize: usize = total_exit_slots
+            .try_into()
+            .context("Layer1AggregatedPI: total_exit_slots exceeds usize range")?;
+        let Some(exit_slots_felts) = total_exit_slots_usize.checked_mul(L1_EXIT_SLOT_FELTS_LEN)
+        else {
+            bail!(
+                "Layer1AggregatedPI: total_exit_slots {} overflows exit-slot felt length",
+                total_exit_slots
+            );
+        };
+
+        let mut cursor = L1_HEADER_FELTS_LEN;
+        let Some(exit_slots_end) = cursor.checked_add(exit_slots_felts) else {
+            bail!(
+                "Layer1AggregatedPI: exit slots end overflows (cursor={}, slots={})",
+                cursor,
+                total_exit_slots
+            );
+        };
+        if exit_slots_end > pis.len() {
+            bail!(
+                "Layer1AggregatedPI: not enough elements for {} exit slots (need {}, got {})",
+                total_exit_slots,
+                exit_slots_end,
+                pis.len()
+            );
+        }
+
+        let mut account_data = Vec::with_capacity(total_exit_slots_usize);
+        for i in 0..total_exit_slots_usize {
+            let summed_output_amount: u32 = pis[cursor].try_into().with_context(|| {
+                format!(
+                    "Layer1AggregatedPI: summed_output_amount at cursor {} exceeds u32 range",
+                    cursor
+                )
+            })?;
+            cursor += 1;
+
+            let exit_account =
+                hash_u64s_to_bytes_digest(&pis[cursor..cursor + 4]).with_context(|| {
+                    format!(
+                        "Layer1AggregatedPI: parsing exit_account[{}] at cursor {}",
+                        i, cursor
+                    )
+                })?;
+            cursor += 4;
+
+            account_data.push(PublicInputsByAccount {
+                summed_output_amount,
+                exit_account,
+            });
+        }
+
+        let remaining = pis.len() - cursor;
+        if !remaining.is_multiple_of(L1_NULLIFIER_FELTS_LEN) {
+            bail!(
+                "Layer1AggregatedPI: malformed nullifier length {} - expected a multiple of {} felts",
+                remaining,
+                L1_NULLIFIER_FELTS_LEN
+            );
+        }
+
+        let nullifier_count = remaining / L1_NULLIFIER_FELTS_LEN;
+        if !total_exit_slots_usize.is_multiple_of(2) {
+            bail!(
+                "Layer1AggregatedPI: total_exit_slots {} is not even; expected two exit slots per nullifier",
+                total_exit_slots
+            );
+        }
+        if nullifier_count * 2 != total_exit_slots_usize {
+            bail!(
+                "Layer1AggregatedPI: inconsistent shape - total_exit_slots={} implies {} nullifiers, got {}",
+                total_exit_slots,
+                total_exit_slots_usize / 2,
+                nullifier_count
+            );
+        }
+
+        let mut nullifiers = Vec::with_capacity(nullifier_count);
+        for i in 0..nullifier_count {
+            let nullifier =
+                hash_u64s_to_bytes_digest(&pis[cursor..cursor + 4]).with_context(|| {
+                    format!(
+                        "Layer1AggregatedPI: parsing nullifier[{}] at cursor {}",
+                        i, cursor
+                    )
+                })?;
+            cursor += 4;
+            nullifiers.push(nullifier);
+        }
+
+        if cursor != pis.len() {
+            bail!(
+                "Layer1AggregatedPI: cursor mismatch - consumed {} felts, input length {}",
+                cursor,
+                pis.len()
+            );
+        }
+
+        Ok(Layer1AggregatedPublicCircuitInputs {
+            aggregator_address,
+            asset_id,
+            volume_fee_bps,
+            block_data: BlockData {
+                block_hash,
+                block_number,
+            },
+            total_exit_slots,
+            account_data,
+            nullifiers,
+            bundle_root: None,
+            circuit_id: None,
+            layout_version: None,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{AggregatedPublicCircuitInputs, PUBLIC_INPUTS_FELTS_LEN};
+    use super::{
+        hash_u64s_to_bytes_digest, AggregatedPublicCircuitInputs,
+        Layer1AggregatedPublicCircuitInputs, L1_AGGREGATOR_ADDRESS_START_INDEX, L1_ASSET_ID_INDEX,
+        L1_BLOCK_HASH_START_INDEX, L1_BLOCK_NUMBER_INDEX, L1_HEADER_FELTS_LEN,
+        L1_TOTAL_EXIT_SLOTS_INDEX, L1_VOLUME_FEE_BPS_INDEX, PUBLIC_INPUTS_FELTS_LEN,
+    };
 
     #[test]
     fn aggregated_public_inputs_reject_malformed_padded_length() {
@@ -467,5 +676,117 @@ mod tests {
         assert_eq!(parsed.block_data.block_number, 42);
         assert_eq!(parsed.account_data.len(), 2);
         assert_eq!(parsed.nullifiers.len(), 1);
+    }
+
+    fn valid_layer1_pis(total_exit_slots: usize) -> Vec<u64> {
+        assert!(total_exit_slots.is_multiple_of(2));
+
+        let mut pis = vec![0u64; L1_HEADER_FELTS_LEN];
+        pis[L1_AGGREGATOR_ADDRESS_START_INDEX] = 0x1111;
+        pis[L1_AGGREGATOR_ADDRESS_START_INDEX + 1] = 0x2222;
+        pis[L1_AGGREGATOR_ADDRESS_START_INDEX + 2] = 0x3333;
+        pis[L1_AGGREGATOR_ADDRESS_START_INDEX + 3] = 0x4444;
+        pis[L1_ASSET_ID_INDEX] = 0;
+        pis[L1_VOLUME_FEE_BPS_INDEX] = 25;
+        pis[L1_BLOCK_HASH_START_INDEX] = 0xAA01;
+        pis[L1_BLOCK_HASH_START_INDEX + 1] = 0xAA02;
+        pis[L1_BLOCK_HASH_START_INDEX + 2] = 0xAA03;
+        pis[L1_BLOCK_HASH_START_INDEX + 3] = 0xAA04;
+        pis[L1_BLOCK_NUMBER_INDEX] = 42;
+        pis[L1_TOTAL_EXIT_SLOTS_INDEX] = total_exit_slots as u64;
+
+        for slot in 0..total_exit_slots {
+            pis.push((slot as u64) + 100);
+            pis.extend_from_slice(&[
+                0xE000 + slot as u64,
+                0xE100 + slot as u64,
+                0xE200 + slot as u64,
+                0xE300 + slot as u64,
+            ]);
+        }
+
+        for nullifier in 0..(total_exit_slots / 2) {
+            pis.extend_from_slice(&[
+                0xA000 + nullifier as u64,
+                0xA100 + nullifier as u64,
+                0xA200 + nullifier as u64,
+                0xA300 + nullifier as u64,
+            ]);
+        }
+
+        pis
+    }
+
+    #[test]
+    fn layer1_public_inputs_parse_valid_minimal_vector() {
+        let pis = valid_layer1_pis(2);
+
+        let parsed = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap();
+
+        assert_eq!(
+            parsed.aggregator_address,
+            hash_u64s_to_bytes_digest(&[0x1111, 0x2222, 0x3333, 0x4444]).unwrap()
+        );
+        assert_eq!(parsed.asset_id, 0);
+        assert_eq!(parsed.volume_fee_bps, 25);
+        assert_eq!(parsed.block_data.block_number, 42);
+        assert_eq!(parsed.total_exit_slots, 2);
+        assert_eq!(parsed.account_data.len(), 2);
+        assert_eq!(parsed.nullifiers.len(), 1);
+        assert_eq!(parsed.bundle_root, None);
+        assert_eq!(parsed.circuit_id, None);
+        assert_eq!(parsed.layout_version, None);
+    }
+
+    #[test]
+    fn layer1_public_inputs_reject_too_short_vector() {
+        let err = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&[0u64; 11]).unwrap_err();
+        assert!(err.to_string().contains("too few elements"));
+    }
+
+    #[test]
+    fn layer1_public_inputs_reject_malformed_nullifier_length() {
+        let mut pis = valid_layer1_pis(2);
+        pis.push(1);
+
+        let err = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap_err();
+        assert!(err.to_string().contains("malformed nullifier length"));
+    }
+
+    #[test]
+    fn layer1_public_inputs_parse_expected_positions() {
+        let pis = valid_layer1_pis(4);
+
+        let parsed = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap();
+
+        assert_eq!(
+            parsed.aggregator_address,
+            hash_u64s_to_bytes_digest(&[0x1111, 0x2222, 0x3333, 0x4444]).unwrap()
+        );
+        assert_eq!(
+            parsed.block_data.block_hash,
+            hash_u64s_to_bytes_digest(&[0xAA01, 0xAA02, 0xAA03, 0xAA04]).unwrap()
+        );
+        assert_eq!(parsed.block_data.block_number, 42);
+    }
+
+    #[test]
+    fn layer1_public_inputs_nullifier_count_matches_expected_shape() {
+        let pis = valid_layer1_pis(4);
+
+        let parsed = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap();
+
+        assert_eq!(parsed.total_exit_slots, 4);
+        assert_eq!(parsed.account_data.len(), 4);
+        assert_eq!(parsed.nullifiers.len(), 2);
+    }
+
+    #[test]
+    fn layer1_public_inputs_reject_cursor_shape_mismatch() {
+        let mut pis = valid_layer1_pis(2);
+        pis.extend_from_slice(&[0xB000, 0xB100, 0xB200, 0xB300]);
+
+        let err = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap_err();
+        assert!(err.to_string().contains("inconsistent shape"));
     }
 }

--- a/wormhole/inputs/src/lib.rs
+++ b/wormhole/inputs/src/lib.rs
@@ -739,9 +739,41 @@ mod tests {
     }
 
     #[test]
+    fn layer1_public_inputs_abi_layout_regression() {
+        assert_eq!(L1_HEADER_FELTS_LEN, 12);
+        assert_eq!(L1_AGGREGATOR_ADDRESS_START_INDEX, 0);
+        assert_eq!(L1_ASSET_ID_INDEX, 4);
+        assert_eq!(L1_VOLUME_FEE_BPS_INDEX, 5);
+        assert_eq!(L1_BLOCK_HASH_START_INDEX, 6);
+        assert_eq!(L1_BLOCK_NUMBER_INDEX, 10);
+        assert_eq!(L1_TOTAL_EXIT_SLOTS_INDEX, 11);
+
+        let pis = valid_layer1_pis(4);
+        assert_eq!(pis.len(), L1_HEADER_FELTS_LEN + 4 * 5 + 2 * 4);
+    }
+
+    #[test]
     fn layer1_public_inputs_reject_too_short_vector() {
         let err = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&[0u64; 11]).unwrap_err();
         assert!(err.to_string().contains("too few elements"));
+    }
+
+    #[test]
+    fn layer1_public_inputs_reject_too_long_vector() {
+        let mut pis = valid_layer1_pis(2);
+        pis.extend_from_slice(&[0xB000, 0xB100, 0xB200, 0xB300]);
+
+        let err = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap_err();
+        assert!(err.to_string().contains("inconsistent shape"));
+    }
+
+    #[test]
+    fn layer1_public_inputs_reject_bad_digest_field_element() {
+        let mut pis = valid_layer1_pis(2);
+        pis[L1_BLOCK_HASH_START_INDEX] = u64::MAX;
+
+        let err = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap_err();
+        assert!(err.to_string().contains("parsing block_hash"));
     }
 
     #[test]
@@ -751,6 +783,27 @@ mod tests {
 
         let err = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap_err();
         assert!(err.to_string().contains("malformed nullifier length"));
+    }
+
+    #[test]
+    fn layer1_public_inputs_reject_odd_exit_slot_count() {
+        let mut pis = valid_layer1_pis(2);
+        pis[L1_TOTAL_EXIT_SLOTS_INDEX] = 1;
+        pis.truncate(L1_HEADER_FELTS_LEN + 1 * 5 + 4);
+
+        let err = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap_err();
+        assert!(err.to_string().contains("total_exit_slots 1 is not even"));
+    }
+
+    #[test]
+    fn layer1_public_inputs_reject_declared_exit_count_larger_than_payload() {
+        let mut pis = valid_layer1_pis(2);
+        pis[L1_TOTAL_EXIT_SLOTS_INDEX] = 4;
+
+        let err = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("not enough elements for 4 exit slots"));
     }
 
     #[test]

--- a/wormhole/inputs/src/lib.rs
+++ b/wormhole/inputs/src/lib.rs
@@ -789,7 +789,7 @@ mod tests {
     fn layer1_public_inputs_reject_odd_exit_slot_count() {
         let mut pis = valid_layer1_pis(2);
         pis[L1_TOTAL_EXIT_SLOTS_INDEX] = 1;
-        pis.truncate(L1_HEADER_FELTS_LEN + 1 * 5 + 4);
+        pis.truncate(L1_HEADER_FELTS_LEN + 5 + 4);
 
         let err = Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&pis).unwrap_err();
         assert!(err.to_string().contains("total_exit_slots 1 is not even"));

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -46,8 +46,9 @@ use qp_plonky2_verifier::util::serialization::DefaultGateSerializer;
 
 // Re-export input types from qp-wormhole-inputs
 pub use qp_wormhole_inputs::{
-    AggregatedPublicCircuitInputs, BlockData, BytesDigest, PublicCircuitInputs,
-    PublicInputsByAccount,
+    AggregatedPublicCircuitInputs, BlockData, BytesDigest, Layer1AggregatedPublicCircuitInputs,
+    PublicCircuitInputs, PublicInputsByAccount, L0_AGGREGATED_PUBLIC_INPUT_LAYOUT_VERSION,
+    L1_AGGREGATED_PUBLIC_INPUT_LAYOUT_VERSION,
 };
 
 /// Parse public inputs from a proof.
@@ -72,6 +73,18 @@ pub fn parse_aggregated_public_inputs(
         .map(|f| f.to_canonical_u64())
         .collect();
     AggregatedPublicCircuitInputs::try_from_u64_slice(&u64s)
+}
+
+/// Parse layer-1 aggregated public inputs from a proof.
+pub fn parse_layer1_aggregated_public_inputs(
+    proof: &ProofWithPublicInputs<F, C, D>,
+) -> anyhow::Result<Layer1AggregatedPublicCircuitInputs> {
+    let u64s: Vec<u64> = proof
+        .public_inputs
+        .iter()
+        .map(|f| f.to_canonical_u64())
+        .collect();
+    Layer1AggregatedPublicCircuitInputs::try_from_u64_slice(&u64s)
 }
 
 /// Verifier for Wormhole circuit proofs.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Modifies layer-1 aggregation circuit constraints and public-input parsing, which can invalidate existing proofs/fixtures if the layout or invariants are wrong. Changes are well-scoped with added negative/ABI regression tests, but affect proof compatibility.
> 
> **Overview**
> Adds first-class support for *layer-1 aggregated proof* public inputs: introduces `Layer1AggregatedPublicCircuitInputs` with an explicit header/slot/nullifier layout, robust shape validation, and comprehensive parser regression/negative tests.
> 
> Tightens the layer-1 aggregation circuit by enforcing **block number consistency** (in addition to block hash) across all child layer-0 proofs, plus a new negative test for mismatched block numbers.
> 
> Adds a `generate_l1_fixture` example that takes a full batch of L0 proof hex files, produces an L1 aggregate proof (`.hex` + `.bin`), and writes an `expected_bundle.json` derived from parsed L1 public inputs; verifier crate now re-exports layout versions and provides `parse_layer1_aggregated_public_inputs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c6fd03ecf03c788f5e7570ffc8421ffbab79c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->