### PR TITLE
ci: Automate workspace version bump to v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ checksum = "78172860cd960773c72e97fba07ead9e5a1c13086c5746283744933e2e4a577b"
 
 [[package]]
 name = "qp-voting-circuit"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "qp-plonky2",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-aggregator"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-circuit"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-circuit-builder"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1089,14 +1089,14 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-inputs"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "qp-wormhole-prover"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-verifier"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "qp-zk-circuits-common"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "qp-plonky2",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "test-helpers"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "hex",
  "qp-plonky2",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "wormhole-memprof"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ edition = "2021"
 keywords = ["circuits", "plonky2", "quantus-network", "wormhole", "zk"]
 license = "MIT"
 repository = "https://github.com/Quantus-Network/qp-zk-circuits"
-version = "2.0.1"
+version = "3.0.0"
 
 [workspace.lints.clippy]
 uninlined_format_args = "allow"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = { workspace = true, default-features = false }
 qp-plonky2 = { workspace = true, default-features = false }
 qp-poseidon-constants = { version = "1.0", default-features = false }
 qp-poseidon-core = { workspace = true, default-features = false }
-qp-wormhole-inputs = { version = "2.0.1", path = "../wormhole/inputs", default-features = false }
+qp-wormhole-inputs = { version = "3.0.0", path = "../wormhole/inputs", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["alloc"], optional = true }
 serde = { workspace = true }
 

--- a/voting/Cargo.toml
+++ b/voting/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "2.0.1", path = "../common" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "3.0.0", path = "../common" }
 
 [features]
 default = ["std"]

--- a/wormhole/aggregator/Cargo.toml
+++ b/wormhole/aggregator/Cargo.toml
@@ -11,14 +11,14 @@ version.workspace = true
 anyhow = { workspace = true }
 hex = "0.4"
 qp-plonky2 = { workspace = true }
-qp-wormhole-inputs = { version = "2.0.1", path = "../inputs" }
+qp-wormhole-inputs = { version = "3.0.0", path = "../inputs" }
 rand = "0.8"
 rayon = { version = "1.10.0", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "2.0.1", path = "../circuit", default-features = false }
-wormhole-prover = { package = "qp-wormhole-prover", version = "2.0.1", path = "../prover", default-features = false }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "2.0.1", path = "../../common" }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "3.0.0", path = "../circuit", default-features = false }
+wormhole-prover = { package = "qp-wormhole-prover", version = "3.0.0", path = "../prover", default-features = false }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "3.0.0", path = "../../common" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/wormhole/circuit-builder/Cargo.toml
+++ b/wormhole/circuit-builder/Cargo.toml
@@ -10,18 +10,18 @@ version.workspace = true
 
 [build-dependencies]
 qp-plonky2 = { workspace = true, features = ["default"] }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "2.0.1", path = "../aggregator", default-features = false, features = ["std"] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "2.0.1", path = "../circuit", default-features = false, features = ["std"] }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "2.0.1", path = "../../common" }
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "3.0.0", path = "../aggregator", default-features = false, features = ["std"] }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "3.0.0", path = "../circuit", default-features = false, features = ["std"] }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "3.0.0", path = "../../common" }
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 clap = { version = "4", features = ["derive"] }
 qp-plonky2 = { workspace = true, features = ["default"] }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "2.0.1", path = "../aggregator", default-features = false, features = [
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "3.0.0", path = "../aggregator", default-features = false, features = [
 	"std",
 ] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "2.0.1", path = "../circuit", default-features = false, features = [
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "3.0.0", path = "../circuit", default-features = false, features = [
 	"std",
 ] }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "2.0.1", path = "../../common" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "3.0.0", path = "../../common" }

--- a/wormhole/circuit/Cargo.toml
+++ b/wormhole/circuit/Cargo.toml
@@ -11,8 +11,8 @@ version.workspace = true
 anyhow = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 qp-plonky2 = { workspace = true }
-qp-wormhole-inputs = { version = "2.0.1", path = "../inputs", default-features = false }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "2.0.1", path = "../../common", default-features = false }
+qp-wormhole-inputs = { version = "3.0.0", path = "../inputs", default-features = false }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "3.0.0", path = "../../common", default-features = false }
 
 [features]
 default = ["std"]

--- a/wormhole/prover/Cargo.toml
+++ b/wormhole/prover/Cargo.toml
@@ -10,12 +10,12 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "2.0.1", path = "../circuit" }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "2.0.1", path = "../../common" }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "3.0.0", path = "../circuit" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "3.0.0", path = "../../common" }
 
 [dev-dependencies]
 criterion = { workspace = true }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "2.0.1", path = "../aggregator" }
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "3.0.0", path = "../aggregator" }
 
 [features]
 default = ["std"]

--- a/wormhole/tests/Cargo.toml
+++ b/wormhole/tests/Cargo.toml
@@ -12,20 +12,20 @@ bench = []
 
 [dependencies]
 anyhow = { workspace = true }
-circuit-builder = { package = "qp-wormhole-circuit-builder", version = "2.0.1", path = "../circuit-builder" }
+circuit-builder = { package = "qp-wormhole-circuit-builder", version = "3.0.0", path = "../circuit-builder" }
 hex = { workspace = true }
 libc = "0.2"
 qp-plonky2 = { workspace = true, default-features = true }
-qp-wormhole-inputs = { version = "2.0.1", path = "../inputs" }
+qp-wormhole-inputs = { version = "3.0.0", path = "../inputs" }
 rand = { version = "0.9.1", default-features = false, features = [
 	"thread_rng",
 ] }
 test-helpers = { path = "./test-helpers" }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "2.0.1", path = "../aggregator", features = ["no_zk"] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "2.0.1", path = "../circuit", default-features = true }
-wormhole-prover = { package = "qp-wormhole-prover", version = "2.0.1", path = "../prover", default-features = true }
-wormhole-verifier = { package = "qp-wormhole-verifier", version = "2.0.1", path = "../verifier", default-features = true }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "2.0.1", path = "../../common" }
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "3.0.0", path = "../aggregator", features = ["no_zk"] }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "3.0.0", path = "../circuit", default-features = true }
+wormhole-prover = { package = "qp-wormhole-prover", version = "3.0.0", path = "../prover", default-features = true }
+wormhole-verifier = { package = "qp-wormhole-verifier", version = "3.0.0", path = "../verifier", default-features = true }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "3.0.0", path = "../../common" }
 
 [lints]
 workspace = true

--- a/wormhole/tests/test-helpers/Cargo.toml
+++ b/wormhole/tests/test-helpers/Cargo.toml
@@ -10,6 +10,6 @@ version.workspace = true
 [dependencies]
 hex = { workspace = true }
 qp-plonky2 = { workspace = true, default-features = true }
-qp-wormhole-inputs = { version = "2.0.1", path = "../../inputs" }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "2.0.1", path = "../../circuit" }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "2.0.1", path = "../../../common" }
+qp-wormhole-inputs = { version = "3.0.0", path = "../../inputs" }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "3.0.0", path = "../../circuit" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "3.0.0", path = "../../../common" }

--- a/wormhole/verifier/Cargo.toml
+++ b/wormhole/verifier/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2-verifier = { version = "1.5.1", default-features = false }
-qp-wormhole-inputs = { version = "2.0.1", path = "../inputs", default-features = false }
+qp-wormhole-inputs = { version = "3.0.0", path = "../inputs", default-features = false }
 
 [dev-dependencies]
 criterion = { workspace = true }


### PR DESCRIPTION
Automated workspace version bump for release v3.0.0.

https://github.com/Quantus-Network/qp-zk-circuits/actions/runs/27003981676

Triggered by workflow run: major

Type: 