### PR TITLE
fix: resolve all high severity findings from V12 audit

### DIFF
--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -192,16 +192,9 @@ fn build_private_batch_constraints(
         for j in 0..4 {
             block_ref[j] = builder.select(take_i, block_hashes[i][j], block_ref[j]);
         }
-        block_number_ref = builder.select(
-            take_i,
-            pis_i[BLOCK_NUMBER_START],
-            block_number_ref,
-        );
-        volume_fee_bps_ref = builder.select(
-            take_i,
-            pis_i[VOLUME_FEE_BPS_START],
-            volume_fee_bps_ref,
-        );
+        block_number_ref = builder.select(take_i, pis_i[BLOCK_NUMBER_START], block_number_ref);
+        volume_fee_bps_ref =
+            builder.select(take_i, pis_i[VOLUME_FEE_BPS_START], volume_fee_bps_ref);
 
         found_real = builder.or(found_real, is_real_i);
     }

--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -152,11 +152,10 @@ fn build_private_batch_constraints(
     // Output: [num_exit_slots, asset_id, volume_fee_bps, block_hash(4), block_number, ...]
     let num_exit_slots_t = builder.constant(F::from_canonical_u64((n_leaf * 2) as u64));
 
-    // asset_id / volume_fee_bps refs come from slot 0. This is positionally safe because
-    // equality is enforced across ALL slots (dummies included) below.
+    // `asset_id` must match across every slot, including dummies. This keeps the historical
+    // partial-batch rule that dummy padding is only compatible with native-asset (`asset_id = 0`)
+    // proofs, which the prover/wrapper preflight enforces before padding.
     let asset_ref = limb1_at_offset::<LEAF_PI_LEN, ASSET_ID_START>(leaf_pi_targets[0], 0);
-    let volume_fee_bps_ref =
-        limb1_at_offset::<LEAF_PI_LEN, VOLUME_FEE_BPS_START>(leaf_pi_targets[0], 0);
 
     // Dummy sentinel at the wrapper level is `block_hash == [0;4]`.
     // Leaf circuit itself uses a stronger dummy condition (block_hash==0 && outputs==0).
@@ -173,7 +172,7 @@ fn build_private_batch_constraints(
         block_hashes.push(block_i);
     }
 
-    // Select the reference block hash / block number from the FIRST NON-DUMMY slot via a
+    // Select the reference block hash / block number / fee from the FIRST NON-DUMMY slot via a
     // prefix scan. This makes the circuit position-independent: the prover may place real
     // and dummy proofs in any order (uniform shuffle), which is required for the privacy
     // argument that real and dummy slots are indistinguishable.
@@ -183,17 +182,26 @@ fn build_private_batch_constraints(
     let mut found_real = builder._false();
     let mut block_ref = [zero, zero, zero, zero];
     let mut block_number_ref = zero;
+    let mut volume_fee_bps_ref = zero;
     for i in 0..n_leaf {
         let is_real_i = builder.not(is_dummy_flags[i]);
         let not_found_yet = builder.not(found_real);
         let take_i = builder.and(is_real_i, not_found_yet);
+        let pis_i = leaf_pi_targets[i];
 
         for j in 0..4 {
             block_ref[j] = builder.select(take_i, block_hashes[i][j], block_ref[j]);
         }
-        let block_number_i =
-            limb1_at_offset::<LEAF_PI_LEN, BLOCK_NUMBER_START>(leaf_pi_targets[i], 0);
-        block_number_ref = builder.select(take_i, block_number_i, block_number_ref);
+        block_number_ref = builder.select(
+            take_i,
+            pis_i[BLOCK_NUMBER_START],
+            block_number_ref,
+        );
+        volume_fee_bps_ref = builder.select(
+            take_i,
+            pis_i[VOLUME_FEE_BPS_START],
+            volume_fee_bps_ref,
+        );
 
         found_real = builder.or(found_real, is_real_i);
     }
@@ -215,7 +223,7 @@ fn build_private_batch_constraints(
     //
     // Also enforce:
     //   asset_id_i == asset_ref
-    //   volume_fee_bps_i == volume_fee_bps_ref
+    //   is_dummy_i OR (volume_fee_bps_i == volume_fee_bps_ref)
 
     for (i, pis_i) in leaf_pi_targets.iter().take(n_leaf).enumerate() {
         let matches_ref = bytes_digest_eq(builder, block_hashes[i], block_ref);
@@ -228,9 +236,13 @@ fn build_private_batch_constraints(
         let asset_i = limb1_at_offset::<LEAF_PI_LEN, ASSET_ID_START>(pis_i, 0);
         builder.connect(asset_i, asset_ref);
 
-        // Enforce volume_fee_bps consistency
         let volume_fee_bps_i = limb1_at_offset::<LEAF_PI_LEN, VOLUME_FEE_BPS_START>(pis_i, 0);
-        builder.connect(volume_fee_bps_i, volume_fee_bps_ref);
+
+        // Enforce volume_fee_bps consistency across real proofs only; dummy slots use a fixed
+        // reusable template fee and must not constrain padded partial batches.
+        let fee_matches_ref = builder.is_equal(volume_fee_bps_i, volume_fee_bps_ref);
+        let valid_fee_relation = builder.or(is_dummy_flags[i], fee_matches_ref);
+        builder.connect(valid_fee_relation.target, one);
     }
 
     // Output block reference (all-dummy case yields zeros, which is fine)

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -35,7 +35,10 @@ use crate::{
     },
     dummy_proof::{generate_random_nullifier_preimage, load_dummy_proof},
     private_batch::{
-        circuit::circuit_logic::{PrivateBatchCircuit, PrivateBatchCircuitTargets},
+        circuit::{
+            circuit_logic::{PrivateBatchCircuit, PrivateBatchCircuitTargets},
+            constants::LEAF_PI_LEN,
+        },
         prover::witness::fill_private_batch_witness,
     },
 };
@@ -116,6 +119,14 @@ impl PrivateBatchProver {
         // 2) Load leaf verifier data (needed to reconstruct targets + parse dummy proof)
         let leaf_verifier_data =
             load_verifier_data_from_bytes(leaf_common_bytes, leaf_verifier_only_bytes, "leaf")?;
+
+        if leaf_verifier_data.common.num_public_inputs != LEAF_PI_LEN {
+            bail!(
+                "leaf circuit has {} public inputs, expected {} for canonical Wormhole leaf circuit",
+                leaf_verifier_data.common.num_public_inputs,
+                LEAF_PI_LEN
+            );
+        }
 
         // 3) Reconstruct the aggregation circuit to get targets.
         // NOTE: This builds a fresh circuit to extract target structure. The verifier key

--- a/wormhole/circuit/src/inputs.rs
+++ b/wormhole/circuit/src/inputs.rs
@@ -21,14 +21,23 @@ use qp_wormhole_inputs::{
 };
 
 /// Inputs required to commit to the wormhole circuit.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CircuitInputs {
     pub public: PublicCircuitInputs,
     pub private: PrivateCircuitInputs,
 }
 
+impl core::fmt::Debug for CircuitInputs {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CircuitInputs")
+            .field("public", &self.public)
+            .field("private", &"<redacted>")
+            .finish()
+    }
+}
+
 /// All of the private inputs required for the circuit.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PrivateCircuitInputs {
     /// Raw bytes of the secret of the nullifier and the unspendable account
     pub secret: BytesDigest,
@@ -62,6 +71,21 @@ pub struct PrivateCircuitInputs {
     /// Position hints (0-3) for each level indicating where current hash
     /// should be inserted among the sorted siblings.
     pub zk_merkle_positions: Vec<u8>,
+}
+
+impl core::fmt::Debug for PrivateCircuitInputs {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrivateCircuitInputs")
+            .field("secret", &"<redacted>")
+            .field("transfer_count", &self.transfer_count)
+            .field("unspendable_account", &"<redacted>")
+            .field("parent_hash", &self.parent_hash)
+            .field("state_root", &self.state_root)
+            .field("extrinsics_root", &self.extrinsics_root)
+            .field("input_amount", &self.input_amount)
+            .field("zk_merkle_siblings_len", &self.zk_merkle_siblings.len())
+            .finish()
+    }
 }
 
 // ============================================================================

--- a/wormhole/circuit/src/nullifier.rs
+++ b/wormhole/circuit/src/nullifier.rs
@@ -46,12 +46,22 @@ pub const NULLIFIER_SIZE_FELTS: usize =
 /// Type alias for the secret as a fixed-size array (4 field elements for 32 bytes)
 pub type Secret = Digest;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Nullifier {
     pub hash: Digest,
     /// Secret encoded with 8 bytes/felt (4 field elements for 32 bytes)
     pub secret: Secret,
     transfer_count: [F; TRANSFER_COUNT_NUM_TARGETS],
+}
+
+impl core::fmt::Debug for Nullifier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Nullifier")
+            .field("hash", &self.hash)
+            .field("secret", &"<redacted>")
+            .field("transfer_count", &"<redacted>")
+            .finish()
+    }
 }
 
 impl Nullifier {

--- a/wormhole/circuit/src/unspendable_account.rs
+++ b/wormhole/circuit/src/unspendable_account.rs
@@ -24,12 +24,21 @@ pub const UNSPENDABLE_SALT: &str = "wormhole";
 /// Type alias for the secret as a fixed-size array (4 felts, 8 bytes/felt)
 pub type Secret = [F; SECRET_NUM_TARGETS];
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct UnspendableAccount {
     /// Account ID as 4 field elements (8 bytes/felt for hash output)
     pub account_id: Digest,
     /// Secret encoded as 4 field elements (8 bytes/felt for 32 bytes)
     pub secret: Secret,
+}
+
+impl core::fmt::Debug for UnspendableAccount {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UnspendableAccount")
+            .field("account_id", &self.account_id)
+            .field("secret", &"<redacted>")
+            .finish()
+    }
 }
 
 impl UnspendableAccount {

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -32,7 +32,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use std::vec::Vec;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 #[cfg(feature = "std")]
 use std::path::Path;
 
@@ -47,7 +47,7 @@ use qp_plonky2_verifier::util::serialization::DefaultGateSerializer;
 // Re-export input types from qp-wormhole-inputs
 pub use qp_wormhole_inputs::{
     BlockData, BytesDigest, PrivateBatchPublicInputs, PublicBatchPublicInputs, PublicCircuitInputs,
-    PublicInputsByAccount,
+    PublicInputsByAccount, PUBLIC_INPUTS_FELTS_LEN,
 };
 
 /// Parse public inputs from a proof.
@@ -96,7 +96,27 @@ pub struct WormholeVerifier {
     pub circuit_data: VerifierCircuitData<F, C, D>,
 }
 
+const MINIMUM_SECURITY_BITS: usize = 100;
+
 impl WormholeVerifier {
+    fn validate_canonical_circuit(common: &CommonCircuitData<F, D>) -> anyhow::Result<()> {
+        if common.num_public_inputs != PUBLIC_INPUTS_FELTS_LEN {
+            bail!(
+                "loaded circuit has {} public inputs, but canonical Wormhole leaf circuit expects {}",
+                common.num_public_inputs,
+                PUBLIC_INPUTS_FELTS_LEN
+            );
+        }
+        if common.config.security_bits < MINIMUM_SECURITY_BITS {
+            bail!(
+                "loaded circuit has security_bits={}, which is below the minimum acceptable threshold of {}",
+                common.config.security_bits,
+                MINIMUM_SECURITY_BITS
+            );
+        }
+        Ok(())
+    }
+
     /// Creates a new [`WormholeVerifier`] from verifier and common data bytes.
     pub fn new_from_bytes(verifier_bytes: &[u8], common_bytes: &[u8]) -> anyhow::Result<Self> {
         let verifier_only = VerifierOnlyCircuitData::from_bytes(verifier_bytes.to_vec())
@@ -104,6 +124,8 @@ impl WormholeVerifier {
 
         let common = CommonCircuitData::from_bytes(common_bytes.to_vec(), &DefaultGateSerializer)
             .map_err(|e| anyhow!("failed to deserialize common circuit data: {}", e))?;
+
+        Self::validate_canonical_circuit(&common)?;
 
         let circuit_data = VerifierCircuitData {
             verifier_only,


### PR DESCRIPTION
## Summary

Fixes all 3 **high severity** findings from the [V12 July 2026 audit](audits/Audit-July-2026-v12.md):

- **#97068** — Fixed-fee dummy padding breaks partial private batches: Made `volume_fee_bps` enforcement dummy-aware in the private-batch circuit by selecting the fee reference from the first non-dummy slot and gating equality checks with `is_dummy`, matching the pattern already used for block data.
- **#97069** — Circuit artifacts not pinned to canonical circuits: Added canonical validation to `WormholeVerifier::new_from_bytes` (checks PI count and minimum `security_bits`) and leaf PI length validation in the private-batch prover loader.
- **#97072** — Debug formatting leaks spend-authorizing witness secrets: Replaced `#[derive(Debug)]` on `CircuitInputs`, `PrivateCircuitInputs`, `Nullifier`, and `UnspendableAccount` with manual `Debug` implementations that redact the `secret` field.

## Test plan

- [x] `cargo check --workspace` passes with zero warnings
- [ ] Existing unit tests pass (`cargo test --workspace`)
- [ ] Private-batch aggregation with partial batches (fee != 10 bps) succeeds
- [ ] `WormholeVerifier::new_from_bytes` rejects weakened artifacts
- [ ] `format!("{:?}", ...)` on secret-bearing types no longer exposes secret bytes