### PR TITLE
Enforce block_number consistency in L0/L1 aggregation wrappers

### DIFF
--- a/wormhole/aggregator/src/layer0/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/layer0/circuit/circuit_logic.rs
@@ -2,7 +2,7 @@
 //!
 //! This circuit verifies `N` leaf wormhole proofs directly (without first building a
 //! dynamic merge circuit), then applies the wormhole-specific wrapper logic:
-//! - enforce block consistency across real proofs
+//! - enforce block hash and block number consistency across real proofs
 //! - enforce asset_id / volume_fee_bps consistency
 //! - dedupe exit accounts and sum output amounts (2 outputs per proof)
 //! - replace dummy nullifiers with hashes of externally provided random preimages
@@ -208,17 +208,23 @@ fn build_layer0_wrapper_constraints(
     // =========================================================================
     //
     // Constraint for each proof i:
-    //   is_dummy_i OR (block_i == block_ref)
+    //   is_dummy_i OR (block_i == block_ref AND block_number_i == block_number_ref)
     //
-    // Since block_ref is the first non-dummy slot's block hash, this forces every real
-    // proof to share that same block, regardless of slot order.
+    // Since block_ref / block_number_ref come from the first non-dummy slot, this forces
+    // every real proof to share the same block hash AND block number, regardless of slot
+    // order. The block number is enforced directly (not just derived from the block hash
+    // via the leaf's header binding) so the wrapper matches the formal spec's
+    // `metadataConsistent` clause without relying on collision resistance.
     //
     // Also enforce:
     //   asset_id_i == asset_ref
     //   volume_fee_bps_i == volume_fee_bps_ref
 
     for (i, pis_i) in leaf_pi_targets.iter().take(n_leaf).enumerate() {
-        let matches_ref = bytes_digest_eq(builder, block_hashes[i], block_ref);
+        let hash_matches = bytes_digest_eq(builder, block_hashes[i], block_ref);
+        let block_number_i = limb1_at_offset::<LEAF_PI_LEN, BLOCK_NUMBER_START>(pis_i, 0);
+        let number_matches = builder.is_equal(block_number_i, block_number_ref);
+        let matches_ref = builder.and(hash_matches, number_matches);
 
         // Enforce `is_dummy_i OR matches_ref == true`
         let valid_block_relation = builder.or(is_dummy_flags[i], matches_ref);
@@ -979,6 +985,61 @@ mod tests {
         assert!(
             res.is_err(),
             "expected failure because proofs are from different blocks"
+        );
+    }
+
+    /// Same block hash everywhere, but one proof reports a different block number.
+    /// Guards the direct block-number consistency constraint (the block hash alone
+    /// would pass).
+    #[test]
+    fn recursive_aggregation_tree_mismatched_block_number_fails() {
+        let output_felts: [F; 8] = core::array::from_fn(|_| F::from_canonical_u64(1));
+
+        let exits_felts: [[F; 8]; 8] = EXIT_ACCOUNTS.map(limbs8_u64_to_felts);
+        let common_block_hash = limbs4_u64_to_felts(BLOCK_HASHES[0]);
+        let nullifiers_felts: [[F; 4]; 8] = NULLIFIERS.map(limbs4_u64_to_felts);
+
+        let asset_id = F::from_canonical_u64(TEST_ASSET_ID_U64);
+        let volume_fee_bps = F::from_canonical_u64(TEST_VOLUME_FEE_BPS);
+
+        let mut pis_list: Vec<[F; LEAF_PI_LEN]> = Vec::with_capacity(8);
+        for i in 0..8 {
+            let block_number = F::from_canonical_u64(if i == 3 { 43 } else { 42 });
+            pis_list.push(make_pi_from_felts(
+                asset_id,
+                output_felts[i],
+                F::ZERO,
+                volume_fee_bps,
+                nullifiers_felts[i],
+                exits_felts[i],
+                [F::ZERO; 8],
+                common_block_hash,
+                block_number,
+            ));
+        }
+
+        let leaves = pis_list
+            .into_iter()
+            .map(prove_fake_leaf_standalone)
+            .collect::<Vec<_>>();
+        let leaf_common = leaves[0].1.common.clone();
+        let leaf_verifier_only = leaves[0].1.verifier_only.clone();
+        let proofs = leaves
+            .into_iter()
+            .map(|(proof, _)| proof)
+            .collect::<Vec<_>>();
+        let dummy_nullifier_pre_images = deterministic_dummy_nullifier_pre_images(proofs.len());
+
+        let res = aggregate_proofs_layer0(
+            proofs,
+            leaf_common,
+            leaf_verifier_only,
+            dummy_nullifier_pre_images,
+        );
+
+        assert!(
+            res.is_err(),
+            "expected failure due to mismatched block numbers"
         );
     }
 

--- a/wormhole/aggregator/src/layer1/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/layer1/circuit/circuit_logic.rs
@@ -177,10 +177,11 @@ fn build_layer1_wrapper_constraints(
         builder.connect(pis_i[l1c::L0_ASSET_ID_OFFSET], asset_ref);
         builder.connect(pis_i[l1c::L0_VOLUME_FEE_BPS_OFFSET], fee_ref);
 
-        // block hash must match ref
+        // block hash and block number must match ref
         let block_i: [Target; 4] = core::array::from_fn(|j| pis_i[l1c::L0_BLOCK_HASH_OFFSET + j]);
         let matches_ref = bytes_digest_eq(builder, block_i, block_ref);
         builder.connect(matches_ref.target, one);
+        builder.connect(pis_i[l1c::L0_BLOCK_NUMBER_OFFSET], block_number_ref);
     }
 
     // Output block reference + number
@@ -645,6 +646,105 @@ mod tests {
         assert!(
             res.is_err(),
             "expected layer-1 proving to fail for mismatched blocks"
+        );
+    }
+
+    /// Negative test: same block hash but different block numbers across layer-0
+    /// proofs must fail. Guards the direct block-number connect at layer 1.
+    #[test]
+    fn layer1_mismatched_block_numbers_fails() {
+        let block_hash: [u64; 4] = [0xAA01, 0xAA02, 0xAA03, 0xAA04];
+
+        let (leaf_data, leaf_targets) = build_fake_leaf_circuit();
+
+        // Batch A reports block_number 42, batch B reports 43 (both internally consistent)
+        let a0 = prove_fake_leaf(
+            &leaf_data,
+            &leaf_targets,
+            make_leaf_pi(
+                100,
+                0,
+                [1, 2, 3, 4],
+                [0, 0, 0, 0],
+                [1, 2, 3, 4],
+                block_hash,
+                42,
+            ),
+        );
+        let a1 = prove_fake_leaf(
+            &leaf_data,
+            &leaf_targets,
+            make_leaf_pi(
+                200,
+                0,
+                [5, 6, 7, 8],
+                [0, 0, 0, 0],
+                [5, 6, 7, 8],
+                block_hash,
+                42,
+            ),
+        );
+        let b0 = prove_fake_leaf(
+            &leaf_data,
+            &leaf_targets,
+            make_leaf_pi(
+                300,
+                0,
+                [9, 10, 11, 12],
+                [0, 0, 0, 0],
+                [9, 10, 11, 12],
+                block_hash,
+                43,
+            ),
+        );
+        let b1 = prove_fake_leaf(
+            &leaf_data,
+            &leaf_targets,
+            make_leaf_pi(
+                400,
+                0,
+                [13, 14, 15, 16],
+                [0, 0, 0, 0],
+                [13, 14, 15, 16],
+                block_hash,
+                43,
+            ),
+        );
+
+        let l0_circuit = Layer0AggregationCircuit::new(
+            CircuitConfig::standard_recursion_config(),
+            leaf_data.common.clone(),
+            &leaf_data.verifier_only,
+            NUM_LEAVES,
+        );
+        let l0_targets = l0_circuit.targets();
+        let l0_data = l0_circuit.build_circuit();
+
+        let l0_a = prove_layer0_batch(&l0_data, &l0_targets, vec![a0, a1]);
+        let l0_b = prove_layer0_batch(&l0_data, &l0_targets, vec![b0, b1]);
+
+        let l1_circuit = Layer1AggregationCircuit::new(
+            CircuitConfig::standard_recursion_config(),
+            l0_data.common.clone(),
+            &l0_data.verifier_only,
+            N_INNER,
+            NUM_LEAVES,
+        );
+        let l1_targets = l1_circuit.targets();
+        let l1_data = l1_circuit.build_circuit();
+
+        let agg_addr = [
+            F::from_canonical_u64(1),
+            F::from_canonical_u64(2),
+            F::from_canonical_u64(3),
+            F::from_canonical_u64(4),
+        ];
+
+        let res = prove_layer1(&l1_data, &l1_targets, vec![l0_a, l0_b], agg_addr);
+
+        assert!(
+            res.is_err(),
+            "expected layer-1 proving to fail for mismatched block numbers"
         );
     }
 }

--- a/wormhole/circuit/src/zk_merkle_proof.rs
+++ b/wormhole/circuit/src/zk_merkle_proof.rs
@@ -8,11 +8,12 @@
 //! 1. **Fixed structure**: Each internal node has exactly 4 children (vs variable MPT nodes)
 //! 2. **Sorted children**: Children are sorted before hashing, eliminating path indices
 //! 3. **Simpler leaf**: Only `(to, transfer_count, asset_id, amount)` - no `from` field
-//! 4. **Two hash modes**: Leaves use injective (4 bytes/felt), nodes use compact (8 bytes/felt)
+//! 4. **Compact encoding**: Leaf recipient and node children use compact (8 bytes/felt)
+//!    encoding, injective only for canonical limbs (guarded on the chain side)
 //!
 //! ## Verification algorithm:
 //!
-//! 1. Compute leaf hash using injective Poseidon
+//! 1. Compute leaf hash with Poseidon2 over the 8-felt leaf preimage
 //! 2. For each level from leaf to root:
 //!    - Combine current hash with 3 siblings
 //!    - Sort all 4 hashes
@@ -416,8 +417,10 @@ impl CircuitFragment for ZkMerkleProofData {
         let diff = builder.sub(rhs, lhs);
         builder.range_check(diff, 48); // ensures lhs <= rhs
 
-        // Compute leaf hash using injective Poseidon (matches chain's hash_leaf)
-        // The chain uses qp_poseidon_core::hash_bytes which is injective (4 bytes/felt)
+        // Compute leaf hash over the same 8-felt preimage as the chain's hash_leaf.
+        // The recipient uses the compact 8-bytes/felt encoding, which is injective only
+        // for canonical limbs (< Goldilocks prime); the chain enforces canonicality in
+        // hash_leaf. See formal/WormholeSpec/LeafBinding.lean for the binding analysis.
         let leaf_felts = targets.leaf.collect_for_hash();
         let leaf_hash = builder.hash_n_to_hash_no_pad_p2::<Poseidon2Hash>(leaf_felts);
 


### PR DESCRIPTION
## Summary

A review of the formal spec (`formal/WormholeSpec`) against the circuit code found one fidelity gap where the Lean model claims more than the wrappers enforce, plus a stale comment. This PR closes both.

### 1. `block_number` consistency was not enforced by the aggregation wrappers

The spec's `metadataConsistent` clause (`formal/WormholeSpec/Aggregation.lean`) asserts that every non-dummy child agrees with the aggregate output on `assetId`, `volumeFeeBps`, `blockHash` **and `blockNumber`**, and `RL1` asserts the same for layer-1. The circuits enforced the first three per child, but only *selected* `block_number_ref` from the first real slot — no per-child constraint tied the remaining children's `block_number` to it.

This was not exploitable: two real children with the same `block_hash` must have the same `block_number`, because each leaf proof binds `block_hash = H(header preimage)` (which contains `block_number`) and Poseidon2 is collision resistant. But that derivation needs the children's leaf relation plus a collision-resistance hypothesis — neither of which the wrapper-level bridge (`Plonky2Bridge` / `AggregationBridge`) invokes, so the planned "circuit constraints ⟹ RL0" theorem would have been undischargeable for this clause. Enforcing it directly makes the spec true as written and removes the hidden dependence on collision resistance.

Changes:
- **Layer 0** (`build_layer0_wrapper_constraints`): the per-child block check is now `is_dummy_i OR (block_hash_i == ref AND block_number_i == ref)`. Dummies stay exempt (they carry `block_number = 0`).
- **Layer 1** (`build_layer1_wrapper_constraints`): direct `connect` of each inner proof's `block_number` to the reference (no dummy gating exists at L1, matching the existing block-hash check).
- New negative tests at both layers: same block hash but a mismatched block number must fail to prove. These fail against the old circuits and pass with the fix.

### 2. Stale leaf-hash encoding comments in `zk_merkle_proof.rs`

Comments claimed the leaf hash uses "injective Poseidon (4 bytes/felt)" matching the chain's `hash_leaf`. Both sides actually use the compact 8-bytes/felt encoding for the recipient, which is injective only for canonical limbs — exactly the subtlety analyzed in `formal/WormholeSpec/LeafBinding.lean` and guarded by the canonicality `debug_assert` in the chain's `hash_leaf`. The chain-side comments were corrected previously; these were not. Updated to describe the real encoding and point at the binding analysis.

## Test plan

- [x] `cargo test --release --package qp-wormhole-aggregator` — 25 passed, including the two new negative tests
- [x] `cargo test --release -p tests -- aggregator_tests` — 9 passed
- [x] `cargo check --tests` on the touched crates