### PR TITLE
Fix release version bump for memprof

### DIFF
--- a/.github/workflows/create-release-proposal.yml
+++ b/.github/workflows/create-release-proposal.yml
@@ -180,6 +180,7 @@ jobs:
             wormhole/verifier/Cargo.toml \
             wormhole/aggregator/Cargo.toml \
             wormhole/circuit-builder/Cargo.toml \
+            wormhole/memprof/Cargo.toml \
             wormhole/tests/Cargo.toml \
             wormhole/tests/test-helpers/Cargo.toml \
             voting/Cargo.toml \


### PR DESCRIPTION
## Summary
- Include `wormhole/memprof/Cargo.toml` in the release proposal workflow's staged files.
- Prevent generated release branches from leaving memprof's internal path dependency versions behind the workspace version.

## Test plan
- Ran `git diff --check`.
- Reproduced the existing release failure on PR #141 in a throwaway worktree with `cargo check --workspace --locked`.