### PR TITLE
Full shuffle of child proofs

### DIFF
--- a/wormhole/README.md
+++ b/wormhole/README.md
@@ -105,7 +105,7 @@ The aggregator combines `N` leaf proofs into a single proof with a fixed public 
 
 - **Single-block storage proof constraint**: All real proofs (non-zero `block_hash`) must reference the same block for storage proofs.
 - **Two outputs per proof**: Each leaf supports `exit_account_1`/`output_amount_1` and `exit_account_2`/`output_amount_2`. Aggregation outputs 2\*`N` exit slots.
-- **Privacy via dummy hiding**: Proofs are shuffled before aggregation while keeping one real proof in slot 0 for reference values. Duplicate exit slots are zeroed (both sum and `exit_account`), making them indistinguishable from dummy padding slots.
+- **Privacy via dummy hiding**: Proofs are uniformly shuffled before aggregation; the circuit selects reference values from the first non-dummy slot in-circuit, so no slot position is special. Duplicate exit slots are zeroed (both sum and `exit_account`), making them indistinguishable from dummy padding slots.
 - **Dynamic dummy proofs**: Dummy proofs are generated on-the-fly for padding. They use sentinel values (`block_hash = 0`, `output_amount_1 = 0`, `output_amount_2 = 0`, `exit_account = 0`) so the leaf circuit can bypass validation. No dummy proof binaries are checked in.
 - **Public input types**: Public input parsing and aggregated outputs live in `wormhole/inputs` (`qp-wormhole-inputs`) and are shared by the circuit, prover, verifier, and aggregator.
 

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Result};
 use plonky2::{
-    field::types::Field,
     field::types::PrimeField64,
     plonk::circuit_data::{CommonCircuitData, VerifierCircuitData, VerifierOnlyCircuitData},
     plonk::proof::ProofWithPublicInputs,
@@ -8,9 +7,7 @@ use plonky2::{
 };
 use zk_circuits_common::circuit::{C, D, F};
 
-use crate::layer0::circuit::constants::{
-    aggregated_output, ASSET_ID_START, BLOCK_HASH_START, LEAF_PI_LEN,
-};
+use crate::layer0::circuit::constants::{aggregated_output, ASSET_ID_START, LEAF_PI_LEN};
 
 /// Load verifier circuit data (common + verifier-only) from serialized bytes.
 pub fn load_verifier_data_from_bytes(
@@ -57,13 +54,6 @@ pub fn leaf_proof_asset_id(proof: &ProofWithPublicInputs<F, C, D>) -> Result<u32
         .to_canonical_u64()
         .try_into()
         .map_err(|_| anyhow!("leaf proof asset_id exceeds u32 range"))
-}
-
-pub fn is_dummy_leaf_proof(proof: &ProofWithPublicInputs<F, C, D>) -> Result<bool> {
-    ensure_proof_public_input_len(proof, LEAF_PI_LEN, "leaf proof")?;
-    Ok(proof.public_inputs[BLOCK_HASH_START..BLOCK_HASH_START + 4]
-        .iter()
-        .all(|f| f.is_zero()))
 }
 
 pub fn l0_num_leaves_from_padded_pi_len(pi_len: usize) -> Result<usize> {

--- a/wormhole/aggregator/src/layer0/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/layer0/circuit/circuit_logic.rs
@@ -152,15 +152,51 @@ fn build_layer0_wrapper_constraints(
     // Output: [num_exit_slots, asset_id, volume_fee_bps, block_hash(4), block_number, ...]
     let num_exit_slots_t = builder.constant(F::from_canonical_u64((n_leaf * 2) as u64));
 
-    // Reference values are taken from slot 0.
-    // Prover shuffles to ensure a real proof is in slot 0 if any real proofs exist.
+    // asset_id / volume_fee_bps refs come from slot 0. This is positionally safe because
+    // equality is enforced across ALL slots (dummies included) below.
     let asset_ref = limb1_at_offset::<LEAF_PI_LEN, ASSET_ID_START>(leaf_pi_targets[0], 0);
     let volume_fee_bps_ref =
         limb1_at_offset::<LEAF_PI_LEN, VOLUME_FEE_BPS_START>(leaf_pi_targets[0], 0);
 
-    let block_ref = limbs4_at_offset::<LEAF_PI_LEN, BLOCK_HASH_START>(leaf_pi_targets[0], 0);
-    let block_number_ref =
-        limb1_at_offset::<LEAF_PI_LEN, BLOCK_NUMBER_START>(leaf_pi_targets[0], 0);
+    // Dummy sentinel at the wrapper level is `block_hash == [0;4]`.
+    // Leaf circuit itself uses a stronger dummy condition (block_hash==0 && outputs==0).
+    // Here we only need the block-hash sentinel for wrapper behavior.
+    let dummy_sentinel = [zero, zero, zero, zero];
+
+    // Compute dummy flags for every slot up front. Also kept for the nullifier section.
+    let mut is_dummy_flags: Vec<BoolTarget> = Vec::with_capacity(n_leaf);
+    let mut block_hashes: Vec<[Target; 4]> = Vec::with_capacity(n_leaf);
+    for pis_i in leaf_pi_targets.iter().take(n_leaf) {
+        let block_i = limbs4_at_offset::<LEAF_PI_LEN, BLOCK_HASH_START>(pis_i, 0);
+        let is_dummy_i = bytes_digest_eq(builder, block_i, dummy_sentinel);
+        is_dummy_flags.push(is_dummy_i);
+        block_hashes.push(block_i);
+    }
+
+    // Select the reference block hash / block number from the FIRST NON-DUMMY slot via a
+    // prefix scan. This makes the circuit position-independent: the prover may place real
+    // and dummy proofs in any order (uniform shuffle), which is required for the privacy
+    // argument that real and dummy slots are indistinguishable.
+    //
+    // If every slot is a dummy, the references remain zero, which the on-chain verifier
+    // rejects as a block reference (and an all-dummy batch settles nothing anyway).
+    let mut found_real = builder._false();
+    let mut block_ref = [zero, zero, zero, zero];
+    let mut block_number_ref = zero;
+    for i in 0..n_leaf {
+        let is_real_i = builder.not(is_dummy_flags[i]);
+        let not_found_yet = builder.not(found_real);
+        let take_i = builder.and(is_real_i, not_found_yet);
+
+        for j in 0..4 {
+            block_ref[j] = builder.select(take_i, block_hashes[i][j], block_ref[j]);
+        }
+        let block_number_i =
+            limb1_at_offset::<LEAF_PI_LEN, BLOCK_NUMBER_START>(leaf_pi_targets[i], 0);
+        block_number_ref = builder.select(take_i, block_number_i, block_number_ref);
+
+        found_real = builder.or(found_real, is_real_i);
+    }
 
     let mut output_pis: Vec<Target> = Vec::new();
     output_pis.push(num_exit_slots_t);
@@ -171,31 +207,21 @@ fn build_layer0_wrapper_constraints(
     // Block consistency + asset consistency + volume_fee_bps consistency
     // =========================================================================
     //
-    // Dummy sentinel at the wrapper level is `block_hash == [0;4]`.
-    // Leaf circuit itself uses a stronger dummy condition (block_hash==0 && outputs==0).
-    // Here we only need the block-hash sentinel for wrapper behavior.
-    //
     // Constraint for each proof i:
     //   is_dummy_i OR (block_i == block_ref)
+    //
+    // Since block_ref is the first non-dummy slot's block hash, this forces every real
+    // proof to share that same block, regardless of slot order.
     //
     // Also enforce:
     //   asset_id_i == asset_ref
     //   volume_fee_bps_i == volume_fee_bps_ref
 
-    let dummy_sentinel = [zero, zero, zero, zero];
-
-    // Track dummy flags so we can conditionally replace nullifiers later.
-    let mut is_dummy_flags: Vec<BoolTarget> = Vec::with_capacity(n_leaf);
-
-    for pis_i in leaf_pi_targets.iter().take(n_leaf) {
-        let block_i = limbs4_at_offset::<LEAF_PI_LEN, BLOCK_HASH_START>(pis_i, 0);
-        let is_dummy_i = bytes_digest_eq(builder, block_i, dummy_sentinel);
-        is_dummy_flags.push(is_dummy_i);
-
-        let matches_ref = bytes_digest_eq(builder, block_i, block_ref);
+    for (i, pis_i) in leaf_pi_targets.iter().take(n_leaf).enumerate() {
+        let matches_ref = bytes_digest_eq(builder, block_hashes[i], block_ref);
 
         // Enforce `is_dummy_i OR matches_ref == true`
-        let valid_block_relation = builder.or(is_dummy_i, matches_ref);
+        let valid_block_relation = builder.or(is_dummy_flags[i], matches_ref);
         builder.connect(valid_block_relation.target, one);
 
         // Enforce asset_id consistency
@@ -1126,6 +1152,122 @@ mod tests {
             "Successfully aggregated {} real proofs + {} dummy proofs!",
             num_real_proofs,
             8 - num_real_proofs
+        );
+    }
+
+    /// Regression test: the circuit must accept dummy proofs in slot 0 (real proof in the
+    /// LAST slot). The old circuit read its block reference from slot 0 and required the
+    /// prover to pin a real proof there, leaking that nullifier[0] was always real. The
+    /// block reference is now selected in-circuit from the first non-dummy slot, so any
+    /// slot order (uniform shuffle) must be satisfiable.
+    #[test]
+    fn recursive_aggregation_dummy_in_slot0_succeeds() {
+        let exits_felts: [[F; 8]; 8] = EXIT_ACCOUNTS.map(limbs8_u64_to_felts);
+        let block_hashes_felts: [[F; 4]; 8] = BLOCK_HASHES.map(limbs4_u64_to_felts);
+        let nullifiers_felts: [[F; 4]; 8] = NULLIFIERS.map(limbs4_u64_to_felts);
+
+        let common_block_hash = block_hashes_felts[0];
+        let common_block_number = F::from_canonical_u64(42);
+        let asset_id = F::from_canonical_u64(TEST_ASSET_ID_U64);
+        let volume_fee_bps = F::from_canonical_u64(TEST_VOLUME_FEE_BPS);
+
+        let num_dummy_proofs = 7usize;
+        let real_slot = num_dummy_proofs; // slot 7 (last)
+
+        let dummy_exit = [F::ZERO; 8];
+        let dummy_block_hash = [F::ZERO; 4];
+
+        let mut pis_list: Vec<[F; LEAF_PI_LEN]> = Vec::with_capacity(8);
+
+        // Dummy proofs occupy slots 0..7
+        for nullifier in nullifiers_felts.iter().take(num_dummy_proofs) {
+            pis_list.push(make_pi_from_felts(
+                asset_id,
+                F::ZERO,
+                F::ZERO,
+                volume_fee_bps,
+                *nullifier,
+                dummy_exit,
+                dummy_exit,
+                dummy_block_hash,
+                F::ZERO,
+            ));
+        }
+
+        // Single real proof in the last slot
+        let real_amount = F::from_canonical_u64(500);
+        pis_list.push(make_pi_from_felts(
+            asset_id,
+            real_amount,
+            F::ZERO,
+            volume_fee_bps,
+            nullifiers_felts[real_slot],
+            exits_felts[real_slot],
+            [F::ZERO; 8],
+            common_block_hash,
+            common_block_number,
+        ));
+
+        let leaves = pis_list
+            .clone()
+            .into_iter()
+            .map(prove_fake_leaf_standalone)
+            .collect::<Vec<_>>();
+        let leaf_common = leaves[0].1.common.clone();
+        let leaf_verifier_only = leaves[0].1.verifier_only.clone();
+        let proofs = leaves
+            .into_iter()
+            .map(|(proof, _)| proof)
+            .collect::<Vec<_>>();
+
+        let dummy_nullifier_pre_images = deterministic_dummy_nullifier_pre_images(proofs.len());
+
+        let (root_proof, root_verifier) = aggregate_proofs_layer0(
+            proofs,
+            leaf_common,
+            leaf_verifier_only,
+            dummy_nullifier_pre_images.clone(),
+        )
+        .expect("aggregation with dummy in slot 0 must be satisfiable");
+
+        root_verifier.verify(root_proof.clone()).unwrap();
+
+        let pis = &root_proof.public_inputs;
+
+        // Header must reference the real block, taken from the last (only real) slot.
+        let block_hash_circuit: [F; 4] = [
+            pis[ROOT_BLOCK_HASH_START],
+            pis[ROOT_BLOCK_HASH_START + 1],
+            pis[ROOT_BLOCK_HASH_START + 2],
+            pis[ROOT_BLOCK_HASH_START + 3],
+        ];
+        assert_eq!(
+            block_hash_circuit, common_block_hash,
+            "block reference must come from the first non-dummy slot"
+        );
+        assert_eq!(pis[ROOT_BLOCK_NUMBER_IDX], common_block_number);
+
+        let nullifier_region_start =
+            ROOT_HEADER_LEN + (pis_list.len() * 2 * aggregated_output::EXIT_SLOT_LEN);
+
+        // Dummy nullifiers (slots 0..7) must be replaced with hashes of the preimages.
+        for (i, pre_image) in dummy_nullifier_pre_images
+            .iter()
+            .enumerate()
+            .take(num_dummy_proofs)
+        {
+            let idx = nullifier_region_start + i * 4;
+            let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
+            let expected = hash_dummy_nullifier_pre_image_native(*pre_image);
+            assert_eq!(got, expected, "dummy nullifier hash mismatch at leaf {i}");
+        }
+
+        // Real nullifier (slot 7) must be forwarded unchanged.
+        let idx = nullifier_region_start + real_slot * 4;
+        let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
+        assert_eq!(
+            got, nullifiers_felts[real_slot],
+            "real nullifier must be preserved in the last slot"
         );
     }
 

--- a/wormhole/aggregator/src/layer0/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/layer0/circuit/circuit_logic.rs
@@ -1155,13 +1155,18 @@ mod tests {
         );
     }
 
-    /// Regression test: the circuit must accept dummy proofs in slot 0 (real proof in the
-    /// LAST slot). The old circuit read its block reference from slot 0 and required the
-    /// prover to pin a real proof there, leaking that nullifier[0] was always real. The
-    /// block reference is now selected in-circuit from the first non-dummy slot, so any
-    /// slot order (uniform shuffle) must be satisfiable.
+    /// Regression test: the circuit must accept the real proof in EVERY slot position. The
+    /// old circuit read its block reference from slot 0 and required the prover to pin a
+    /// real proof there, leaking that nullifier[0] was always real. The block reference is
+    /// now selected in-circuit from the first non-dummy slot, so any slot order (uniform
+    /// shuffle) must be satisfiable.
+    ///
+    /// Runs the full flow (leaf proving, aggregation, root verification, public-input
+    /// checks) once per position of the real proof in a 4-leaf batch.
     #[test]
-    fn recursive_aggregation_dummy_in_slot0_succeeds() {
+    fn recursive_aggregation_real_proof_in_every_slot_succeeds() {
+        const N_LEAF: usize = 4;
+
         let exits_felts: [[F; 8]; 8] = EXIT_ACCOUNTS.map(limbs8_u64_to_felts);
         let block_hashes_felts: [[F; 4]; 8] = BLOCK_HASHES.map(limbs4_u64_to_felts);
         let nullifiers_felts: [[F; 4]; 8] = NULLIFIERS.map(limbs4_u64_to_felts);
@@ -1171,104 +1176,101 @@ mod tests {
         let asset_id = F::from_canonical_u64(TEST_ASSET_ID_U64);
         let volume_fee_bps = F::from_canonical_u64(TEST_VOLUME_FEE_BPS);
 
-        let num_dummy_proofs = 7usize;
-        let real_slot = num_dummy_proofs; // slot 7 (last)
-
         let dummy_exit = [F::ZERO; 8];
         let dummy_block_hash = [F::ZERO; 4];
 
-        let mut pis_list: Vec<[F; LEAF_PI_LEN]> = Vec::with_capacity(8);
+        for real_slot in 0..N_LEAF {
+            let mut pis_list: Vec<[F; LEAF_PI_LEN]> = Vec::with_capacity(N_LEAF);
 
-        // Dummy proofs occupy slots 0..7
-        for nullifier in nullifiers_felts.iter().take(num_dummy_proofs) {
-            pis_list.push(make_pi_from_felts(
-                asset_id,
-                F::ZERO,
-                F::ZERO,
-                volume_fee_bps,
-                *nullifier,
-                dummy_exit,
-                dummy_exit,
-                dummy_block_hash,
-                F::ZERO,
-            ));
+            for i in 0..N_LEAF {
+                if i == real_slot {
+                    let real_amount = F::from_canonical_u64(500);
+                    pis_list.push(make_pi_from_felts(
+                        asset_id,
+                        real_amount,
+                        F::ZERO,
+                        volume_fee_bps,
+                        nullifiers_felts[i],
+                        exits_felts[i],
+                        [F::ZERO; 8],
+                        common_block_hash,
+                        common_block_number,
+                    ));
+                } else {
+                    pis_list.push(make_pi_from_felts(
+                        asset_id,
+                        F::ZERO,
+                        F::ZERO,
+                        volume_fee_bps,
+                        nullifiers_felts[i],
+                        dummy_exit,
+                        dummy_exit,
+                        dummy_block_hash,
+                        F::ZERO,
+                    ));
+                }
+            }
+
+            let leaves = pis_list
+                .clone()
+                .into_iter()
+                .map(prove_fake_leaf_standalone)
+                .collect::<Vec<_>>();
+            let leaf_common = leaves[0].1.common.clone();
+            let leaf_verifier_only = leaves[0].1.verifier_only.clone();
+            let proofs = leaves
+                .into_iter()
+                .map(|(proof, _)| proof)
+                .collect::<Vec<_>>();
+
+            let dummy_nullifier_pre_images = deterministic_dummy_nullifier_pre_images(proofs.len());
+
+            let (root_proof, root_verifier) = aggregate_proofs_layer0(
+                proofs,
+                leaf_common,
+                leaf_verifier_only,
+                dummy_nullifier_pre_images.clone(),
+            )
+            .unwrap_or_else(|e| {
+                panic!("aggregation with real proof in slot {real_slot} must be satisfiable: {e}")
+            });
+
+            root_verifier.verify(root_proof.clone()).unwrap();
+
+            let pis = &root_proof.public_inputs;
+
+            // Header must reference the real block regardless of which slot holds it.
+            let block_hash_circuit: [F; 4] = [
+                pis[ROOT_BLOCK_HASH_START],
+                pis[ROOT_BLOCK_HASH_START + 1],
+                pis[ROOT_BLOCK_HASH_START + 2],
+                pis[ROOT_BLOCK_HASH_START + 3],
+            ];
+            assert_eq!(
+                block_hash_circuit, common_block_hash,
+                "block reference must come from the real slot {real_slot}"
+            );
+            assert_eq!(pis[ROOT_BLOCK_NUMBER_IDX], common_block_number);
+
+            let nullifier_region_start =
+                ROOT_HEADER_LEN + (N_LEAF * 2 * aggregated_output::EXIT_SLOT_LEN);
+
+            for (i, pre_image) in dummy_nullifier_pre_images.iter().enumerate() {
+                let idx = nullifier_region_start + i * 4;
+                let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
+                if i == real_slot {
+                    // Real nullifier must be forwarded unchanged.
+                    assert_eq!(
+                        got, nullifiers_felts[i],
+                        "real nullifier must be preserved in slot {i}"
+                    );
+                } else {
+                    // Dummy nullifiers must be replaced with hashes of the preimages.
+                    let expected = hash_dummy_nullifier_pre_image_native(*pre_image);
+                    assert_eq!(got, expected, "dummy nullifier hash mismatch at leaf {i}");
+                }
+            }
         }
-
-        // Single real proof in the last slot
-        let real_amount = F::from_canonical_u64(500);
-        pis_list.push(make_pi_from_felts(
-            asset_id,
-            real_amount,
-            F::ZERO,
-            volume_fee_bps,
-            nullifiers_felts[real_slot],
-            exits_felts[real_slot],
-            [F::ZERO; 8],
-            common_block_hash,
-            common_block_number,
-        ));
-
-        let leaves = pis_list
-            .clone()
-            .into_iter()
-            .map(prove_fake_leaf_standalone)
-            .collect::<Vec<_>>();
-        let leaf_common = leaves[0].1.common.clone();
-        let leaf_verifier_only = leaves[0].1.verifier_only.clone();
-        let proofs = leaves
-            .into_iter()
-            .map(|(proof, _)| proof)
-            .collect::<Vec<_>>();
-
-        let dummy_nullifier_pre_images = deterministic_dummy_nullifier_pre_images(proofs.len());
-
-        let (root_proof, root_verifier) = aggregate_proofs_layer0(
-            proofs,
-            leaf_common,
-            leaf_verifier_only,
-            dummy_nullifier_pre_images.clone(),
-        )
-        .expect("aggregation with dummy in slot 0 must be satisfiable");
-
-        root_verifier.verify(root_proof.clone()).unwrap();
-
-        let pis = &root_proof.public_inputs;
-
-        // Header must reference the real block, taken from the last (only real) slot.
-        let block_hash_circuit: [F; 4] = [
-            pis[ROOT_BLOCK_HASH_START],
-            pis[ROOT_BLOCK_HASH_START + 1],
-            pis[ROOT_BLOCK_HASH_START + 2],
-            pis[ROOT_BLOCK_HASH_START + 3],
-        ];
-        assert_eq!(
-            block_hash_circuit, common_block_hash,
-            "block reference must come from the first non-dummy slot"
-        );
-        assert_eq!(pis[ROOT_BLOCK_NUMBER_IDX], common_block_number);
-
-        let nullifier_region_start =
-            ROOT_HEADER_LEN + (pis_list.len() * 2 * aggregated_output::EXIT_SLOT_LEN);
-
-        // Dummy nullifiers (slots 0..7) must be replaced with hashes of the preimages.
-        for (i, pre_image) in dummy_nullifier_pre_images
-            .iter()
-            .enumerate()
-            .take(num_dummy_proofs)
-        {
-            let idx = nullifier_region_start + i * 4;
-            let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
-            let expected = hash_dummy_nullifier_pre_image_native(*pre_image);
-            assert_eq!(got, expected, "dummy nullifier hash mismatch at leaf {i}");
-        }
-
-        // Real nullifier (slot 7) must be forwarded unchanged.
-        let idx = nullifier_region_start + real_slot * 4;
-        let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
-        assert_eq!(
-            got, nullifiers_felts[real_slot],
-            "real nullifier must be preserved in the last slot"
-        );
     }
 
     #[test]

--- a/wormhole/aggregator/src/layer0/prover/lib.rs
+++ b/wormhole/aggregator/src/layer0/prover/lib.rs
@@ -31,8 +31,7 @@ use zk_circuits_common::{
 
 use crate::{
     common::utils::{
-        ensure_proof_public_input_len, is_dummy_leaf_proof, leaf_proof_asset_id,
-        load_verifier_data_from_bytes,
+        ensure_proof_public_input_len, leaf_proof_asset_id, load_verifier_data_from_bytes,
     },
     dummy_proof::{generate_random_nullifier_preimage, load_dummy_proof},
     layer0::{
@@ -250,8 +249,12 @@ impl Layer0AggregationProver {
             proofs.push(self.dummy_proof_template.clone());
         }
 
-        // Shuffle proofs to hide dummy positions while preserving a real proof in slot 0 (if any)
-        shuffle_proofs_preserving_first_real_layer0(&mut proofs);
+        // Uniformly shuffle proofs to hide dummy positions. The circuit selects its block
+        // reference from the first non-dummy slot in-circuit, so no position is special.
+        if proofs.len() > 1 {
+            let mut rng = rand::thread_rng();
+            proofs.shuffle(&mut rng);
+        }
 
         // Generate one dummy nullifier preimage per slot.
         // In-circuit hashes these only for dummy proofs.
@@ -279,26 +282,6 @@ impl Layer0AggregationProver {
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
-
-/// Shuffle proofs while ensuring a real proof remains in slot 0 (if any real proof exists).
-///
-/// This hides dummy proof positions while maintaining valid circuit semantics
-/// (slot 0 must contain a real proof for reference value extraction).
-fn shuffle_proofs_preserving_first_real_layer0(proofs: &mut [ProofWithPublicInputs<F, C, D>]) {
-    // Find the first real proof
-    if let Some(first_real_idx) = proofs
-        .iter()
-        .position(|p| !is_dummy_leaf_proof(p).unwrap_or(false))
-    {
-        proofs.swap(0, first_real_idx);
-    }
-
-    // Shuffle remaining proofs
-    if proofs.len() > 1 {
-        let mut rng = rand::thread_rng();
-        proofs[1..].shuffle(&mut rng);
-    }
-}
 
 /// If we're padding with dummy proofs (`asset_id = 0`), real proofs must also use `asset_id = 0`
 /// because the layer-0 circuit enforces asset_id equality across all proofs.


### PR DESCRIPTION
- fully shuffle child proofs
- now first nullifier is not guaranteed to be real
- simplifies privacy analysis
- add regression test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes layer-0 ZK wrapper constraints and prover ordering; privacy improves but aggregated circuit binaries must be rebuilt and re-verified for production.
> 
> **Overview**
> Layer-0 aggregation no longer treats **slot 0** as special for privacy. The prover **uniformly shuffles** all leaf proofs (including dummies) instead of pinning a real proof in slot 0 and shuffling only the rest.
> 
> The aggregation circuit now picks **`block_hash` / `block_number` references** with an in-circuit scan over the **first non-dummy** slot (dummy = `block_hash == [0;4]`), then still enforces that every real leaf matches that block. **`asset_id` / `volume_fee_bps`** still come from slot 0 with equality enforced on all slots.
> 
> Removed prover-only **`is_dummy_leaf_proof`** and the **`shuffle_proofs_preserving_first_real_layer0`** helper. README documents the new shuffle behavior. Added **`recursive_aggregation_real_proof_in_every_slot_succeeds`** so aggregation works when the sole real proof sits in any slot.
> 
> **Note:** This changes layer-0 circuit logic; prebuilt circuit binaries should be regenerated after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5bc7f8e3c2b264ad9116eb79783c1e982adb642. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->