### PR TITLE
Out with Random Oracle in with Collision Resistance

### DIFF
--- a/formal/SPEC.md
+++ b/formal/SPEC.md
@@ -14,7 +14,7 @@ spec + the differential safety net.
 | `WormholeSpec/Hash.lean` | Random-oracle interface, `WA`/`Null`/`leafHash`/`nodeHash`/`dummyNull` |
 | `WormholeSpec/Leaf.lean` | Leaf relation `Rleaf` (C1–C5, conditional dummy path) |
 | `WormholeSpec/Aggregation.lean` | `RL0`, `RL1` |
-| `WormholeSpec/Security.lean` | Deterministic cores of the reduction theorems (injective-RO model) |
+| `WormholeSpec/Security.lean` | Deterministic cores of the reduction theorems (`*_or_collision` + collision-resistance corollaries) |
 | `WormholeSpec/Encoding.lean` | Byte↔felt encoding safety (4-byte injective edges, 8-byte canonical-only) |
 | `WormholeSpec/LeafBinding.lean` | Finding A: chain↔circuit leaf-recipient consistency (spendable ⟺ recipient = `WA(s)`) |
 | `../wormhole/tests/.../spec_differential.rs` | proptest harness: native oracles vs spec |
@@ -37,22 +37,22 @@ hermetic. Toolchain is pinned in `lean-toolchain` (Lean `v4.30`).
   *explicitly* over `Nat` with the modulus `goldilocks` — see `Encoding.lean` —
   so they do not require `Felt` to be the field. **The representation is not a
   free global swap:** redefining `Felt := ZMod goldilocks` workspace-wide would
-  make `Digest = Felt⁴` finite while `List Felt` stays infinite, so no injective
-  `H` exists (pigeonhole), `RandomOracle` becomes uninhabited, and every
-  RO-dependent theorem (`Security.lean`, `LeafBinding.lean`) silently turns
-  *vacuous*. Today `Felt = Nat` is infinite, so `RandomOracle` is inhabited and
-  those theorems have content. Phase-2 in-field arithmetic and Phase-4
-  game-based resistance therefore live in a separate concrete-field layer; the
-  RO modules stay over an infinite/abstract `Felt`. (See the warnings in
-  `Basic.lean` / `Hash.lean`.)
-- **Hash `H` as a random oracle.** Represented by an opaque total function `H`
-  (capturing *determinism*) plus an `injective` field — the RO "no collisions"
-  idealization that soundness/security proofs may invoke (`Hash.lean`). This
-  *total* injectivity is consistent only over an infinite `Felt`; a compressing
-  hash over a finite field is never literally injective, so the faithful
-  finite-field model is the Phase-4 game (collisions negligibly rare, not
-  impossible). The Phase-4 game-based track replaces this with an explicit lazily-sampled RO game;
-  this structure is the seam.
+  force the `Nat`-level arithmetic/encoding proofs (`Aggregation` conservation,
+  `Encoding` byte bounds, all `omega`) to be reworked for modular arithmetic. The
+  *hash interface* no longer pins the carrier (see next bullet). (See the warnings
+  in `Basic.lean` / `Hash.lean`.)
+- **Hash `H` with explicit collision resistance.** Represented by an opaque total
+  function `H` (capturing *determinism*); `RandomOracle` carries **no** idealizing
+  field, so it is inhabited by *any* `H` — including a compressing finite-field hash
+  (`Hash.lean`). Collision resistance is a *separate, opt-in* predicate
+  `RandomOracle.CollisionResistant`. The security results come in two forms: a
+  **reduction** (`*_or_collision`) provable for any `H` with no assumption ("a scheme
+  break constructs a collision in `H`"), and a **corollary** under
+  `CollisionResistant` that recovers the clean conclusion. This is what lets the
+  oracle be instantiated by the concrete finite-field Poseidon2 sponge
+  (`Plonky2Spec.Sponge`); the old `injective` field made `RandomOracle` *uninhabited*
+  over a finite field (pigeonhole) and every RO theorem vacuous. The `ε_coll`/`ε_pre`
+  probabilistic accounting is the Phase-4 game-based track; this interface is the seam.
 - **TCB.** Not re-verified: Plonky2's FRI/PLONK soundness, the `PoseidonGate`
   implementation, the Lean kernel. The claim is: *given a sound proof system and
   a correct Poseidon2 gate, the constraints implement these relations.*
@@ -93,13 +93,16 @@ hermetic. Toolchain is pinned in `lean-toolchain` (Lean `v4.30`).
 
 ### Security reductions (`Security.lean`)
 
-Deterministic cores of the game-based theorems, in the injective-RO model.
+Deterministic cores of the game-based theorems. Each has a **reduction** form
+(`*_or_collision`, no assumption, "break ⇒ explicit `H` collision") and a
+**corollary** under the explicit `CollisionResistant ro` hypothesis.
 
 | Spec clause | Paper | Notes |
 |-------------|-------|-------|
-| `WA_inj` (`WA s = WA s' → s = s'`) | §4.2 | collision resistance ⇒ injectivity, idealized |
-| **thm** `same_deposit_same_nullifier` / `no_double_spend` | Thm (One-Time Withdrawal) | same deposit ⇒ same nullifier; `n₁ ≠ n₂` unsatisfiable |
-| **thm** `spend_path_unique` (`H pk = WA s → pk = H(salt_wh ‖ s) .toList`) | Thm (Spend-Path Exclusivity) | unique outer preimage; case (2) ⟶ case (1) |
+| `WA_inj_or_collision` / `WA_inj` (`WA s = WA s' → s = s'`) | §4.2 | distinct secrets sharing an address ⇒ collision; injective under CR |
+| **thm** `same_deposit_same_nullifier` / `no_double_spend` | Thm (One-Time Withdrawal) | same deposit ⇒ same nullifier; `n₁ ≠ n₂` unsatisfiable (under CR) |
+| **thm** `spend_path_unique_or_collision` / `spend_path_unique` (`H pk = WA s → pk = H(salt_wh ‖ s) .toList`) | Thm (Spend-Path Exclusivity) | unique outer preimage (under CR); case (2) ⟶ case (1) |
+| `Demo.collapsingRO` | — | payoff: a non-injective `H` inhabiting `RandomOracle` (impossible under the old `injective` field) |
 
 ### Encoding safety (`Encoding.lean`)
 
@@ -133,7 +136,7 @@ to `WA(s)`):
 
 | Spec clause | Content |
 |-------------|---------|
-| `chain_circuit_leaf_eq_iff` | pallet leaf = circuit `WA(s)` leaf ⟺ recipient *decodes* to `WA(s)` (`H` injective) |
+| `chain_circuit_leaf_eq_iff` | pallet leaf = circuit `WA(s)` leaf ⟺ recipient *decodes* to `WA(s)` (under `CollisionResistant ro`) |
 | `spendable_recipient_reduces_to_address` | **any** spendable recipient reduces to `WA(s)` — a non-canonical alias binds to the same address/nullifier, no advantage |
 | `spendable_iff_is_wormhole_address` | among **canonical** recipients the spendable one is **unique** = `WA(s)` |
 | `wormhole_address_canonical` | `WA(s)` is canonical (RO outputs are), so the honest recipient meets the precondition |
@@ -170,8 +173,9 @@ step is the Phase-4 preimage game, as for the other security theorems.
    spec reflects this (no `Rleaf` clause references them); the binding obligation
    lives in `RL0`.
 6. **Game-based probabilistic accounting.** `Security.lean` proves the
-   *deterministic* cores of one-time withdrawal and spend-path exclusivity in the
-   injective-RO model. The `ε_coll`/`ε_pre` terms and the knowledge-soundness
+   *deterministic* cores of one-time withdrawal and spend-path exclusivity as
+   reductions to an `H` collision, clean under the `CollisionResistant` hypothesis.
+   The `ε_coll`/`ε_pre` terms and the knowledge-soundness
    extractor (and likewise deposit binding, nullifier indistinguishability, and
    transaction unlinkability) require an explicit lazily-sampled RO game — the
    Phase-4 track, out of scope for the current deterministic spec.

--- a/formal/WormholeSpec.lean
+++ b/formal/WormholeSpec.lean
@@ -8,7 +8,7 @@
 
   Module map:
   * `WormholeSpec.Basic`       field/digest model, salts, range predicate
-  * `WormholeSpec.Hash`        random-oracle interface and derived hashes
+  * `WormholeSpec.Hash`        hash interface (`H`, `CollisionResistant`) and derived hashes
   * `WormholeSpec.Leaf`        leaf relation R_leaf (C1–C5, conditional dummy path)
   * `WormholeSpec.Aggregation` layer-0 / layer-1 aggregation relations
   * `WormholeSpec.Trusted`     the trusted base (T4): explicit `axiom`s for the
@@ -17,7 +17,8 @@
                                `RL0`/`RL1`, and (with `Trusted`) a satisfied
                                aggregation circuit attests its own + each child's relation
   * `WormholeSpec.Security`    reduction-style theorems (one-time withdrawal,
-                               spend-path exclusivity) in the injective-RO model
+                               spend-path exclusivity): `*_or_collision` reductions
+                               + corollaries under the `CollisionResistant` hypothesis
   * `WormholeSpec.Encoding`    byte↔felt encoding safety: 4-byte injective at the
                                edges, 8-byte injective only on canonical inputs
 

--- a/formal/WormholeSpec.lean
+++ b/formal/WormholeSpec.lean
@@ -11,6 +11,11 @@
   * `WormholeSpec.Hash`        random-oracle interface and derived hashes
   * `WormholeSpec.Leaf`        leaf relation R_leaf (C1–C5, conditional dummy path)
   * `WormholeSpec.Aggregation` layer-0 / layer-1 aggregation relations
+  * `WormholeSpec.Trusted`     the trusted base (T4): explicit `axiom`s for the
+                               recursive-verifier (`verify_proof`) soundness
+  * `WormholeSpec.AggregationBridge`  the L0/L1 wrapper *circuit constraints* imply
+                               `RL0`/`RL1`, and (with `Trusted`) a satisfied
+                               aggregation circuit attests its own + each child's relation
   * `WormholeSpec.Security`    reduction-style theorems (one-time withdrawal,
                                spend-path exclusivity) in the injective-RO model
   * `WormholeSpec.Encoding`    byte↔felt encoding safety: 4-byte injective at the
@@ -22,6 +27,8 @@ import WormholeSpec.Basic
 import WormholeSpec.Hash
 import WormholeSpec.Leaf
 import WormholeSpec.Aggregation
+import WormholeSpec.Trusted
+import WormholeSpec.AggregationBridge
 import WormholeSpec.Security
 import WormholeSpec.Encoding
 import WormholeSpec.LeafBinding

--- a/formal/WormholeSpec/AggregationBridge.lean
+++ b/formal/WormholeSpec/AggregationBridge.lean
@@ -1,0 +1,135 @@
+/-
+  The aggregation bridge: the L0/L1 wrapper *circuit constraints* imply the spec
+  relations `RL0` / `RL1`, and — composed with the trusted recursive-verifier
+  soundness (`Trusted.lean`) — a satisfied aggregation circuit attests both its own
+  relation and every child's relation.
+
+  WHAT THIS MODELS. We model the wrapper constraints of `build_layer0_wrapper_constraints`
+  / `build_layer1_wrapper_constraints` as the facts the circuit *enforces* on the
+  decoded public inputs (`Layer0Circuit` / `Layer1Circuit`), then prove each implies
+  the corresponding spec relation. The faithfulness of "the wrapper *gadgets* compute
+  these conditionals" — `select`/`and`/`or`/the first-real prefix scan — is the
+  separate, field-level (`ZMod p`) contribution of `qp-plonky2/formal`'s
+  `Plonky2Spec.Wrapper`; the two compose at the `ZMod.val ↔ Felt` boundary (the
+  cross-package seam, kept explicit since `WormholeSpec` is deliberately mathlib-free
+  over `Felt = ℕ` and does not import the plonky2 spec). Concretely:
+
+    * nullifier per slot      `select(is_dummy, H(H u), real)`  — `Plonky2Spec.Wrapper.nullifier_replacement`
+    * exit grouping/dedup     `select`/`matchSum`/`groupAux`     — `Plonky2Spec.Wrapper.{match_contribution, dedup_select}`
+    * block reference         first-real prefix scan             — `Plonky2Spec.Wrapper.scanFirst_correct`
+    * metadata `or`-clause    `or(is_dummy, matches) = 1`        — `Plonky2Spec.Wrapper.{block_consistency, real_block_matches}`
+
+  This file is the public-input-level half: given those conditionals, the constructed
+  aggregate output satisfies `RL0` / `RL1`.
+-/
+import WormholeSpec.Basic
+import WormholeSpec.Hash
+import WormholeSpec.Leaf
+import WormholeSpec.Aggregation
+import WormholeSpec.Trusted
+
+namespace WormholeSpec
+
+/-! ### Layer-0 -/
+
+/-- The per-slot nullifier output the circuit builds: `select(is_dummy, H(H u), real)`
+    for each `(child, preimage)` pair. Mirrors `nullifiersReplaced`'s per-slot body. -/
+def buildNullifiers (ro : RandomOracle) :
+    List LeafPublic → List (List Felt) → List Digest
+  | [], _ => []
+  | _, [] => []
+  | p :: ps, u :: us =>
+      (if isDummyL0 p then ro.dummyNull u else p.nullifier) :: buildNullifiers ro ps us
+
+/-- `buildNullifiers` realizes `nullifiersReplaced` when there is one preimage per
+    child (the circuit witness layout: `dummy_nullifier_pre_images.len() = n_leaf`). -/
+theorem nullifiersReplaced_build (ro : RandomOracle) :
+    ∀ (leaves : List LeafPublic) (us : List (List Felt)),
+      us.length = leaves.length →
+      nullifiersReplaced ro leaves us (buildNullifiers ro leaves us)
+  | [], [], _ => trivial
+  | p :: ps, u :: us, h => by
+      refine ⟨rfl, nullifiersReplaced_build ro ps us ?_⟩
+      simpa using h
+  | [], _ :: _, h => by simp at h
+  | _ :: _, [], h => by simp at h
+
+/-- `buildNullifiers` has one entry per child (matching `out.nullifiers.length`). -/
+theorem buildNullifiers_length (ro : RandomOracle) :
+    ∀ (leaves : List LeafPublic) (us : List (List Felt)),
+      us.length = leaves.length →
+      (buildNullifiers ro leaves us).length = leaves.length
+  | [], [], _ => rfl
+  | p :: ps, u :: us, h => by
+      simp only [buildNullifiers, List.length_cons]
+      rw [buildNullifiers_length ro ps us (by simpa using h)]
+  | [], _ :: _, h => by simp at h
+  | _ :: _, [], h => by simp at h
+
+/-- The layer-0 wrapper constraints, as the circuit enforces them on the decoded
+    public inputs (`build_layer0_wrapper_constraints`). The metadata/reference clauses
+    are the satisfied form of the `or(is_dummy, matches)` constraint and the first-real
+    scan; the nullifier/exit clauses are the `select`/grouping outputs. -/
+structure Layer0Circuit (ro : RandomOracle) (leaves : List LeafPublic)
+    (us : List (List Felt)) (out : Layer0Output) : Prop where
+  /-- One dummy-nullifier preimage per leaf slot. -/
+  uslen : us.length = leaves.length
+  /-- Per-slot `select(is_dummy, H(H u), real)`. -/
+  nulls : out.nullifiers = buildNullifiers ro leaves us
+  /-- The `2N` settled slots are the in-circuit group/dedup of every child's outputs. -/
+  exits : out.exitSlots = groupExits (childPairs leaves)
+  /-- Each non-dummy child agrees with the aggregate header (the `or`-clause, satisfied). -/
+  metaOk : metadataConsistent leaves out
+  /-- The header is taken from the first non-dummy child (first-real scan result). -/
+  ref : referenceFromFirstReal leaves out
+
+/-- **Layer-0 bridge.** The wrapper constraints imply the spec relation `RL0`. -/
+theorem layer0_bridge {ro : RandomOracle} {leaves : List LeafPublic}
+    {us : List (List Felt)} {out : Layer0Output}
+    (h : Layer0Circuit ro leaves us out) : RL0 ro leaves us out := by
+  refine ⟨h.metaOk, h.ref, ?_, ?_, h.exits⟩
+  · rw [h.nulls]; exact nullifiersReplaced_build ro leaves us h.uslen
+  · rw [h.nulls]; exact buildNullifiers_length ro leaves us h.uslen
+
+/-- **Layer-0 soundness (end to end).** A satisfied layer-0 aggregation circuit whose
+    recursion gadget accepted every child leaf proof attests both the layer-0 relation
+    `RL0` *and* that each child's public inputs satisfy the leaf relation `Rleaf`
+    (the latter via the trusted `leaf_proof_sound`). -/
+theorem layer0_sound {ro : RandomOracle} {leaves : List LeafPublic}
+    {us : List (List Felt)} {out : Layer0Output}
+    (hacc : ∀ p ∈ leaves, LeafProofAccepted ro p)
+    (hcirc : Layer0Circuit ro leaves us out) :
+    RL0 ro leaves us out ∧ ∀ p ∈ leaves, ∃ w : LeafWitness, Rleaf ro p w :=
+  ⟨layer0_bridge hcirc, fun p hp => leaf_proof_sound ro p (hacc p hp)⟩
+
+/-! ### Layer-1 -/
+
+/-- The layer-1 wrapper constraints (`build_layer1_wrapper_constraints`): bind the
+    aggregator address, enforce metadata consistency across the inner layer-0 outputs,
+    and forward the exit slots / nullifiers in order. -/
+structure Layer1Circuit (ro : RandomOracle) (inner : List Layer0Output)
+    (addr : Digest) (out : Layer1Output) : Prop where
+  addrEq : out.aggregatorAddress = addr
+  metaOk : ∀ o ∈ inner,
+      o.assetId = out.assetId ∧ o.volumeFeeBps = out.volumeFeeBps ∧
+      o.blockHash = out.blockHash ∧ o.blockNumber = out.blockNumber
+  exits : out.exitSlots = (inner.map (fun o => o.exitSlots)).flatten
+  nulls : out.nullifiers = (inner.map (fun o => o.nullifiers)).flatten
+
+/-- **Layer-1 bridge.** The wrapper constraints imply the spec relation `RL1`. -/
+theorem layer1_bridge {ro : RandomOracle} {inner : List Layer0Output}
+    {addr : Digest} {out : Layer1Output}
+    (h : Layer1Circuit ro inner addr out) : RL1 ro inner addr out :=
+  ⟨h.addrEq, h.metaOk, h.exits, h.nulls⟩
+
+/-- **Layer-1 soundness (end to end).** A satisfied layer-1 aggregation circuit whose
+    recursion gadget accepted every inner layer-0 proof attests both `RL1` *and* that
+    each inner output satisfies `RL0` for some children (via `layer0_proof_sound`). -/
+theorem layer1_sound {ro : RandomOracle} {inner : List Layer0Output}
+    {addr : Digest} {out : Layer1Output}
+    (hacc : ∀ o ∈ inner, Layer0ProofAccepted ro o)
+    (hcirc : Layer1Circuit ro inner addr out) :
+    RL1 ro inner addr out ∧ ∀ o ∈ inner, ∃ leaves us, RL0 ro leaves us o :=
+  ⟨layer1_bridge hcirc, fun o ho => layer0_proof_sound ro o (hacc o ho)⟩
+
+end WormholeSpec

--- a/formal/WormholeSpec/AggregationBridge.lean
+++ b/formal/WormholeSpec/AggregationBridge.lean
@@ -138,9 +138,9 @@ theorem layer0_sound {ro : RandomOracle} {leaves : List LeafPublic}
     body in two places (which would let the circuit predicate and the relation drift), we
     *define* `Layer1Circuit` as `RL1` itself rather than as a separate structure; the
     `layer1_bridge` below is then honestly the identity. -/
-abbrev Layer1Circuit (ro : RandomOracle) (inner : List Layer0Output)
+abbrev Layer1Circuit (_ro : RandomOracle) (inner : List Layer0Output)
     (addr : Digest) (out : Layer1Output) : Prop :=
-  RL1 ro inner addr out
+  RL1 _ro inner addr out
 
 /-- **Layer-1 bridge.** Definitionally the identity (`Layer1Circuit` *is* `RL1`): the
     layer-1 wrapper enforces precisely `RL1`'s conjuncts, with no functional decode to

--- a/formal/WormholeSpec/AggregationBridge.lean
+++ b/formal/WormholeSpec/AggregationBridge.lean
@@ -21,6 +21,25 @@
 
   This file is the public-input-level half: given those conditionals, the constructed
   aggregate output satisfies `RL0` / `RL1`.
+
+  SCOPE / ASSURANCE (read honestly). With gadget-level faithfulness delegated to
+  `Plonky2Spec.Wrapper` and proof-system soundness to `Trusted.lean`, the theorems
+  *here* are deliberately thin, and that should be stated plainly:
+
+    * `layer0_bridge` does one piece of real work — relating the *functional*
+      `buildNullifiers` the circuit computes to the *relational* `nullifiersReplaced`
+      (`nullifiersReplaced_build`); its other conjuncts (`metaOk`, `ref`, `exits`) are
+      shared verbatim with `RL0`. So `layer0_sound` is "the `layer0_proof_sound` axiom
+      + that one modest nullifier lemma".
+    * `layer1_bridge` is the *identity*. The layer-1 wrapper conditions are
+      field-for-field `RL1`, so `Layer1Circuit` is *defined as* `RL1` (below) rather than
+      restated, and the bridge carries no logical content. Consequently `layer1_sound`
+      is "the `layer0_proof_sound` axiom + a structural repackaging" — near-trivial as
+      currently scoped.
+
+  This is the intended package boundary, not an oversight; the non-trivial content lives
+  in `Plonky2Spec.Wrapper` (gadgets), `Trusted.lean` (proof-system soundness), and the
+  layer-0 grouping/conservation proofs in `Aggregation.lean`.
 -/
 import WormholeSpec.Basic
 import WormholeSpec.Hash
@@ -94,7 +113,11 @@ theorem layer0_bridge {ro : RandomOracle} {leaves : List LeafPublic}
 /-- **Layer-0 soundness (end to end).** A satisfied layer-0 aggregation circuit whose
     recursion gadget accepted every child leaf proof attests both the layer-0 relation
     `RL0` *and* that each child's public inputs satisfy the leaf relation `Rleaf`
-    (the latter via the trusted `leaf_proof_sound`). -/
+    (the latter via the trusted `leaf_proof_sound`).
+
+    Honestly scoped, this is "the `leaf_proof_sound` axiom + `layer0_bridge`", and the
+    only real work inside the bridge is `nullifiersReplaced_build` (the rest of `RL0` is
+    shared verbatim with `Layer0Circuit`). -/
 theorem layer0_sound {ro : RandomOracle} {leaves : List LeafPublic}
     {us : List (List Felt)} {out : Layer0Output}
     (hacc : ∀ p ∈ leaves, LeafProofAccepted ro p)
@@ -106,25 +129,35 @@ theorem layer0_sound {ro : RandomOracle} {leaves : List LeafPublic}
 
 /-- The layer-1 wrapper constraints (`build_layer1_wrapper_constraints`): bind the
     aggregator address, enforce metadata consistency across the inner layer-0 outputs,
-    and forward the exit slots / nullifiers in order. -/
-structure Layer1Circuit (ro : RandomOracle) (inner : List Layer0Output)
-    (addr : Digest) (out : Layer1Output) : Prop where
-  addrEq : out.aggregatorAddress = addr
-  metaOk : ∀ o ∈ inner,
-      o.assetId = out.assetId ∧ o.volumeFeeBps = out.volumeFeeBps ∧
-      o.blockHash = out.blockHash ∧ o.blockNumber = out.blockNumber
-  exits : out.exitSlots = (inner.map (fun o => o.exitSlots)).flatten
-  nulls : out.nullifiers = (inner.map (fun o => o.nullifiers)).flatten
+    and forward the exit slots / nullifiers in order.
 
-/-- **Layer-1 bridge.** The wrapper constraints imply the spec relation `RL1`. -/
+    Unlike layer 0 — where the circuit's *functional* `buildNullifiers` has to be related
+    to the *relational* `nullifiersReplaced` (`nullifiersReplaced_build`, the real work)
+    — the layer-1 wrapper performs no functional decode: the four conditions it enforces
+    are *exactly* the four conjuncts of the spec relation `RL1`. To avoid restating that
+    body in two places (which would let the circuit predicate and the relation drift), we
+    *define* `Layer1Circuit` as `RL1` itself rather than as a separate structure; the
+    `layer1_bridge` below is then honestly the identity. -/
+abbrev Layer1Circuit (ro : RandomOracle) (inner : List Layer0Output)
+    (addr : Digest) (out : Layer1Output) : Prop :=
+  RL1 ro inner addr out
+
+/-- **Layer-1 bridge.** Definitionally the identity (`Layer1Circuit` *is* `RL1`): the
+    layer-1 wrapper enforces precisely `RL1`'s conjuncts, with no functional decode to
+    relate (contrast `layer0_bridge`, which must invoke `nullifiersReplaced_build`). Kept
+    only for naming parity with `layer0_bridge`; it carries no logical content. -/
 theorem layer1_bridge {ro : RandomOracle} {inner : List Layer0Output}
     {addr : Digest} {out : Layer1Output}
-    (h : Layer1Circuit ro inner addr out) : RL1 ro inner addr out :=
-  ⟨h.addrEq, h.metaOk, h.exits, h.nulls⟩
+    (h : Layer1Circuit ro inner addr out) : RL1 ro inner addr out := h
 
 /-- **Layer-1 soundness (end to end).** A satisfied layer-1 aggregation circuit whose
     recursion gadget accepted every inner layer-0 proof attests both `RL1` *and* that
-    each inner output satisfies `RL0` for some children (via `layer0_proof_sound`). -/
+    each inner output satisfies `RL0` for some children (via `layer0_proof_sound`).
+
+    As currently scoped this is near-trivial: the `RL1` half is `layer1_bridge` (the
+    identity above), so the only substantive content is the trusted `layer0_proof_sound`
+    axiom. The structural faithfulness of the layer-1 wrapper gadgets lives in
+    `Plonky2Spec.Wrapper`, not here. -/
 theorem layer1_sound {ro : RandomOracle} {inner : List Layer0Output}
     {addr : Digest} {out : Layer1Output}
     (hacc : ∀ o ∈ inner, Layer0ProofAccepted ro o)

--- a/formal/WormholeSpec/Basic.lean
+++ b/formal/WormholeSpec/Basic.lean
@@ -12,19 +12,23 @@
 
   WARNING — the field representation is NOT a free global swap.
   -----------------------------------------------------------
-  Do **not** redefine `abbrev Felt := ZMod goldilocks` workspace-wide. `Hash.lean`
-  models the hash as a *totally injective* `H : List Felt → Digest` (the
-  random-oracle idealization). That is satisfiable only while the carrier is
-  infinite — as `Nat` is, so `RandomOracle` is inhabited today and the security
-  theorems have content. Over a *finite* `Felt`, `Digest = Felt⁴` is finite while
-  `List Felt` is infinite, so by pigeonhole no injective `H` exists ⇒
-  `RandomOracle` becomes uninhabited ⇒ every RO-dependent theorem
-  (`Security.lean`, `LeafBinding.lean`) silently turns vacuous. See the matching
-  warning in `Hash.lean`.
+  Do **not** redefine `abbrev Felt := ZMod goldilocks` workspace-wide. The reason is
+  now the *arithmetic*, not the hash: `Encoding.lean` and `Aggregation.lean` discharge
+  byte-bound and value-conservation goals with `omega` over `Nat`, and those proofs
+  would have to be reworked for modular field arithmetic.
+
+  The hash interface no longer forces this choice. `Hash.lean` used to bake a *totally
+  injective* `H` into `RandomOracle`, which is satisfiable only over an infinite carrier
+  (over a finite `Felt`, pigeonhole kills injectivity, `RandomOracle` becomes
+  uninhabited, and every RO-dependent theorem turns vacuous). That field is gone:
+  collision resistance is now an *explicit hypothesis* (`RandomOracle.CollisionResistant`)
+  and the security results are stated as reductions that hold for any `H`. Collision
+  resistance is consistent over a finite field, so the oracle can be instantiated by the
+  concrete finite-field Poseidon2 sponge.
 
   Consequently the interactive in-field arithmetic (Phase 2) and the game-based
-  collision / preimage resistance (Phase 4) belong in their own concrete-field
-  layer; the RO-dependent modules must stay over an infinite / abstract `Felt`.
+  `ε_coll` / `ε_pre` accounting (Phase 4) still belong in their own layer, but the
+  modeling obstruction that pinned the RO modules to an infinite carrier is removed.
 -/
 
 namespace WormholeSpec

--- a/formal/WormholeSpec/Hash.lean
+++ b/formal/WormholeSpec/Hash.lean
@@ -1,69 +1,88 @@
 /-
   Random-oracle interface and the hash derivations used by the circuit.
 
-  H AS A RANDOM ORACLE
-  --------------------
-  At the specification level we represent the Poseidon2 hash as a *random oracle*
-  via two pieces:
+  H AS A HASH WITH AN EXPLICIT COLLISION-RESISTANCE ASSUMPTION
+  ------------------------------------------------------------
+  At the specification level we represent the Poseidon2 hash as:
 
   1. `H : List Felt → Digest`, a total opaque function. Totality + functionhood
-     already capture *determinism* (equal preimages give equal digests), which is
-     all the functional spec needs.
+     already capture *determinism* (equal preimages give equal digests).
 
-  2. `injective`, the RO idealization that "no collisions occur". In a
-     deterministic proof assistant collision resistance cannot be a theorem about
-     a concrete function, so we surface it as an assumption that soundness proofs
-     may invoke. Modeling the RO as injective is the standard spec-level
-     idealization and is exactly what the deposit-binding / nullifier arguments
-     rely on.
+  2. `CollisionResistant ro`, a *separate, opt-in* assumption (not a field of the
+     structure). It says `H` has no collision; the security results are stated as
+     **reductions** that hold for *any* `H` ("a scheme break constructs a collision
+     in `H`", the `*_or_collision` lemmas), and recover their clean conclusions only
+     when this assumption is supplied. This is the deterministic core of the paper's
+     game-based reductions; the `ε_coll` / `ε_pre` probabilistic accounting is the
+     Phase-4 game, out of scope here.
 
-  WARNING — total injectivity is only consistent over an INFINITE `Felt`.
-  ---------------------------------------------------------------------
-  `HashInjective` quantifies over all of `List Felt` (infinite) into `Digest`
-  (`Felt⁴`). With the current `Felt := Nat` the codomain is infinite, an injective
-  `H` exists, and `RandomOracle` is inhabited — so the theorems downstream
-  (`WA_inj`, `same_deposit_same_nullifier`, `spend_path_unique`, the Finding-A
-  binding lemmas) are non-vacuous. But a *compressing* hash over a finite field is
-  never literally injective: if `Felt` is swapped to `ZMod goldilocks`, `Digest`
-  becomes finite, no injective `H : List Felt → Digest` exists (pigeonhole), and
-  `RandomOracle` becomes uninhabited. Every theorem taking `ro : RandomOracle`
-  would then be *vacuously* true and content-free. So this module must stay over
-  an infinite / abstract `Felt`; never instantiate it at the concrete field.
+  WHY THIS, NOT TOTAL INJECTIVITY AS A FIELD.
+  -------------------------------------------
+  The previous model baked `injective : ∀ x y, H x = H y → x = y` into the structure.
+  That is the right *idealization* but with a fatal side effect: a compressing hash
+  over a finite field is never injective (pigeonhole), so over `Felt = ZMod goldilocks`
+  no injective `H` exists, `RandomOracle` is *uninhabited*, and every theorem taking
+  `ro : RandomOracle` is vacuously true. Making collision resistance an *external
+  hypothesis* keeps `RandomOracle` inhabited by *any* `H` — including the concrete
+  finite-field Poseidon2 sponge — which is exactly the obstruction that previously
+  blocked instantiating the oracle (`Plonky2Spec.Sponge`, Step 3c). The honest content
+  moves into the reductions; collision resistance is invoked only where a clean
+  conclusion is wanted, precisely as a real cryptographic reduction does.
 
-  The faithful finite-field model is the Phase-4 game-based track (deposit
-  binding, unlinkability, nullifier indistinguishability): an explicit
-  lazily-sampled RO game with `ε_coll` / `ε_pre` advantage bounds, where
-  collisions are *negligibly rare* rather than *impossible*. This interface is the
-  seam where that richer model plugs in.
+  `Felt` stays `Nat` here, but now for a *different* reason: the `Nat`-level arithmetic
+  and encoding proofs (`Aggregation` conservation via `omega`, `Encoding` byte bounds)
+  need it. Unlike injectivity, collision resistance is consistent over a finite carrier,
+  so the hash interface is no longer what forces the choice.
 -/
 import WormholeSpec.Basic
 
 namespace WormholeSpec
 
-/-- Build-time tripwire for the warning above. The RO idealization
-    (`HashInjective`) is consistent only over an *infinite* carrier; this `rfl`
-    pins `Felt` to `Nat`. If a future change redefines `Felt` as a finite field,
-    THIS line stops compiling — forcing the author to confront the vacuity issue
-    (move the RO modules to an abstract/infinite carrier, or the Phase-4 game)
-    rather than silently turning every RO-dependent theorem vacuous. -/
+/-- Build-time tripwire: this `rfl` pins `Felt` to `Nat`. The `Nat`-level arithmetic
+    and encoding proofs (`Aggregation` conservation, `Encoding` byte bounds) rely on
+    it; if a future change redefines `Felt` (e.g. as `ZMod goldilocks`), THIS line
+    stops compiling, forcing those `omega`/byte proofs to be reworked for the field.
+    (Note: unlike the old injective-RO model, the hash interface is *not* what forces
+    `Nat` — collision resistance is finite-field-consistent.) -/
 example : Felt = Nat := rfl
 
-/-- Spec-level injectivity for the hash (the RO "no collisions" idealization).
-    Consistent ONLY over an infinite `Felt` (see the module-header warning): with
-    a finite field this is unsatisfiable and makes `RandomOracle` uninhabited. -/
-def HashInjective (H : List Felt → Digest) : Prop :=
-  ∀ x y, H x = H y → x = y
+/-- A collision in `H`: two *distinct* preimages with the same digest. This is the
+    object a collision-resistance adversary must exhibit; the security *reductions*
+    below construct one from any scheme break. -/
+def HasCollision (H : List Felt → Digest) : Prop :=
+  ∃ x y, x ≠ y ∧ H x = H y
 
-/-- A Poseidon2 hash modeled as a random oracle. -/
+/-- A Poseidon2 hash. Unlike the old injective-RO model this carries *no* idealizing
+    field: it is just `H`, so it is inhabited over any carrier (including the finite
+    field, where an injective `H` cannot exist). Collision resistance is supplied
+    separately, as the explicit `CollisionResistant` hypothesis. -/
 structure RandomOracle where
   /-- The hash function: `hash_n_to_hash_no_pad` over Goldilocks, 4-felt output. -/
   H : List Felt → Digest
-  /-- RO idealization: collisions do not occur (see module header). -/
-  injective : HashInjective H
 
 namespace RandomOracle
 
 variable (ro : RandomOracle)
+
+/-- Collision resistance, idealized: `H` has no collision (equivalently, `H` is
+    injective). Now an explicit *assumption* threaded into the corollaries that need
+    it — not a baked-in field — so `RandomOracle` itself stays inhabited (and
+    finite-field-ready). Computational reading: no *efficient* adversary produces a
+    `HasCollision` witness; the `ε_coll` accounting is the Phase-4 game. -/
+def CollisionResistant : Prop := ∀ x y, ro.H x = ro.H y → x = y
+
+/-- A collision-resistant oracle has no collision witness — used to discharge the
+    `HasCollision` branch of the reductions. -/
+theorem CollisionResistant.notHasCollision {ro : RandomOracle}
+    (cr : ro.CollisionResistant) : ¬ HasCollision ro.H :=
+  fun ⟨x, y, hne, hc⟩ => hne (cr x y hc)
+
+/-- Atomic reduction: from `H a = H b`, either the preimages are equal, or we have
+    exhibited a collision in `H`. Holds for *any* `H`; the engine of the security
+    reductions below. -/
+theorem hash_inj_or_collision (a b : List Felt) (h : ro.H a = ro.H b) :
+    a = b ∨ HasCollision ro.H :=
+  if hab : a = b then Or.inl hab else Or.inr ⟨a, b, hab, h⟩
 
 /-- The double hash `H(H(·))` used pervasively (WA, Null, dummy nullifiers). The
     inner digest is re-expanded to its 4-felt list before the outer call, matching

--- a/formal/WormholeSpec/Hash.lean
+++ b/formal/WormholeSpec/Hash.lean
@@ -67,8 +67,14 @@ variable (ro : RandomOracle)
 /-- Collision resistance, idealized: `H` has no collision (equivalently, `H` is
     injective). Now an explicit *assumption* threaded into the corollaries that need
     it — not a baked-in field — so `RandomOracle` itself stays inhabited (and
-    finite-field-ready). Computational reading: no *efficient* adversary produces a
-    `HasCollision` witness; the `ε_coll` accounting is the Phase-4 game. -/
+    finite-field-ready).
+
+    NAMING CAVEAT: as defined this is *perfect collision-freeness* (= full injectivity),
+    which is strictly **stronger** than the cryptographic "collision resistance" notion
+    (no *efficient* adversary finds a collision). We keep the name because the
+    deterministic core of the paper's reductions is exactly this idealization; the gap is
+    the probabilistic `ε_coll` accounting, deferred to the Phase-4 game. Computational
+    reading of this hypothesis: no efficient adversary produces a `HasCollision` witness. -/
 def CollisionResistant : Prop := ∀ x y, ro.H x = ro.H y → x = y
 
 /-- A collision-resistant oracle has no collision witness — used to discharge the

--- a/formal/WormholeSpec/LeafBinding.lean
+++ b/formal/WormholeSpec/LeafBinding.lean
@@ -19,7 +19,7 @@
 
   Results:
   * `chain_circuit_leaf_eq_iff` — a chain leaf and the circuit's `WA(s)` leaf hash
-    to the same value iff the recipient *decodes* to `WA(s)` (injective `H`);
+    to the same value iff the recipient *decodes* to `WA(s)` (collision-resistant `H`);
   * `spendable_recipient_reduces_to_address` — therefore ANY spendable recipient
     (canonical or not) reduces to `WA(s)`: a non-canonical alias binds to the same
     address and nullifier, conferring no advantage;
@@ -85,9 +85,9 @@ theorem wormhole_address_canonical (hco : ro.CanonicalOutputs) (s : Digest) :
   exact hco _ v hv
 
 /-- Chain↔circuit consistency: a pallet leaf and the circuit's `WA(s)` leaf agree
-    iff the recipient *decodes* to `WA(s)`. (`H` injective; cancel the common
-    `transfer_count ‖ asset ‖ amount` suffix.) -/
-theorem chain_circuit_leaf_eq_iff
+    iff the recipient *decodes* to `WA(s)`. (Collision-resistant `H`; cancel the
+    common `transfer_count ‖ asset ‖ amount` suffix.) -/
+theorem chain_circuit_leaf_eq_iff (cr : ro.CollisionResistant)
     {recipient transferCount : List Felt} {assetId inputAmount : Felt} {s : Digest} :
     ro.chainLeafHash recipient transferCount assetId inputAmount
         = ro.leafHash (ro.WA s) transferCount assetId inputAmount
@@ -95,36 +95,36 @@ theorem chain_circuit_leaf_eq_iff
   unfold chainLeafHash RandomOracle.leafHash
   constructor
   · intro h
-    have h2 := ro.injective _ _ h
+    have h2 := cr _ _ h
     exact List.append_cancel_right (List.append_cancel_right h2)
   · intro h
     rw [h]
 
 /-- ANY spendable recipient reduces to `WA(s)`: a non-canonical alias binds to the
     same address (and hence the same nullifier `Null(s, c)`), so it gains nothing. -/
-theorem spendable_recipient_reduces_to_address
+theorem spendable_recipient_reduces_to_address (cr : ro.CollisionResistant)
     {recipient transferCount : List Felt} {assetId inputAmount : Felt} {s : Digest}
     (h : ro.chainLeafHash recipient transferCount assetId inputAmount
         = ro.leafHash (ro.WA s) transferCount assetId inputAmount) :
     bytesToDigest recipient = (ro.WA s).toList :=
-  (ro.chain_circuit_leaf_eq_iff).1 h
+  (ro.chain_circuit_leaf_eq_iff cr).1 h
 
 /-- **Finding A core**: among *canonical* recipients, the recipient spendable for
     secret `s` is **unique** — it must be exactly the wormhole address `WA(s)`. No
     different canonical recipient can be crafted to be spendable. -/
-theorem spendable_iff_is_wormhole_address
+theorem spendable_iff_is_wormhole_address (cr : ro.CollisionResistant)
     {recipient transferCount : List Felt} {assetId inputAmount : Felt} {s : Digest}
     (hrec : ∀ v ∈ recipient, Canonical v) :
     ro.chainLeafHash recipient transferCount assetId inputAmount
         = ro.leafHash (ro.WA s) transferCount assetId inputAmount
       ↔ recipient = (ro.WA s).toList := by
-  rw [ro.chain_circuit_leaf_eq_iff, bytesToDigest_canonical_id hrec]
+  rw [ro.chain_circuit_leaf_eq_iff cr, bytesToDigest_canonical_id hrec]
 
 /-- Distinct secrets yield distinct unique recipients: a leaf spendable for `s` is
     never spendable for `s' ≠ s`. (Ties Finding A to `WA_inj`.) -/
-theorem distinct_secrets_distinct_recipients {s s' : Digest}
+theorem distinct_secrets_distinct_recipients (cr : ro.CollisionResistant) {s s' : Digest}
     (h : (ro.WA s).toList = (ro.WA s').toList) : s = s' :=
-  ro.WA_inj (Digest.toList_inj h)
+  ro.WA_inj cr (Digest.toList_inj h)
 
 end RandomOracle
 

--- a/formal/WormholeSpec/Security.lean
+++ b/formal/WormholeSpec/Security.lean
@@ -3,20 +3,24 @@
 
   The paper states these as game-based reductions to *computational* hardness:
   collision resistance (`one-time withdrawal`, §4.2) and preimage resistance
-  (`spend-path exclusivity`, §4.3). In our spec we model `H` as an injective
-  random oracle (`RandomOracle.injective`, see `Hash.lean`), which is the standard
-  idealization. Under that idealization the computational reductions become
-  *exact* structural facts:
+  (`spend-path exclusivity`, §4.3). We follow that shape literally: each result has
 
-    * collision resistance ⇒ derivations are injective, so "same deposit ⇒ same
-      nullifier" (hence two distinct nullifiers cannot come from one deposit);
-    * preimage resistance ⇒ the wormhole address has a *unique* outer preimage,
-      the structured inner value `H(salt_wh ‖ s)` — i.e. the paper's case (2)
-      collapses into case (1), there is exactly one spend path.
+    * a **reduction** form (`*_or_collision`), provable for *any* `H` with no
+      assumption — "if the scheme breaks, here is an explicit collision in `H`";
+    * a **corollary** under the explicit `CollisionResistant ro` hypothesis, which
+      eliminates the collision branch and recovers the clean structural conclusion:
+        - collision resistance ⇒ derivations are injective, so "same deposit ⇒ same
+          nullifier" (hence two distinct nullifiers cannot come from one deposit);
+        - preimage resistance ⇒ the wormhole address has a *unique* outer preimage,
+          the structured inner value `H(salt_wh ‖ s)` — the paper's case (2)
+          collapses into case (1), there is exactly one spend path.
 
-  These discharge the deterministic skeleton the game proofs hang on; the
-  probabilistic accounting (the `ε_coll`/`ε_pre` terms and the knowledge-soundness
-  extractor) is the Phase-4 game-based track and is out of scope here.
+  Splitting the assumption out of `RandomOracle` (see `Hash.lean`) is what lets the
+  oracle be instantiated by the concrete finite-field sponge: the reductions survive
+  a compressing `H`, and collision resistance is invoked only at the corollary.
+
+  The probabilistic accounting (the `ε_coll`/`ε_pre` terms and the
+  knowledge-soundness extractor) is the Phase-4 game-based track, out of scope here.
 -/
 import WormholeSpec.Basic
 import WormholeSpec.Hash
@@ -37,17 +41,56 @@ namespace RandomOracle
 
 variable (ro : RandomOracle)
 
-/-- The double hash `H(H(·))` inherits injectivity from `H`. -/
-theorem hh_inj {x y : List Felt} (h : ro.hh x = ro.hh y) : x = y := by
-  unfold RandomOracle.hh at h
-  exact ro.injective _ _ (Digest.toList_inj (ro.injective _ _ h))
+/-! ### Reductions — hold for *any* `H`, no assumption.
+    Each says: from a (would-be) break, *construct* a collision in `H`. -/
 
-/-- C2 derivation is injective: distinct secrets yield distinct wormhole
-    addresses. (Collision resistance, idealized.) -/
-theorem WA_inj {s s' : Digest} (h : ro.WA s = ro.WA s') : s = s' := by
+/-- The double hash `H(H(·))`: equal images give equal preimages, or a collision in
+    `H` (at the inner or the outer call). -/
+theorem hh_inj_or_collision {x y : List Felt} (h : ro.hh x = ro.hh y) :
+    x = y ∨ HasCollision ro.H := by
+  unfold RandomOracle.hh at h
+  rcases ro.hash_inj_or_collision _ _ h with htl | hcol
+  · exact ro.hash_inj_or_collision x y (Digest.toList_inj htl)
+  · exact Or.inr hcol
+
+/-- **One-time withdrawal, reduction form** (§4.2): if two distinct secrets share a
+    wormhole address, that is a collision in `H`. -/
+theorem WA_inj_or_collision {s s' : Digest} (h : ro.WA s = ro.WA s') :
+    s = s' ∨ HasCollision ro.H := by
   unfold RandomOracle.WA at h
-  have h1 : wormholeSalt ++ s.toList = wormholeSalt ++ s'.toList := ro.hh_inj h
-  exact Digest.toList_inj (List.append_cancel_left h1)
+  rcases ro.hh_inj_or_collision h with h1 | hcol
+  · exact Or.inl (Digest.toList_inj (List.append_cancel_left h1))
+  · exact Or.inr hcol
+
+/-- A deposit determines its nullifier — or the shared address is an `H` collision. -/
+theorem same_deposit_same_nullifier_or_collision
+    {s₁ s₂ : Digest} {c₁ c₂ : List Felt}
+    (haddr : ro.WA s₁ = ro.WA s₂) (hc : c₁ = c₂) :
+    ro.Null s₁ c₁ = ro.Null s₂ c₂ ∨ HasCollision ro.H := by
+  rcases ro.WA_inj_or_collision haddr with hs | hcol
+  · exact Or.inl (by rw [hs, hc])
+  · exact Or.inr hcol
+
+/-- **Spend-path exclusivity, reduction form** (§4.3): any `pk` with `H(pk) = WA(s)`
+    is the structured inner value `H(salt_wh ‖ s)`, or `pk` collides with it under
+    `H`. -/
+theorem spend_path_unique_or_collision {pk : List Felt} {s : Digest}
+    (h : ro.H pk = ro.WA s) :
+    pk = (ro.H (wormholeSalt ++ s.toList)).toList ∨ HasCollision ro.H := by
+  unfold RandomOracle.WA RandomOracle.hh at h
+  exact ro.hash_inj_or_collision _ _ h
+
+/-! ### Corollaries — under the explicit `CollisionResistant ro` assumption. -/
+
+/-- The double hash `H(H(·))` inherits injectivity from a collision-resistant `H`. -/
+theorem hh_inj (cr : ro.CollisionResistant) {x y : List Felt} (h : ro.hh x = ro.hh y) :
+    x = y :=
+  (ro.hh_inj_or_collision h).resolve_right cr.notHasCollision
+
+/-- C2 derivation is injective: distinct secrets yield distinct wormhole addresses. -/
+theorem WA_inj (cr : ro.CollisionResistant) {s s' : Digest} (h : ro.WA s = ro.WA s') :
+    s = s' :=
+  (ro.WA_inj_or_collision h).resolve_right cr.notHasCollision
 
 /-- **One-time withdrawal core** (§4.2): a deposit determines its nullifier.
     Both proofs in the double-spend game reference the same deposit, so they share
@@ -55,20 +98,19 @@ theorem WA_inj {s s' : Digest} (h : ro.WA s = ro.WA s') : s = s' := by
     and the same ZK-tree counter (`hc`, the counter is part of the authenticated
     leaf); hence the nullifiers coincide. The game's winning requirement
     `n₁ ≠ n₂` is therefore unsatisfiable. -/
-theorem same_deposit_same_nullifier
+theorem same_deposit_same_nullifier (cr : ro.CollisionResistant)
     {s₁ s₂ : Digest} {c₁ c₂ : List Felt}
     (haddr : ro.WA s₁ = ro.WA s₂) (hc : c₁ = c₂) :
-    ro.Null s₁ c₁ = ro.Null s₂ c₂ := by
-  have hs : s₁ = s₂ := ro.WA_inj haddr
-  rw [hs, hc]
+    ro.Null s₁ c₁ = ro.Null s₂ c₂ :=
+  (ro.same_deposit_same_nullifier_or_collision haddr hc).resolve_right cr.notHasCollision
 
 /-- Contrapositive used in the double-spend reduction: two distinct nullifiers
     cannot have come from the same deposit. -/
-theorem no_double_spend
+theorem no_double_spend (cr : ro.CollisionResistant)
     {s₁ s₂ : Digest} {c₁ c₂ : List Felt}
     (haddr : ro.WA s₁ = ro.WA s₂) (hc : c₁ = c₂)
     (hn : ro.Null s₁ c₁ ≠ ro.Null s₂ c₂) : False :=
-  hn (ro.same_deposit_same_nullifier haddr hc)
+  hn (ro.same_deposit_same_nullifier cr haddr hc)
 
 /-- **Spend-path exclusivity core** (§4.3): the *only* preimage of a wormhole
     address `WA(s)` under the outer hash is the structured inner value
@@ -76,12 +118,39 @@ theorem no_double_spend
     equal it, so the paper's case (2) ("some other `pk`") collapses into case (1).
     Combined with `|pk| > |H|` for post-quantum keys (case (1) is then
     impossible), there is no spend path other than knowing `s`. -/
-theorem spend_path_unique {pk : List Felt} {s : Digest}
+theorem spend_path_unique (cr : ro.CollisionResistant) {pk : List Felt} {s : Digest}
     (h : ro.H pk = ro.WA s) :
-    pk = (ro.H (wormholeSalt ++ s.toList)).toList := by
-  unfold RandomOracle.WA RandomOracle.hh at h
-  exact ro.injective _ _ h
+    pk = (ro.H (wormholeSalt ++ s.toList)).toList :=
+  (ro.spend_path_unique_or_collision h).resolve_right cr.notHasCollision
 
 end RandomOracle
+
+/-! ### Payoff: the oracle is now inhabited by *non-injective* hashes.
+
+    With the old `injective` field this section would not type-check — you cannot build
+    a `RandomOracle` from a compressing hash. Now `RandomOracle` is just `H`, so it
+    admits any hash, including the concrete finite-field Poseidon2 sponge
+    (`Plonky2Spec.Sponge.H`, Step 3c), which a future adapter package can drop in as
+    `{ H := … }`. The security theorems apply to *every* such oracle via the
+    `*_or_collision` reductions; they need `CollisionResistant` only for the clean
+    corollaries — which a compressing hash genuinely fails, as below. -/
+namespace Demo
+
+/-- A maximally-compressing oracle: every preimage maps to the zero digest. It inhabits
+    `RandomOracle` despite being the opposite of injective. -/
+def collapsingRO : RandomOracle := { H := fun _ => Digest.zero }
+
+/-- It is honestly *not* collision-resistant — so the reductions above are non-vacuous:
+    `[]` and `[0]` are a collision. -/
+example : ¬ collapsingRO.CollisionResistant := fun cr =>
+  absurd (cr [] [0] rfl) (by decide)
+
+/-- And the reduction *constructs* a collision: two distinct secrets share the
+    (degenerate) wormhole address, and `WA_inj_or_collision` returns the right disjunct. -/
+example : HasCollision collapsingRO.H :=
+  (collapsingRO.WA_inj_or_collision (s := Digest.zero) (s' := ⟨1, 0, 0, 0⟩) rfl).resolve_left
+    (by decide)
+
+end Demo
 
 end WormholeSpec

--- a/formal/WormholeSpec/Security.lean
+++ b/formal/WormholeSpec/Security.lean
@@ -146,10 +146,13 @@ example : ¬ collapsingRO.CollisionResistant := fun cr =>
   absurd (cr [] [0] rfl) (by decide)
 
 /-- And the reduction *constructs* a collision: two distinct secrets share the
-    (degenerate) wormhole address, and `WA_inj_or_collision` returns the right disjunct. -/
-example : HasCollision collapsingRO.H :=
-  (collapsingRO.WA_inj_or_collision (s := Digest.zero) (s' := ⟨1, 0, 0, 0⟩) rfl).resolve_left
-    (by decide)
+    (degenerate) wormhole address, so `WA_inj_or_collision` must return the collision
+    disjunct (the equality disjunct is impossible — the secrets differ). -/
+example : HasCollision collapsingRO.H := by
+  rcases collapsingRO.WA_inj_or_collision (s := Digest.zero) (s' := ⟨1, 0, 0, 0⟩) rfl with
+    heq | hcol
+  · exact absurd heq (by decide)   -- `Digest.zero = ⟨1,0,0,0⟩` is false: the secrets differ
+  · exact hcol                     -- the reduction handed us the collision in `H`
 
 end Demo
 

--- a/formal/WormholeSpec/Trusted.lean
+++ b/formal/WormholeSpec/Trusted.lean
@@ -1,0 +1,80 @@
+/-
+  The trusted base (T4 + the seam to layer 1).
+
+  Everything else in `WormholeSpec` is a theorem about explicit relations. This
+  module is the *opposite*: it enumerates, as explicit Lean `axiom`s, the
+  assumptions the aggregation soundness argument is allowed to invoke but does not
+  prove. Each is the boundary to a body of work that is out of scope for this
+  spec-level development (a full machine-checked SNARK verifier), and each is
+  documented with (a) what it asserts, (b) why it is justified, and (c) what it
+  would take to discharge. This mirrors how `RandomOracle.CollisionResistant` makes the
+  collision-resistance idealization an explicit, opt-in hypothesis rather than hidden.
+
+  WHY AXIOMS, NOT DEFINITIONS. The recursive verifier gadget
+  (`add_recursive_verifiers` → `builder.verify_proof`, baking the child verifier key
+  in as constants) constrains that a child proof is valid under the proof system.
+  Turning "the recursion gadget is satisfied" into "the child's public-input relation
+  holds" is precisely *proof-system soundness* (FRI query soundness, the Plonk/AIR
+  arithmetization, Fiat–Shamir — QROM Fiat–Shamir for the post-quantum claims — and
+  the recursion composition). Formalizing that is a multi-year effort; here it is the
+  trusted seam, the rung labeled `(1)` in `qp-plonky2/formal/PLAN.md` §1.
+
+  These axioms are intentionally confined to this file; only `AggregationBridge`'s
+  end-to-end soundness theorems (`layer0_sound`, `layer1_sound`) invoke them, so a
+  `#print axioms` on any other result stays free of them.
+-/
+import WormholeSpec.Basic
+import WormholeSpec.Hash
+import WormholeSpec.Leaf
+import WormholeSpec.Aggregation
+
+namespace WormholeSpec
+
+/-! ### The recursive-verifier acceptance predicates (abstract)
+
+These stand for "the in-circuit recursive verifier accepted a child proof whose
+public inputs decode to this structure, under the *constant* (baked-in) child
+verifier key." They are abstract: the spec never inspects how the gadget works, only
+what its satisfaction attests (the soundness axioms below). Realized in Rust by
+`wormhole/aggregator/src/common/recursive.rs::add_recursive_verifiers`. -/
+
+/-- A layer-0 aggregation circuit accepted a recursive **leaf** proof whose 21-felt
+    public inputs decode to `p`. (Constant leaf verifier key; one per leaf slot.) -/
+axiom LeafProofAccepted (ro : RandomOracle) (p : LeafPublic) : Prop
+
+/-- A layer-1 aggregation circuit accepted a recursive **layer-0** proof whose public
+    inputs decode to `out`. (Constant layer-0 verifier key; one per inner slot.) -/
+axiom Layer0ProofAccepted (ro : RandomOracle) (out : Layer0Output) : Prop
+
+/-! ### `verify_proof` soundness (T4) -/
+
+/--
+**TRUSTED (T4 + proof-system soundness (1)).** `verify_proof` soundness for the leaf
+circuit: if the layer-0 recursion gadget accepts a leaf proof (under the baked leaf
+verifier key), then its public inputs satisfy the leaf relation `Rleaf` for some
+witness.
+
+*Justification.* Given proof-system soundness (1), a satisfied recursion gadget
+implies the child proof is valid, hence (by the leaf circuit's own
+constraints-⟺-`Rleaf` bridge, T0–T3) `Rleaf` holds on the child's public inputs.
+
+*To discharge:* (i) a verified plonky2 verifier (FRI + Plonk + Fiat–Shamir +
+recursion), and (ii) the leaf circuit ⟺ `Rleaf` bridge. (ii) is the T0–T3 program in
+`qp-plonky2/formal`; (i) is rung (1), out of scope. -/
+axiom leaf_proof_sound (ro : RandomOracle) (p : LeafPublic) :
+    LeafProofAccepted ro p → ∃ w : LeafWitness, Rleaf ro p w
+
+/--
+**TRUSTED (T4 + proof-system soundness (1)).** `verify_proof` soundness for the
+layer-0 circuit: if the layer-1 recursion gadget accepts a layer-0 proof (under the
+baked layer-0 verifier key), then its public inputs satisfy the layer-0 relation
+`RL0` for some children and dummy-nullifier preimages.
+
+*Justification & discharge:* as `leaf_proof_sound`, with the layer-0 circuit ⟺ `RL0`
+bridge (`AggregationBridge.layer0_bridge`) playing the role of the child-circuit
+bridge — so this axiom's (ii) component is itself a *theorem* here; only the
+proof-system-soundness component (i) remains genuinely trusted. -/
+axiom layer0_proof_sound (ro : RandomOracle) (out : Layer0Output) :
+    Layer0ProofAccepted ro out → ∃ leaves us, RL0 ro leaves us out
+
+end WormholeSpec

--- a/formal/WormholeSpec/Trusted.lean
+++ b/formal/WormholeSpec/Trusted.lean
@@ -34,17 +34,26 @@ namespace WormholeSpec
 
 These stand for "the in-circuit recursive verifier accepted a child proof whose
 public inputs decode to this structure, under the *constant* (baked-in) child
-verifier key." They are abstract: the spec never inspects how the gadget works, only
-what its satisfaction attests (the soundness axioms below). Realized in Rust by
+verifier key." They are `opaque`, not `axiom`s: abstract predicates whose truth is
+never assumed (the spec never inspects how the gadget works, only what its
+satisfaction attests via the soundness *axioms* below), so they stay out of the
+trusted axiom set. Realized in Rust by
 `wormhole/aggregator/src/common/recursive.rs::add_recursive_verifiers`. -/
 
 /-- A layer-0 aggregation circuit accepted a recursive **leaf** proof whose 21-felt
-    public inputs decode to `p`. (Constant leaf verifier key; one per leaf slot.) -/
-axiom LeafProofAccepted (ro : RandomOracle) (p : LeafPublic) : Prop
+    public inputs decode to `p`. (Constant leaf verifier key; one per leaf slot.)
+
+    `opaque`, not `axiom`: this is an *abstract predicate* (its truth value is never
+    assumed), so it should not enlarge the trusted axiom set. Only the soundness facts
+    below (`leaf_proof_sound`, `layer0_proof_sound`) are genuine `axiom`s. -/
+opaque LeafProofAccepted (ro : RandomOracle) (p : LeafPublic) : Prop
 
 /-- A layer-1 aggregation circuit accepted a recursive **layer-0** proof whose public
-    inputs decode to `out`. (Constant layer-0 verifier key; one per inner slot.) -/
-axiom Layer0ProofAccepted (ro : RandomOracle) (out : Layer0Output) : Prop
+    inputs decode to `out`. (Constant layer-0 verifier key; one per inner slot.)
+
+    `opaque` for the same reason as `LeafProofAccepted`: an abstract predicate, not an
+    assumed truth. -/
+opaque Layer0ProofAccepted (ro : RandomOracle) (out : Layer0Output) : Prop
 
 /-! ### `verify_proof` soundness (T4) -/
 


### PR DESCRIPTION
We basically remove the security assumption around poseidon2 being a random oracle and replace it with a collision resistance reduction. 

If you double spend, it implies you found a hash collision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This PR reframes cryptographic assumptions and adds trusted SNARK soundness axioms used only by end-to-end aggregation theorems; impact is confined to the Lean spec, but reviewers should confirm the reduction statements match the intended paper claims and that axiom scope stays limited to `Trusted` + bridge soundness.
> 
> **Overview**
> The formal wormhole spec **stops treating Poseidon2 as an ideal injective random oracle** and instead models hash security as **optional `RandomOracle.CollisionResistant`** plus unconditional **reduction lemmas** (`hash_inj_or_collision`, `WA_inj_or_collision`, `same_deposit_same_nullifier_or_collision`, `spend_path_unique_or_collision`) that turn breaks into explicit `HasCollision` witnesses; clean corollaries (`WA_inj`, `no_double_spend`, `spend_path_unique`, etc.) now take `CollisionResistant` as an argument. **`RandomOracle` is only `{ H }`**, so finite-field / compressing hashes can inhabit it (demonstrated by `Demo.collapsingRO`), enabling future concrete sponge instantiation without vacuous theorems.
> 
> **`LeafBinding.lean`** threads the same `CollisionResistant` hypothesis into chain↔circuit recipient lemmas. **`SPEC.md` / `Basic.lean` / `Hash.lean`** document the modeling shift (Nat `Felt` kept for encoding/`omega`, not for RO injectivity).
> 
> New modules wire **aggregation soundness**: **`AggregationBridge.lean`** defines `Layer0Circuit` / `Layer1Circuit` wrapper constraint bundles, proves `layer0_bridge` / `layer1_bridge` into `RL0` / `RL1`, and **`layer0_sound` / `layer1_sound`** compose those with **`Trusted.lean`** axioms (`LeafProofAccepted`, `layer0_proof_sound`, etc.) for recursive `verify_proof` soundness at the trusted seam.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5135f13ea84bf97a75f8843c69761503efb717f7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->