### PR TITLE
Tighter wire config

### DIFF
--- a/common/src/circuit.rs
+++ b/common/src/circuit.rs
@@ -36,8 +36,17 @@ pub fn wormhole_leaf_circuit_config() -> CircuitConfig {
 ///
 /// The aggregated proofs are verified on-chain, so they must use ZK to prevent leaking
 /// witness information to the public.
+///
+/// This config uses:
+/// - Row blinding ZK mode (lower memory than PolyFri, same security)
+/// - num_wires = 135 (minimum for PoseidonGate)
+/// - num_routed_wires = 60 (optimal for 16-leaf aggregation - lower values cause degree overflow)
 pub fn wormhole_aggregator_circuit_config() -> CircuitConfig {
-    CircuitConfig::standard_recursion_polyfri_zk_config()
+    CircuitConfig {
+        num_wires: 135,
+        num_routed_wires: 60,
+        ..CircuitConfig::standard_recursion_zk_config()
+    }
 }
 
 pub trait CircuitFragment {


### PR DESCRIPTION
- peak memory usage drops by ~45%
- proving time drops by ~40%

we basically drop it into a lower FRI degree by changing the shape of the trace (wires are columns)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ZK and trace parameters for on-chain-verified aggregation circuits; incorrect wire bounds could break proving or constraints, though scope is limited to the shared aggregator config helper.
> 
> **Overview**
> **Tightens Plonky2 trace layout for wormhole aggregation proofs** by replacing the PolyFri ZK preset with a custom `CircuitConfig` built on **row-blinding** ZK (`standard_recursion_zk_config`) and explicit wire counts: **`num_wires = 135`** (Poseidon minimum) and **`num_routed_wires = 60`** (tuned for 16-leaf aggregation; lower values risk degree overflow).
> 
> This only affects **`wormhole_aggregator_circuit_config()`**—leaf proofs stay on the existing non-ZK recursion config. The intent is a smaller FRI degree via a narrower trace, which the author reports cuts **peak memory ~45%** and **proving time ~40%** without changing the on-chain ZK requirement for aggregated proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb1c78e4801ad2956a235253abe2985ad2947f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->