### PR TITLE
fix: V12 high-severity audit findings (#97068, #97069, #97072)

### DIFF
--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -9,10 +9,9 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 use plonky2::plonk::{
-    circuit_data::{CommonCircuitData, VerifierCircuitData, VerifierOnlyCircuitData},
+    circuit_data::{CommonCircuitData, VerifierCircuitData},
     proof::ProofWithPublicInputs,
 };
-use plonky2::util::serialization::DefaultGateSerializer;
 use qp_wormhole_inputs::BytesDigest;
 use std::path::{Path, PathBuf};
 
@@ -22,7 +21,12 @@ use zk_circuits_common::circuit::{C, D, F};
 
 use crate::public_batch::prover::{PublicBatchInputs, PublicBatchProver};
 use crate::{
-    common::utils::{ensure_proof_public_input_len, leaf_proof_asset_id},
+    common::utils::{
+        ensure_proof_public_input_len, ensure_verifier_data_matches_canonical,
+        leaf_proof_asset_id, load_canonical_leaf_verifier_data,
+        load_canonical_private_batch_verifier_data, load_verifier_data_from_bytes,
+        canonical_public_batch_verifier_data,
+    },
     private_batch::prover::PrivateBatchProver,
     CircuitBinsConfig,
 };
@@ -60,43 +64,61 @@ pub trait AggregationBackend: Send + Sync {
 // Shared helpers
 // ============================================================================
 
-fn load_common_from_bins<P: AsRef<Path>>(
-    bins_dir: P,
-    common_file: &str,
-) -> Result<CommonCircuitData<F, D>> {
-    let gate_serializer = DefaultGateSerializer;
-
-    let common_bytes = fs::read(bins_dir.as_ref().join(common_file)).with_context(|| {
-        format!(
-            "failed to read {}",
-            bins_dir.as_ref().join(common_file).display()
-        )
-    })?;
-    CommonCircuitData::from_bytes(common_bytes, &gate_serializer)
-        .map_err(|e| anyhow!("failed to deserialize {}: {}", common_file, e))
+fn load_leaf_common_from_bins(bins_dir: &Path) -> Result<CommonCircuitData<F, D>> {
+    let common_bytes = fs::read(bins_dir.join("common.bin"))
+        .with_context(|| format!("failed to read {}", bins_dir.join("common.bin").display()))?;
+    let verifier_bytes = fs::read(bins_dir.join("verifier.bin"))
+        .with_context(|| format!("failed to read {}", bins_dir.join("verifier.bin").display()))?;
+    Ok(load_canonical_leaf_verifier_data(&common_bytes, &verifier_bytes)?.common)
 }
 
-fn load_verifier_from_bins(
+fn load_private_batch_verifier_from_bins(
     bins_dir: &Path,
-    common_file: &str,
-    verifier_file: &str,
+    num_leaf_proofs: usize,
 ) -> Result<VerifierCircuitData<F, C, D>> {
-    let gate_serializer = DefaultGateSerializer;
+    let common_bytes = fs::read(bins_dir.join("private_batch_common.bin")).with_context(|| {
+        format!(
+            "failed to read {}",
+            bins_dir.join("private_batch_common.bin").display()
+        )
+    })?;
+    let verifier_bytes = fs::read(bins_dir.join("private_batch_verifier.bin")).with_context(|| {
+        format!(
+            "failed to read {}",
+            bins_dir.join("private_batch_verifier.bin").display()
+        )
+    })?;
+    load_canonical_private_batch_verifier_data(&common_bytes, &verifier_bytes, num_leaf_proofs)
+}
 
-    let common_bytes = fs::read(bins_dir.join(common_file))
-        .with_context(|| format!("failed to read {}", bins_dir.join(common_file).display()))?;
-    let common = CommonCircuitData::from_bytes(common_bytes, &gate_serializer)
-        .map_err(|e| anyhow!("failed to deserialize {}: {}", common_file, e))?;
-
-    let verifier_bytes = fs::read(bins_dir.join(verifier_file))
-        .with_context(|| format!("failed to read {}", bins_dir.join(verifier_file).display()))?;
-    let verifier_only = VerifierOnlyCircuitData::<C, D>::from_bytes(verifier_bytes)
-        .map_err(|e| anyhow!("failed to deserialize {}: {}", verifier_file, e))?;
-
-    Ok(VerifierCircuitData {
-        verifier_only,
-        common,
-    })
+fn load_public_batch_verifier_from_bins(
+    bins_dir: &Path,
+    num_leaf_proofs: usize,
+    num_private_batch_proofs: usize,
+) -> Result<VerifierCircuitData<F, C, D>> {
+    let private_batch = load_private_batch_verifier_from_bins(bins_dir, num_leaf_proofs)?;
+    let loaded = load_verifier_data_from_bytes(
+        &fs::read(bins_dir.join("public_batch_common.bin")).with_context(|| {
+            format!(
+                "failed to read {}",
+                bins_dir.join("public_batch_common.bin").display()
+            )
+        })?,
+        &fs::read(bins_dir.join("public_batch_verifier.bin")).with_context(|| {
+            format!(
+                "failed to read {}",
+                bins_dir.join("public_batch_verifier.bin").display()
+            )
+        })?,
+        "public_batch",
+    )?;
+    let canonical = canonical_public_batch_verifier_data(
+        &private_batch,
+        num_private_batch_proofs,
+        num_leaf_proofs,
+    );
+    ensure_verifier_data_matches_canonical(&loaded, &canonical, "public_batch")?;
+    Ok(loaded)
 }
 
 /// A small bounded buffer helper so the backends don't duplicate capacity checks / draining logic.
@@ -149,6 +171,8 @@ pub struct PublicBatchAggregator {
     aggregator_address: BytesDigest,
     buf: ProofBuffer,
     expected_private_batch_pi_len: usize,
+    num_leaf_proofs: usize,
+    num_private_batch_proofs: usize,
 }
 
 impl PublicBatchAggregator {
@@ -161,22 +185,25 @@ impl PublicBatchAggregator {
         let num_private_batch_proofs = config
             .num_private_batch_proofs
             .ok_or_else(|| anyhow!("config is missing num_private_batch_proofs. Please regenerate the binaries and set \"num_private_batch_proofs\""))?;
+        let num_leaf_proofs = config.num_leaf_proofs;
         let expected_private_batch_pi_len =
-            load_common_from_bins(&bins_dir, "private_batch_common.bin")?.num_public_inputs;
+            load_private_batch_verifier_from_bins(&bins_dir, num_leaf_proofs)?.common.num_public_inputs;
 
         Ok(Self {
             bins_dir,
             aggregator_address,
             buf: ProofBuffer::new(num_private_batch_proofs),
             expected_private_batch_pi_len,
+            num_leaf_proofs,
+            num_private_batch_proofs,
         })
     }
 
     fn load_verifier(&self) -> Result<VerifierCircuitData<F, C, D>> {
-        load_verifier_from_bins(
+        load_public_batch_verifier_from_bins(
             &self.bins_dir,
-            "public_batch_common.bin",
-            "public_batch_verifier.bin",
+            self.num_leaf_proofs,
+            self.num_private_batch_proofs,
         )
     }
 }
@@ -231,12 +258,12 @@ impl AggregationBackend for PublicBatchAggregator {
     }
 
     fn load_common_data(&self, circuit_type: CircuitType) -> Result<CommonCircuitData<F, D>> {
-        let common_file = match circuit_type {
-            CircuitType::Root => "public_batch_common.bin",
-            CircuitType::Leaf => "private_batch_common.bin",
-        };
-
-        load_common_from_bins(&self.bins_dir, common_file)
+        match circuit_type {
+            CircuitType::Root => Ok(self.load_verifier()?.common),
+            CircuitType::Leaf => {
+                Ok(load_private_batch_verifier_from_bins(&self.bins_dir, self.num_leaf_proofs)?.common)
+            }
+        }
     }
 }
 
@@ -248,6 +275,7 @@ pub struct PrivateBatchAggregator {
     bins_dir: PathBuf,
     buf: ProofBuffer,
     expected_leaf_pi_len: usize,
+    num_leaf_proofs: usize,
 }
 
 impl PrivateBatchAggregator {
@@ -256,13 +284,14 @@ impl PrivateBatchAggregator {
 
         // Load config
         let config = CircuitBinsConfig::load(&bins_dir)?;
-        let expected_leaf_pi_len =
-            load_common_from_bins(&bins_dir, "common.bin")?.num_public_inputs;
+        let num_leaf_proofs = config.num_leaf_proofs;
+        let expected_leaf_pi_len = load_leaf_common_from_bins(&bins_dir)?.num_public_inputs;
 
         Ok(Self {
             bins_dir,
-            buf: ProofBuffer::new(config.num_leaf_proofs),
+            buf: ProofBuffer::new(num_leaf_proofs),
             expected_leaf_pi_len,
+            num_leaf_proofs,
         })
     }
 
@@ -272,11 +301,7 @@ impl PrivateBatchAggregator {
     }
 
     fn load_verifier(&self) -> Result<VerifierCircuitData<F, C, D>> {
-        load_verifier_from_bins(
-            &self.bins_dir,
-            "private_batch_common.bin",
-            "private_batch_verifier.bin",
-        )
+        load_private_batch_verifier_from_bins(&self.bins_dir, self.num_leaf_proofs)
     }
 }
 
@@ -333,11 +358,9 @@ impl AggregationBackend for PrivateBatchAggregator {
     }
 
     fn load_common_data(&self, circuit_type: CircuitType) -> Result<CommonCircuitData<F, D>> {
-        let common_file = match circuit_type {
-            CircuitType::Root => "private_batch_common.bin",
-            CircuitType::Leaf => "common.bin",
-        };
-
-        load_common_from_bins(&self.bins_dir, common_file)
+        match circuit_type {
+            CircuitType::Root => Ok(self.load_verifier()?.common),
+            CircuitType::Leaf => Ok(load_leaf_common_from_bins(&self.bins_dir)?),
+        }
     }
 }

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -22,8 +22,8 @@ use zk_circuits_common::circuit::{C, D, F};
 use crate::public_batch::prover::{PublicBatchInputs, PublicBatchProver};
 use crate::{
     common::utils::{
-        canonical_public_batch_verifier_data, ensure_proof_public_input_len,
-        ensure_verifier_data_matches_canonical, leaf_proof_asset_id,
+        canonical_leaf_verifier_data, canonical_public_batch_verifier_data,
+        ensure_proof_public_input_len, ensure_verifier_data_matches_canonical, leaf_proof_asset_id,
         load_canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
         load_verifier_data_from_bytes,
     },
@@ -64,57 +64,44 @@ pub trait AggregationBackend: Send + Sync {
 // Shared helpers
 // ============================================================================
 
-fn load_leaf_common_from_bins(bins_dir: &Path) -> Result<CommonCircuitData<F, D>> {
-    let common_bytes = fs::read(bins_dir.join("common.bin"))
-        .with_context(|| format!("failed to read {}", bins_dir.join("common.bin").display()))?;
-    let verifier_bytes = fs::read(bins_dir.join("verifier.bin"))
-        .with_context(|| format!("failed to read {}", bins_dir.join("verifier.bin").display()))?;
-    Ok(load_canonical_leaf_verifier_data(&common_bytes, &verifier_bytes)?.common)
+fn read_bin(bins_dir: &Path, file: &str) -> Result<Vec<u8>> {
+    fs::read(bins_dir.join(file))
+        .with_context(|| format!("failed to read {}", bins_dir.join(file).display()))
+}
+
+fn load_leaf_verifier_from_bins(bins_dir: &Path) -> Result<VerifierCircuitData<F, C, D>> {
+    load_canonical_leaf_verifier_data(
+        &read_bin(bins_dir, "common.bin")?,
+        &read_bin(bins_dir, "verifier.bin")?,
+    )
 }
 
 fn load_private_batch_verifier_from_bins(
     bins_dir: &Path,
+    leaf: &VerifierCircuitData<F, C, D>,
     num_leaf_proofs: usize,
 ) -> Result<VerifierCircuitData<F, C, D>> {
-    let common_bytes = fs::read(bins_dir.join("private_batch_common.bin")).with_context(|| {
-        format!(
-            "failed to read {}",
-            bins_dir.join("private_batch_common.bin").display()
-        )
-    })?;
-    let verifier_bytes =
-        fs::read(bins_dir.join("private_batch_verifier.bin")).with_context(|| {
-            format!(
-                "failed to read {}",
-                bins_dir.join("private_batch_verifier.bin").display()
-            )
-        })?;
-    load_canonical_private_batch_verifier_data(&common_bytes, &verifier_bytes, num_leaf_proofs)
+    load_canonical_private_batch_verifier_data(
+        &read_bin(bins_dir, "private_batch_common.bin")?,
+        &read_bin(bins_dir, "private_batch_verifier.bin")?,
+        leaf,
+        num_leaf_proofs,
+    )
 }
 
 fn load_public_batch_verifier_from_bins(
     bins_dir: &Path,
+    private_batch: &VerifierCircuitData<F, C, D>,
     num_leaf_proofs: usize,
     num_private_batch_proofs: usize,
 ) -> Result<VerifierCircuitData<F, C, D>> {
-    let private_batch = load_private_batch_verifier_from_bins(bins_dir, num_leaf_proofs)?;
     let loaded = load_verifier_data_from_bytes(
-        &fs::read(bins_dir.join("public_batch_common.bin")).with_context(|| {
-            format!(
-                "failed to read {}",
-                bins_dir.join("public_batch_common.bin").display()
-            )
-        })?,
-        &fs::read(bins_dir.join("public_batch_verifier.bin")).with_context(|| {
-            format!(
-                "failed to read {}",
-                bins_dir.join("public_batch_verifier.bin").display()
-            )
-        })?,
+        &read_bin(bins_dir, "public_batch_common.bin")?,
+        &read_bin(bins_dir, "public_batch_verifier.bin")?,
         "public_batch",
     )?;
     let canonical = canonical_public_batch_verifier_data(
-        &private_batch,
+        private_batch,
         num_private_batch_proofs,
         num_leaf_proofs,
     );
@@ -171,9 +158,10 @@ pub struct PublicBatchAggregator {
     bins_dir: PathBuf,
     aggregator_address: BytesDigest,
     buf: ProofBuffer,
-    expected_private_batch_pi_len: usize,
-    num_leaf_proofs: usize,
-    num_private_batch_proofs: usize,
+    /// Canonical-pinned private-batch common data (inner proofs), loaded once at construction.
+    private_batch_common: CommonCircuitData<F, D>,
+    /// Canonical-pinned public-batch verifier data, loaded once at construction.
+    verifier: VerifierCircuitData<F, C, D>,
 }
 
 impl PublicBatchAggregator {
@@ -187,27 +175,24 @@ impl PublicBatchAggregator {
             .num_private_batch_proofs
             .ok_or_else(|| anyhow!("config is missing num_private_batch_proofs. Please regenerate the binaries and set \"num_private_batch_proofs\""))?;
         let num_leaf_proofs = config.num_leaf_proofs;
-        let expected_private_batch_pi_len =
-            load_private_batch_verifier_from_bins(&bins_dir, num_leaf_proofs)?
-                .common
-                .num_public_inputs;
+
+        let leaf = canonical_leaf_verifier_data();
+        let private_batch =
+            load_private_batch_verifier_from_bins(&bins_dir, &leaf, num_leaf_proofs)?;
+        let verifier = load_public_batch_verifier_from_bins(
+            &bins_dir,
+            &private_batch,
+            num_leaf_proofs,
+            num_private_batch_proofs,
+        )?;
 
         Ok(Self {
             bins_dir,
             aggregator_address,
             buf: ProofBuffer::new(num_private_batch_proofs),
-            expected_private_batch_pi_len,
-            num_leaf_proofs,
-            num_private_batch_proofs,
+            private_batch_common: private_batch.common,
+            verifier,
         })
-    }
-
-    fn load_verifier(&self) -> Result<VerifierCircuitData<F, C, D>> {
-        load_public_batch_verifier_from_bins(
-            &self.bins_dir,
-            self.num_leaf_proofs,
-            self.num_private_batch_proofs,
-        )
     }
 }
 
@@ -215,7 +200,7 @@ impl AggregationBackend for PublicBatchAggregator {
     fn push_proof(&mut self, proof: Proof) -> Result<()> {
         ensure_proof_public_input_len(
             &proof,
-            self.expected_private_batch_pi_len,
+            self.private_batch_common.num_public_inputs,
             "private-batch aggregated proof",
         )?;
         self.buf.push(proof)
@@ -254,20 +239,15 @@ impl AggregationBackend for PublicBatchAggregator {
     }
 
     fn verify(&self, proof: Proof) -> Result<()> {
-        let verifier = self.load_verifier()?;
-        verifier
+        self.verifier
             .verify(proof)
             .map_err(|e| anyhow!("public-batch aggregated proof verification failed: {}", e))
     }
 
     fn load_common_data(&self, circuit_type: CircuitType) -> Result<CommonCircuitData<F, D>> {
         match circuit_type {
-            CircuitType::Root => Ok(self.load_verifier()?.common),
-            CircuitType::Leaf => Ok(load_private_batch_verifier_from_bins(
-                &self.bins_dir,
-                self.num_leaf_proofs,
-            )?
-            .common),
+            CircuitType::Root => Ok(self.verifier.common.clone()),
+            CircuitType::Leaf => Ok(self.private_batch_common.clone()),
         }
     }
 }
@@ -279,8 +259,10 @@ impl AggregationBackend for PublicBatchAggregator {
 pub struct PrivateBatchAggregator {
     bins_dir: PathBuf,
     buf: ProofBuffer,
-    expected_leaf_pi_len: usize,
-    num_leaf_proofs: usize,
+    /// Canonical-pinned leaf common data, loaded once at construction.
+    leaf_common: CommonCircuitData<F, D>,
+    /// Canonical-pinned private-batch verifier data, loaded once at construction.
+    verifier: VerifierCircuitData<F, C, D>,
 }
 
 impl PrivateBatchAggregator {
@@ -290,13 +272,15 @@ impl PrivateBatchAggregator {
         // Load config
         let config = CircuitBinsConfig::load(&bins_dir)?;
         let num_leaf_proofs = config.num_leaf_proofs;
-        let expected_leaf_pi_len = load_leaf_common_from_bins(&bins_dir)?.num_public_inputs;
+
+        let leaf = load_leaf_verifier_from_bins(&bins_dir)?;
+        let verifier = load_private_batch_verifier_from_bins(&bins_dir, &leaf, num_leaf_proofs)?;
 
         Ok(Self {
             bins_dir,
             buf: ProofBuffer::new(num_leaf_proofs),
-            expected_leaf_pi_len,
-            num_leaf_proofs,
+            leaf_common: leaf.common,
+            verifier,
         })
     }
 
@@ -304,15 +288,11 @@ impl PrivateBatchAggregator {
         PrivateBatchProver::new_from_binaries_dir(&self.bins_dir)
             .context("failed to load prebuilt private-batch prover from binaries dir")
     }
-
-    fn load_verifier(&self) -> Result<VerifierCircuitData<F, C, D>> {
-        load_private_batch_verifier_from_bins(&self.bins_dir, self.num_leaf_proofs)
-    }
 }
 
 impl AggregationBackend for PrivateBatchAggregator {
     fn push_proof(&mut self, proof: Proof) -> Result<()> {
-        ensure_proof_public_input_len(&proof, self.expected_leaf_pi_len, "leaf proof")?;
+        ensure_proof_public_input_len(&proof, self.leaf_common.num_public_inputs, "leaf proof")?;
         self.buf.push(proof)
     }
 
@@ -356,16 +336,15 @@ impl AggregationBackend for PrivateBatchAggregator {
     }
 
     fn verify(&self, proof: Proof) -> Result<()> {
-        let verifier = self.load_verifier()?;
-        verifier
+        self.verifier
             .verify(proof)
             .map_err(|e| anyhow!("private-batch aggregated proof verification failed: {}", e))
     }
 
     fn load_common_data(&self, circuit_type: CircuitType) -> Result<CommonCircuitData<F, D>> {
         match circuit_type {
-            CircuitType::Root => Ok(self.load_verifier()?.common),
-            CircuitType::Leaf => Ok(load_leaf_common_from_bins(&self.bins_dir)?),
+            CircuitType::Root => Ok(self.verifier.common.clone()),
+            CircuitType::Leaf => Ok(self.leaf_common.clone()),
         }
     }
 }

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -22,10 +22,10 @@ use zk_circuits_common::circuit::{C, D, F};
 use crate::public_batch::prover::{PublicBatchInputs, PublicBatchProver};
 use crate::{
     common::utils::{
-        ensure_proof_public_input_len, ensure_verifier_data_matches_canonical,
-        leaf_proof_asset_id, load_canonical_leaf_verifier_data,
-        load_canonical_private_batch_verifier_data, load_verifier_data_from_bytes,
-        canonical_public_batch_verifier_data,
+        canonical_public_batch_verifier_data, ensure_proof_public_input_len,
+        ensure_verifier_data_matches_canonical, leaf_proof_asset_id,
+        load_canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
+        load_verifier_data_from_bytes,
     },
     private_batch::prover::PrivateBatchProver,
     CircuitBinsConfig,
@@ -82,12 +82,13 @@ fn load_private_batch_verifier_from_bins(
             bins_dir.join("private_batch_common.bin").display()
         )
     })?;
-    let verifier_bytes = fs::read(bins_dir.join("private_batch_verifier.bin")).with_context(|| {
-        format!(
-            "failed to read {}",
-            bins_dir.join("private_batch_verifier.bin").display()
-        )
-    })?;
+    let verifier_bytes =
+        fs::read(bins_dir.join("private_batch_verifier.bin")).with_context(|| {
+            format!(
+                "failed to read {}",
+                bins_dir.join("private_batch_verifier.bin").display()
+            )
+        })?;
     load_canonical_private_batch_verifier_data(&common_bytes, &verifier_bytes, num_leaf_proofs)
 }
 
@@ -187,7 +188,9 @@ impl PublicBatchAggregator {
             .ok_or_else(|| anyhow!("config is missing num_private_batch_proofs. Please regenerate the binaries and set \"num_private_batch_proofs\""))?;
         let num_leaf_proofs = config.num_leaf_proofs;
         let expected_private_batch_pi_len =
-            load_private_batch_verifier_from_bins(&bins_dir, num_leaf_proofs)?.common.num_public_inputs;
+            load_private_batch_verifier_from_bins(&bins_dir, num_leaf_proofs)?
+                .common
+                .num_public_inputs;
 
         Ok(Self {
             bins_dir,
@@ -260,9 +263,11 @@ impl AggregationBackend for PublicBatchAggregator {
     fn load_common_data(&self, circuit_type: CircuitType) -> Result<CommonCircuitData<F, D>> {
         match circuit_type {
             CircuitType::Root => Ok(self.load_verifier()?.common),
-            CircuitType::Leaf => {
-                Ok(load_private_batch_verifier_from_bins(&self.bins_dir, self.num_leaf_proofs)?.common)
-            }
+            CircuitType::Leaf => Ok(load_private_batch_verifier_from_bins(
+                &self.bins_dir,
+                self.num_leaf_proofs,
+            )?
+            .common),
         }
     }
 }

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -51,11 +51,7 @@ pub fn load_canonical_leaf_verifier_data(
     verifier_only_bytes: &[u8],
 ) -> Result<VerifierCircuitData<F, C, D>> {
     let loaded = load_verifier_data_from_bytes(common_bytes, verifier_only_bytes, "leaf")?;
-    ensure_verifier_data_matches_canonical(
-        &loaded,
-        &canonical_leaf_verifier_data(),
-        "leaf",
-    )?;
+    ensure_verifier_data_matches_canonical(&loaded, &canonical_leaf_verifier_data(), "leaf")?;
     Ok(loaded)
 }
 
@@ -104,10 +100,13 @@ pub fn ensure_verifier_data_matches_canonical(
 ) -> Result<()> {
     ensure_common_matches_canonical(&loaded.common, &canonical.common, label)?;
 
-    let loaded_vo = loaded
-        .verifier_only
-        .to_bytes()
-        .map_err(|e| anyhow!("failed to serialize loaded {} verifier-only data: {}", label, e))?;
+    let loaded_vo = loaded.verifier_only.to_bytes().map_err(|e| {
+        anyhow!(
+            "failed to serialize loaded {} verifier-only data: {}",
+            label,
+            e
+        )
+    })?;
     let canonical_vo = canonical.verifier_only.to_bytes().map_err(|e| {
         anyhow!(
             "failed to serialize canonical {} verifier-only data: {}",

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -17,14 +17,11 @@ use zk_circuits_common::circuit::{
 
 use crate::private_batch::circuit::{
     circuit_logic::PrivateBatchCircuit,
-    constants::{aggregated_output, ASSET_ID_START, LEAF_PI_LEN, VOLUME_FEE_BPS_START},
+    constants::{aggregated_output, ASSET_ID_START, LEAF_PI_LEN},
 };
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 
 /// Load verifier circuit data (common + verifier-only) from serialized bytes.
-///
-/// When `canonical` is provided, the loaded artifacts are pinned to that exact
-/// verifier data (byte-identical common + verifier-only).
 pub fn load_verifier_data_from_bytes(
     common_bytes: &[u8],
     verifier_only_bytes: &[u8],
@@ -55,15 +52,16 @@ pub fn load_canonical_leaf_verifier_data(
     Ok(loaded)
 }
 
-/// Load private-batch verifier data pinned to the canonical private-batch circuit for `num_leaf_proofs`.
+/// Load private-batch verifier data pinned to the canonical private-batch circuit for
+/// `num_leaf_proofs`. `leaf` must be canonical leaf verifier data (loaded pinned or rebuilt).
 pub fn load_canonical_private_batch_verifier_data(
     common_bytes: &[u8],
     verifier_only_bytes: &[u8],
+    leaf: &VerifierCircuitData<F, C, D>,
     num_leaf_proofs: usize,
 ) -> Result<VerifierCircuitData<F, C, D>> {
     let loaded = load_verifier_data_from_bytes(common_bytes, verifier_only_bytes, "private_batch")?;
-    let leaf = canonical_leaf_verifier_data();
-    let canonical = canonical_private_batch_verifier_data(&leaf, num_leaf_proofs);
+    let canonical = canonical_private_batch_verifier_data(leaf, num_leaf_proofs);
     ensure_verifier_data_matches_canonical(&loaded, &canonical, "private_batch")?;
     Ok(loaded)
 }
@@ -198,14 +196,6 @@ pub fn leaf_proof_asset_id(proof: &ProofWithPublicInputs<F, C, D>) -> Result<u32
         .to_canonical_u64()
         .try_into()
         .map_err(|_| anyhow!("leaf proof asset_id exceeds u32 range"))
-}
-
-pub fn leaf_proof_volume_fee_bps(proof: &ProofWithPublicInputs<F, C, D>) -> Result<u32> {
-    ensure_proof_public_input_len(proof, LEAF_PI_LEN, "leaf proof")?;
-    proof.public_inputs[VOLUME_FEE_BPS_START]
-        .to_canonical_u64()
-        .try_into()
-        .map_err(|_| anyhow!("leaf proof volume_fee_bps exceeds u32 range"))
 }
 
 pub fn private_batch_num_leaves_from_padded_pi_len(pi_len: usize) -> Result<usize> {

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -1,15 +1,30 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use plonky2::{
     field::types::PrimeField64,
-    plonk::circuit_data::{CommonCircuitData, VerifierCircuitData, VerifierOnlyCircuitData},
-    plonk::proof::ProofWithPublicInputs,
+    plonk::{
+        circuit_data::{
+            CircuitConfig, CommonCircuitData, VerifierCircuitData, VerifierOnlyCircuitData,
+        },
+        proof::ProofWithPublicInputs,
+    },
     util::serialization::DefaultGateSerializer,
 };
-use zk_circuits_common::circuit::{C, D, F};
+use wormhole_circuit::circuit::circuit_logic::WormholeCircuit;
+use zk_circuits_common::circuit::{
+    wormhole_leaf_circuit_config, wormhole_private_batch_circuit_config,
+    wormhole_public_batch_circuit_config, C, D, F,
+};
 
-use crate::private_batch::circuit::constants::{aggregated_output, ASSET_ID_START, LEAF_PI_LEN};
+use crate::private_batch::circuit::{
+    circuit_logic::PrivateBatchCircuit,
+    constants::{aggregated_output, ASSET_ID_START, LEAF_PI_LEN, VOLUME_FEE_BPS_START},
+};
+use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 
 /// Load verifier circuit data (common + verifier-only) from serialized bytes.
+///
+/// When `canonical` is provided, the loaded artifacts are pinned to that exact
+/// verifier data (byte-identical common + verifier-only).
 pub fn load_verifier_data_from_bytes(
     common_bytes: &[u8],
     verifier_only_bytes: &[u8],
@@ -28,6 +43,136 @@ pub fn load_verifier_data_from_bytes(
         verifier_only,
         common,
     })
+}
+
+/// Load leaf verifier data and reject anything that is not the canonical Wormhole leaf circuit.
+pub fn load_canonical_leaf_verifier_data(
+    common_bytes: &[u8],
+    verifier_only_bytes: &[u8],
+) -> Result<VerifierCircuitData<F, C, D>> {
+    let loaded = load_verifier_data_from_bytes(common_bytes, verifier_only_bytes, "leaf")?;
+    ensure_verifier_data_matches_canonical(
+        &loaded,
+        &canonical_leaf_verifier_data(),
+        "leaf",
+    )?;
+    Ok(loaded)
+}
+
+/// Load private-batch verifier data pinned to the canonical private-batch circuit for `num_leaf_proofs`.
+pub fn load_canonical_private_batch_verifier_data(
+    common_bytes: &[u8],
+    verifier_only_bytes: &[u8],
+    num_leaf_proofs: usize,
+) -> Result<VerifierCircuitData<F, C, D>> {
+    let loaded = load_verifier_data_from_bytes(common_bytes, verifier_only_bytes, "private_batch")?;
+    let leaf = canonical_leaf_verifier_data();
+    let canonical = canonical_private_batch_verifier_data(&leaf, num_leaf_proofs);
+    ensure_verifier_data_matches_canonical(&loaded, &canonical, "private_batch")?;
+    Ok(loaded)
+}
+
+pub fn ensure_common_matches_canonical(
+    loaded: &CommonCircuitData<F, D>,
+    canonical: &CommonCircuitData<F, D>,
+    label: &str,
+) -> Result<()> {
+    ensure_config_is_canonical(&loaded.config, &canonical.config, label)?;
+
+    let gate_serializer = DefaultGateSerializer;
+    let loaded_bytes = loaded
+        .to_bytes(&gate_serializer)
+        .map_err(|e| anyhow!("failed to serialize loaded {} common data: {}", label, e))?;
+    let canonical_bytes = canonical
+        .to_bytes(&gate_serializer)
+        .map_err(|e| anyhow!("failed to serialize canonical {} common data: {}", label, e))?;
+
+    if loaded_bytes != canonical_bytes {
+        bail!(
+            "loaded {} common circuit data does not match the canonical circuit",
+            label
+        );
+    }
+
+    Ok(())
+}
+
+pub fn ensure_verifier_data_matches_canonical(
+    loaded: &VerifierCircuitData<F, C, D>,
+    canonical: &VerifierCircuitData<F, C, D>,
+    label: &str,
+) -> Result<()> {
+    ensure_common_matches_canonical(&loaded.common, &canonical.common, label)?;
+
+    let loaded_vo = loaded
+        .verifier_only
+        .to_bytes()
+        .map_err(|e| anyhow!("failed to serialize loaded {} verifier-only data: {}", label, e))?;
+    let canonical_vo = canonical.verifier_only.to_bytes().map_err(|e| {
+        anyhow!(
+            "failed to serialize canonical {} verifier-only data: {}",
+            label,
+            e
+        )
+    })?;
+
+    if loaded_vo != canonical_vo {
+        bail!(
+            "loaded {} verifier-only data does not match the canonical circuit",
+            label
+        );
+    }
+
+    Ok(())
+}
+
+pub fn ensure_config_is_canonical(
+    loaded: &CircuitConfig,
+    expected: &CircuitConfig,
+    label: &str,
+) -> Result<()> {
+    if loaded != expected {
+        bail!(
+            "loaded {} circuit config does not match the canonical Wormhole config \
+             (security_bits loaded={}, expected={})",
+            label,
+            loaded.security_bits,
+            expected.security_bits
+        );
+    }
+    Ok(())
+}
+
+pub fn canonical_leaf_verifier_data() -> VerifierCircuitData<F, C, D> {
+    WormholeCircuit::new(wormhole_leaf_circuit_config()).build_verifier()
+}
+
+pub fn canonical_private_batch_verifier_data(
+    leaf: &VerifierCircuitData<F, C, D>,
+    num_leaf_proofs: usize,
+) -> VerifierCircuitData<F, C, D> {
+    PrivateBatchCircuit::new(
+        wormhole_private_batch_circuit_config(),
+        &leaf.common,
+        &leaf.verifier_only,
+        num_leaf_proofs,
+    )
+    .build_verifier()
+}
+
+pub fn canonical_public_batch_verifier_data(
+    private_batch: &VerifierCircuitData<F, C, D>,
+    num_private_batch_proofs: usize,
+    num_leaf_proofs: usize,
+) -> VerifierCircuitData<F, C, D> {
+    PublicBatchCircuit::new(
+        wormhole_public_batch_circuit_config(),
+        private_batch.common.clone(),
+        &private_batch.verifier_only,
+        num_private_batch_proofs,
+        num_leaf_proofs,
+    )
+    .build_verifier()
 }
 
 pub fn ensure_proof_public_input_len(
@@ -54,6 +199,14 @@ pub fn leaf_proof_asset_id(proof: &ProofWithPublicInputs<F, C, D>) -> Result<u32
         .to_canonical_u64()
         .try_into()
         .map_err(|_| anyhow!("leaf proof asset_id exceeds u32 range"))
+}
+
+pub fn leaf_proof_volume_fee_bps(proof: &ProofWithPublicInputs<F, C, D>) -> Result<u32> {
+    ensure_proof_public_input_len(proof, LEAF_PI_LEN, "leaf proof")?;
+    proof.public_inputs[VOLUME_FEE_BPS_START]
+        .to_canonical_u64()
+        .try_into()
+        .map_err(|_| anyhow!("leaf proof volume_fee_bps exceeds u32 range"))
 }
 
 pub fn private_batch_num_leaves_from_padded_pi_len(pi_len: usize) -> Result<usize> {

--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -152,11 +152,10 @@ fn build_private_batch_constraints(
     // Output: [num_exit_slots, asset_id, volume_fee_bps, block_hash(4), block_number, ...]
     let num_exit_slots_t = builder.constant(F::from_canonical_u64((n_leaf * 2) as u64));
 
-    // asset_id / volume_fee_bps refs come from slot 0. This is positionally safe because
-    // equality is enforced across ALL slots (dummies included) below.
+    // `asset_id` must match across every slot, including dummies. This keeps the historical
+    // partial-batch rule that dummy padding is only compatible with native-asset (`asset_id = 0`)
+    // proofs, which the prover/wrapper preflight enforces before padding.
     let asset_ref = limb1_at_offset::<LEAF_PI_LEN, ASSET_ID_START>(leaf_pi_targets[0], 0);
-    let volume_fee_bps_ref =
-        limb1_at_offset::<LEAF_PI_LEN, VOLUME_FEE_BPS_START>(leaf_pi_targets[0], 0);
 
     // Dummy sentinel at the wrapper level is `block_hash == [0;4]`.
     // Leaf circuit itself uses a stronger dummy condition (block_hash==0 && outputs==0).
@@ -173,27 +172,36 @@ fn build_private_batch_constraints(
         block_hashes.push(block_i);
     }
 
-    // Select the reference block hash / block number from the FIRST NON-DUMMY slot via a
-    // prefix scan. This makes the circuit position-independent: the prover may place real
-    // and dummy proofs in any order (uniform shuffle), which is required for the privacy
-    // argument that real and dummy slots are indistinguishable.
+    // Select the reference block hash / block number / volume_fee_bps from the FIRST
+    // NON-DUMMY slot via a prefix scan. This makes the circuit position-independent: the
+    // prover may place real and dummy proofs in any order (uniform shuffle), which is
+    // required for the privacy argument that real and dummy slots are indistinguishable.
     //
     // If every slot is a dummy, the references remain zero, which the on-chain verifier
     // rejects as a block reference (and an all-dummy batch settles nothing anyway).
     let mut found_real = builder._false();
     let mut block_ref = [zero, zero, zero, zero];
     let mut block_number_ref = zero;
+    let mut volume_fee_bps_ref = zero;
     for i in 0..n_leaf {
         let is_real_i = builder.not(is_dummy_flags[i]);
         let not_found_yet = builder.not(found_real);
         let take_i = builder.and(is_real_i, not_found_yet);
+        let pis_i = leaf_pi_targets[i];
 
         for j in 0..4 {
             block_ref[j] = builder.select(take_i, block_hashes[i][j], block_ref[j]);
         }
-        let block_number_i =
-            limb1_at_offset::<LEAF_PI_LEN, BLOCK_NUMBER_START>(leaf_pi_targets[i], 0);
-        block_number_ref = builder.select(take_i, block_number_i, block_number_ref);
+        block_number_ref = builder.select(
+            take_i,
+            pis_i[BLOCK_NUMBER_START],
+            block_number_ref,
+        );
+        volume_fee_bps_ref = builder.select(
+            take_i,
+            pis_i[VOLUME_FEE_BPS_START],
+            volume_fee_bps_ref,
+        );
 
         found_real = builder.or(found_real, is_real_i);
     }
@@ -215,7 +223,7 @@ fn build_private_batch_constraints(
     //
     // Also enforce:
     //   asset_id_i == asset_ref
-    //   volume_fee_bps_i == volume_fee_bps_ref
+    //   is_dummy_i OR (volume_fee_bps_i == volume_fee_bps_ref)
 
     for (i, pis_i) in leaf_pi_targets.iter().take(n_leaf).enumerate() {
         let matches_ref = bytes_digest_eq(builder, block_hashes[i], block_ref);
@@ -228,9 +236,13 @@ fn build_private_batch_constraints(
         let asset_i = limb1_at_offset::<LEAF_PI_LEN, ASSET_ID_START>(pis_i, 0);
         builder.connect(asset_i, asset_ref);
 
-        // Enforce volume_fee_bps consistency
         let volume_fee_bps_i = limb1_at_offset::<LEAF_PI_LEN, VOLUME_FEE_BPS_START>(pis_i, 0);
-        builder.connect(volume_fee_bps_i, volume_fee_bps_ref);
+
+        // Enforce volume_fee_bps consistency across real proofs only; dummy slots use a fixed
+        // reusable template fee and must not constrain padded partial batches.
+        let fee_matches_ref = builder.is_equal(volume_fee_bps_i, volume_fee_bps_ref);
+        let valid_fee_relation = builder.or(is_dummy_flags[i], fee_matches_ref);
+        builder.connect(valid_fee_relation.target, one);
     }
 
     // Output block reference (all-dummy case yields zeros, which is fine)

--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -192,16 +192,9 @@ fn build_private_batch_constraints(
         for j in 0..4 {
             block_ref[j] = builder.select(take_i, block_hashes[i][j], block_ref[j]);
         }
-        block_number_ref = builder.select(
-            take_i,
-            pis_i[BLOCK_NUMBER_START],
-            block_number_ref,
-        );
-        volume_fee_bps_ref = builder.select(
-            take_i,
-            pis_i[VOLUME_FEE_BPS_START],
-            volume_fee_bps_ref,
-        );
+        block_number_ref = builder.select(take_i, pis_i[BLOCK_NUMBER_START], block_number_ref);
+        volume_fee_bps_ref =
+            builder.select(take_i, pis_i[VOLUME_FEE_BPS_START], volume_fee_bps_ref);
 
         found_real = builder.or(found_real, is_real_i);
     }

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -31,8 +31,8 @@ use zk_circuits_common::{
 
 use crate::{
     common::utils::{
-        canonical_private_batch_verifier_data, ensure_common_matches_canonical,
-        ensure_proof_public_input_len, leaf_proof_asset_id, load_canonical_leaf_verifier_data,
+        ensure_common_matches_canonical, ensure_proof_public_input_len, leaf_proof_asset_id,
+        load_canonical_leaf_verifier_data,
     },
     dummy_proof::{generate_random_nullifier_preimage, load_dummy_proof},
     private_batch::{
@@ -106,12 +106,21 @@ impl PrivateBatchProver {
         let leaf_verifier_data =
             load_canonical_leaf_verifier_data(leaf_common_bytes, leaf_verifier_only_bytes)?;
 
-        // 2) Load prebuilt aggregation circuit prover data and pin common data.
+        // 2) Reconstruct the canonical aggregation circuit once: it provides both the
+        // witness targets and the canonical common data used to pin the prebuilt artifacts.
+        let circuit = PrivateBatchCircuit::new(
+            wormhole_private_batch_circuit_config(),
+            &leaf_verifier_data.common,
+            &leaf_verifier_data.verifier_only,
+            num_leaf_proofs,
+        );
+        let targets = Some(circuit.targets());
+        let canonical_agg = circuit.build_verifier();
+
+        // 3) Load prebuilt aggregation circuit prover data and pin common data.
         let agg_common =
             CommonCircuitData::from_bytes(aggregated_common_bytes.to_vec(), &gate_serializer)
                 .map_err(|e| anyhow!("failed to deserialize aggregated common data: {}", e))?;
-        let canonical_agg =
-            canonical_private_batch_verifier_data(&leaf_verifier_data, num_leaf_proofs);
         ensure_common_matches_canonical(&agg_common, &canonical_agg.common, "private_batch")?;
 
         let agg_prover_only = ProverOnlyCircuitData::from_bytes(
@@ -120,16 +129,6 @@ impl PrivateBatchProver {
             &agg_common,
         )
         .map_err(|e| anyhow!("failed to deserialize aggregated prover data: {}", e))?;
-
-        // 3) Reconstruct the aggregation circuit to get targets using the canonical config.
-        let circuit = PrivateBatchCircuit::new(
-            wormhole_private_batch_circuit_config(),
-            &leaf_verifier_data.common,
-            &leaf_verifier_data.verifier_only,
-            num_leaf_proofs,
-        );
-
-        let targets = Some(circuit.targets());
 
         // 4) Load dummy proof template compatible with the leaf verifier common data
         let dummy_proof_template =

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -25,13 +25,15 @@ use rand::seq::SliceRandom;
 use std::{fs, path::Path};
 
 use zk_circuits_common::{
-    circuit::{C, D, F},
+    circuit::{wormhole_private_batch_circuit_config, C, D, F},
     utils::bytes_to_digest,
 };
 
 use crate::{
     common::utils::{
-        ensure_proof_public_input_len, leaf_proof_asset_id, load_verifier_data_from_bytes,
+        ensure_common_matches_canonical, ensure_proof_public_input_len,
+        leaf_proof_asset_id, load_canonical_leaf_verifier_data,
+        canonical_private_batch_verifier_data,
     },
     dummy_proof::{generate_random_nullifier_preimage, load_dummy_proof},
     private_batch::{
@@ -101,10 +103,17 @@ impl PrivateBatchProver {
             _phantom: Default::default(),
         };
 
-        // 1) Load prebuilt aggregation circuit prover data
+        // 1) Load and pin leaf verifier data to the canonical Wormhole leaf circuit.
+        let leaf_verifier_data =
+            load_canonical_leaf_verifier_data(leaf_common_bytes, leaf_verifier_only_bytes)?;
+
+        // 2) Load prebuilt aggregation circuit prover data and pin common data.
         let agg_common =
             CommonCircuitData::from_bytes(aggregated_common_bytes.to_vec(), &gate_serializer)
                 .map_err(|e| anyhow!("failed to deserialize aggregated common data: {}", e))?;
+        let canonical_agg =
+            canonical_private_batch_verifier_data(&leaf_verifier_data, num_leaf_proofs);
+        ensure_common_matches_canonical(&agg_common, &canonical_agg.common, "private_batch")?;
 
         let agg_prover_only = ProverOnlyCircuitData::from_bytes(
             aggregated_prover_only_bytes,
@@ -113,15 +122,9 @@ impl PrivateBatchProver {
         )
         .map_err(|e| anyhow!("failed to deserialize aggregated prover data: {}", e))?;
 
-        // 2) Load leaf verifier data (needed to reconstruct targets + parse dummy proof)
-        let leaf_verifier_data =
-            load_verifier_data_from_bytes(leaf_common_bytes, leaf_verifier_only_bytes, "leaf")?;
-
-        // 3) Reconstruct the aggregation circuit to get targets.
-        // NOTE: This builds a fresh circuit to extract target structure. The verifier key
-        // must match what was used when the prebuilt binaries were created.
+        // 3) Reconstruct the aggregation circuit to get targets using the canonical config.
         let circuit = PrivateBatchCircuit::new(
-            agg_common.config.clone(),
+            wormhole_private_batch_circuit_config(),
             &leaf_verifier_data.common,
             &leaf_verifier_data.verifier_only,
             num_leaf_proofs,

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -31,9 +31,8 @@ use zk_circuits_common::{
 
 use crate::{
     common::utils::{
-        ensure_common_matches_canonical, ensure_proof_public_input_len,
-        leaf_proof_asset_id, load_canonical_leaf_verifier_data,
-        canonical_private_batch_verifier_data,
+        canonical_private_batch_verifier_data, ensure_common_matches_canonical,
+        ensure_proof_public_input_len, leaf_proof_asset_id, load_canonical_leaf_verifier_data,
     },
     dummy_proof::{generate_random_nullifier_preimage, load_dummy_proof},
     private_batch::{

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -22,12 +22,15 @@ use qp_wormhole_inputs::BytesDigest;
 use std::{fs, path::Path};
 
 use zk_circuits_common::{
-    circuit::{C, D, F},
+    circuit::{wormhole_public_batch_circuit_config, C, D, F},
     utils::bytes_to_digest,
 };
 
 use crate::{
-    common::utils::load_verifier_data_from_bytes,
+    common::utils::{
+        canonical_public_batch_verifier_data, ensure_common_matches_canonical,
+        load_canonical_private_batch_verifier_data,
+    },
     public_batch::{
         circuit::circuit_logic::{PublicBatchCircuit, PublicBatchCircuitTargets},
         prover::witness::fill_public_batch_witness,
@@ -99,10 +102,29 @@ impl PublicBatchProver {
             _phantom: Default::default(),
         };
 
-        // 1) Load prebuilt public-batch circuit prover data
+        let (num_leaf_proofs, num_private_batch_proofs) = config;
+
+        // 1) Load and pin private-batch verifier data to the canonical circuit.
+        let private_batch_verifier_data = load_canonical_private_batch_verifier_data(
+            private_batch_common_bytes,
+            private_batch_verifier_only_bytes,
+            num_leaf_proofs,
+        )?;
+
+        // 2) Load prebuilt public-batch circuit prover data and pin common data.
         let public_batch_common =
             CommonCircuitData::from_bytes(public_batch_common_bytes.to_vec(), &gate_serializer)
                 .map_err(|e| anyhow!("failed to deserialize public_batch common data: {}", e))?;
+        let canonical_public = canonical_public_batch_verifier_data(
+            &private_batch_verifier_data,
+            num_private_batch_proofs,
+            num_leaf_proofs,
+        );
+        ensure_common_matches_canonical(
+            &public_batch_common,
+            &canonical_public.common,
+            "public_batch",
+        )?;
 
         let public_batch_prover_only = ProverOnlyCircuitData::from_bytes(
             public_batch_prover_only_bytes,
@@ -111,17 +133,8 @@ impl PublicBatchProver {
         )
         .map_err(|e| anyhow!("failed to deserialize public_batch prover data: {}", e))?;
 
-        // 2) Load private-batch verifier data (needed for witness filling and dummy proof parsing)
-        let private_batch_verifier_data = load_verifier_data_from_bytes(
-            private_batch_common_bytes,
-            private_batch_verifier_only_bytes,
-            "private_batch",
-        )?;
-
-        let (num_leaf_proofs, num_private_batch_proofs) = config;
-
         let circuit = PublicBatchCircuit::new(
-            public_batch_common.config.clone(),
+            wormhole_public_batch_circuit_config(),
             private_batch_verifier_data.common.clone(),
             &private_batch_verifier_data.verifier_only,
             num_private_batch_proofs,

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -28,7 +28,7 @@ use zk_circuits_common::{
 
 use crate::{
     common::utils::{
-        canonical_public_batch_verifier_data, ensure_common_matches_canonical,
+        canonical_leaf_verifier_data, ensure_common_matches_canonical,
         load_canonical_private_batch_verifier_data,
     },
     public_batch::{
@@ -108,18 +108,26 @@ impl PublicBatchProver {
         let private_batch_verifier_data = load_canonical_private_batch_verifier_data(
             private_batch_common_bytes,
             private_batch_verifier_only_bytes,
+            &canonical_leaf_verifier_data(),
             num_leaf_proofs,
         )?;
 
-        // 2) Load prebuilt public-batch circuit prover data and pin common data.
-        let public_batch_common =
-            CommonCircuitData::from_bytes(public_batch_common_bytes.to_vec(), &gate_serializer)
-                .map_err(|e| anyhow!("failed to deserialize public_batch common data: {}", e))?;
-        let canonical_public = canonical_public_batch_verifier_data(
-            &private_batch_verifier_data,
+        // 2) Reconstruct the canonical public-batch circuit once: it provides both the
+        // witness targets and the canonical common data used to pin the prebuilt artifacts.
+        let circuit = PublicBatchCircuit::new(
+            wormhole_public_batch_circuit_config(),
+            private_batch_verifier_data.common.clone(),
+            &private_batch_verifier_data.verifier_only,
             num_private_batch_proofs,
             num_leaf_proofs,
         );
+        let targets = Some(circuit.targets());
+        let canonical_public = circuit.build_verifier();
+
+        // 3) Load prebuilt public-batch circuit prover data and pin common data.
+        let public_batch_common =
+            CommonCircuitData::from_bytes(public_batch_common_bytes.to_vec(), &gate_serializer)
+                .map_err(|e| anyhow!("failed to deserialize public_batch common data: {}", e))?;
         ensure_common_matches_canonical(
             &public_batch_common,
             &canonical_public.common,
@@ -133,17 +141,7 @@ impl PublicBatchProver {
         )
         .map_err(|e| anyhow!("failed to deserialize public_batch prover data: {}", e))?;
 
-        let circuit = PublicBatchCircuit::new(
-            wormhole_public_batch_circuit_config(),
-            private_batch_verifier_data.common.clone(),
-            &private_batch_verifier_data.verifier_only,
-            num_private_batch_proofs,
-            num_leaf_proofs,
-        );
-
-        let targets = Some(circuit.targets());
-
-        // 3) Load the dummy private-batch proof template used to pad partial batches
+        // 4) Load the dummy private-batch proof template used to pad partial batches
         let dummy_proof_template = ProofWithPublicInputs::<F, C, D>::from_bytes(
             dummy_private_batch_proof_bytes.to_vec(),
             &private_batch_verifier_data.common,

--- a/wormhole/circuit/src/inputs.rs
+++ b/wormhole/circuit/src/inputs.rs
@@ -21,14 +21,23 @@ use qp_wormhole_inputs::{
 };
 
 /// Inputs required to commit to the wormhole circuit.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CircuitInputs {
     pub public: PublicCircuitInputs,
     pub private: PrivateCircuitInputs,
 }
 
+impl core::fmt::Debug for CircuitInputs {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CircuitInputs")
+            .field("public", &self.public)
+            .field("private", &self.private)
+            .finish()
+    }
+}
+
 /// All of the private inputs required for the circuit.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PrivateCircuitInputs {
     /// Raw bytes of the secret of the nullifier and the unspendable account
     pub secret: BytesDigest,
@@ -62,6 +71,24 @@ pub struct PrivateCircuitInputs {
     /// Position hints (0-3) for each level indicating where current hash
     /// should be inserted among the sorted siblings.
     pub zk_merkle_positions: Vec<u8>,
+}
+
+impl core::fmt::Debug for PrivateCircuitInputs {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrivateCircuitInputs")
+            .field("secret", &"[REDACTED]")
+            .field("transfer_count", &self.transfer_count)
+            .field("unspendable_account", &self.unspendable_account)
+            .field("parent_hash", &self.parent_hash)
+            .field("state_root", &self.state_root)
+            .field("extrinsics_root", &self.extrinsics_root)
+            .field("digest", &"[REDACTED]")
+            .field("input_amount", &self.input_amount)
+            .field("zk_tree_root", &self.zk_tree_root)
+            .field("zk_merkle_siblings", &"[REDACTED]")
+            .field("zk_merkle_positions", &"[REDACTED]")
+            .finish()
+    }
 }
 
 // ============================================================================
@@ -315,5 +342,27 @@ mod tests {
         let parsed = result.unwrap();
         assert_eq!(parsed.account_data.len(), 2); // 2 outputs per leaf
         assert_eq!(parsed.nullifiers.len(), 1); // 1 nullifier per leaf
+    }
+
+    #[test]
+    fn private_circuit_inputs_debug_redacts_secret() {
+        let secret = BytesDigest::try_from([0xab; 32].as_slice()).unwrap();
+        let inputs = PrivateCircuitInputs {
+            secret,
+            transfer_count: 1,
+            unspendable_account: BytesDigest::default(),
+            parent_hash: BytesDigest::default(),
+            state_root: BytesDigest::default(),
+            extrinsics_root: BytesDigest::default(),
+            digest: [0u8; DIGEST_LOGS_SIZE],
+            input_amount: 100,
+            zk_tree_root: [0u8; 32],
+            zk_merkle_siblings: vec![],
+            zk_merkle_positions: vec![],
+        };
+        let dump = format!("{:?}", inputs);
+        assert!(dump.contains("[REDACTED]"));
+        assert!(!dump.contains("abababab"));
+        assert!(!dump.contains("secret: BytesDigest"));
     }
 }

--- a/wormhole/circuit/src/nullifier.rs
+++ b/wormhole/circuit/src/nullifier.rs
@@ -46,12 +46,22 @@ pub const NULLIFIER_SIZE_FELTS: usize =
 /// Type alias for the secret as a fixed-size array (4 field elements for 32 bytes)
 pub type Secret = Digest;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct Nullifier {
     pub hash: Digest,
     /// Secret encoded with 8 bytes/felt (4 field elements for 32 bytes)
     pub secret: Secret,
     transfer_count: [F; TRANSFER_COUNT_NUM_TARGETS],
+}
+
+impl core::fmt::Debug for Nullifier {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Nullifier")
+            .field("hash", &self.hash)
+            .field("secret", &"[REDACTED]")
+            .field("transfer_count", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl Nullifier {

--- a/wormhole/circuit/src/unspendable_account.rs
+++ b/wormhole/circuit/src/unspendable_account.rs
@@ -24,12 +24,21 @@ pub const UNSPENDABLE_SALT: &str = "wormhole";
 /// Type alias for the secret as a fixed-size array (4 felts, 8 bytes/felt)
 pub type Secret = [F; SECRET_NUM_TARGETS];
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct UnspendableAccount {
     /// Account ID as 4 field elements (8 bytes/felt for hash output)
     pub account_id: Digest,
     /// Secret encoded as 4 field elements (8 bytes/felt for 32 bytes)
     pub secret: Secret,
+}
+
+impl core::fmt::Debug for UnspendableAccount {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UnspendableAccount")
+            .field("account_id", &self.account_id)
+            .field("secret", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl UnspendableAccount {

--- a/wormhole/inputs/src/lib.rs
+++ b/wormhole/inputs/src/lib.rs
@@ -32,12 +32,10 @@ const GOLDILOCKS_ORDER: u64 = 0xFFFFFFFF00000001;
 /// but is not exposed as a public input since block_hash already commits to it.
 pub const PUBLIC_INPUTS_FELTS_LEN: usize = 21;
 
-/// Canonical leaf circuit security target (bits). Must match
-/// `CircuitConfig::standard_recursion_config().security_bits` in qp-plonky2.
-pub const CANONICAL_LEAF_SECURITY_BITS: usize = 100;
-
-/// Canonical leaf circuit public-input length.
-pub const CANONICAL_LEAF_NUM_PUBLIC_INPUTS: usize = PUBLIC_INPUTS_FELTS_LEN;
+/// Minimum acceptable security level (bits) for the canonical leaf circuit config.
+/// Guards against a qp-plonky2 upgrade silently weakening
+/// `CircuitConfig::standard_recursion_config()` below this floor.
+pub const MIN_LEAF_SECURITY_BITS: usize = 100;
 
 // Index constants for parsing public inputs
 pub const ASSET_ID_INDEX: usize = 0;

--- a/wormhole/inputs/src/lib.rs
+++ b/wormhole/inputs/src/lib.rs
@@ -32,6 +32,13 @@ const GOLDILOCKS_ORDER: u64 = 0xFFFFFFFF00000001;
 /// but is not exposed as a public input since block_hash already commits to it.
 pub const PUBLIC_INPUTS_FELTS_LEN: usize = 21;
 
+/// Canonical leaf circuit security target (bits). Must match
+/// `CircuitConfig::standard_recursion_config().security_bits` in qp-plonky2.
+pub const CANONICAL_LEAF_SECURITY_BITS: usize = 100;
+
+/// Canonical leaf circuit public-input length.
+pub const CANONICAL_LEAF_NUM_PUBLIC_INPUTS: usize = PUBLIC_INPUTS_FELTS_LEN;
+
 // Index constants for parsing public inputs
 pub const ASSET_ID_INDEX: usize = 0;
 pub const OUTPUT_AMOUNT_1_INDEX: usize = 1;

--- a/wormhole/prover/src/lib.rs
+++ b/wormhole/prover/src/lib.rs
@@ -77,7 +77,7 @@ use plonky2::{
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
 
-use zk_circuits_common::circuit::{CircuitFragment, C, D, F};
+use zk_circuits_common::circuit::{wormhole_leaf_circuit_config, CircuitFragment, C, D, F};
 use zk_circuits_common::zk_merkle::MAX_DEPTH;
 
 use wormhole_circuit::nullifier::Nullifier;
@@ -117,11 +117,21 @@ impl WormholeProver {
     fn ensure_loaded_common_matches_canonical(
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<()> {
+        let expected_config = wormhole_leaf_circuit_config();
+        if common_data.config != expected_config {
+            bail!(
+                "loaded common circuit config does not match the canonical Wormhole leaf config \
+                 (security_bits loaded={}, expected={})",
+                common_data.config.security_bits,
+                expected_config.security_bits
+            );
+        }
+
         let gate_serializer = DefaultGateSerializer;
         let loaded_bytes = common_data
             .to_bytes(&gate_serializer)
             .map_err(|e| anyhow!("failed to serialize loaded common circuit data: {}", e))?;
-        let canonical_common = WormholeCircuit::new(common_data.config.clone())
+        let canonical_common = WormholeCircuit::new(expected_config)
             .build_verifier()
             .common;
         let canonical_bytes = canonical_common
@@ -155,7 +165,7 @@ impl WormholeProver {
         )
         .map_err(|e| anyhow!("failed to deserialize prover-only data: {}", e))?;
 
-        let wormhole_circuit = WormholeCircuit::new(common_data.config.clone());
+        let wormhole_circuit = WormholeCircuit::new(wormhole_leaf_circuit_config());
         let targets = Some(wormhole_circuit.targets());
 
         let circuit_data = ProverCircuitData {
@@ -206,7 +216,7 @@ impl WormholeProver {
             )
         })?;
 
-        let wormhole_circuit = WormholeCircuit::new(common_data.config.clone());
+        let wormhole_circuit = WormholeCircuit::new(wormhole_leaf_circuit_config());
         let targets = Some(wormhole_circuit.targets());
 
         let circuit_data = ProverCircuitData {

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -48,7 +48,7 @@ use qp_plonky2_verifier::util::serialization::DefaultGateSerializer;
 // Re-export input types from qp-wormhole-inputs
 pub use qp_wormhole_inputs::{
     BlockData, BytesDigest, PrivateBatchPublicInputs, PublicBatchPublicInputs, PublicCircuitInputs,
-    PublicInputsByAccount, CANONICAL_LEAF_NUM_PUBLIC_INPUTS, CANONICAL_LEAF_SECURITY_BITS,
+    PublicInputsByAccount, MIN_LEAF_SECURITY_BITS, PUBLIC_INPUTS_FELTS_LEN,
 };
 
 /// Parse public inputs from a proof.
@@ -122,33 +122,30 @@ impl WormholeVerifier {
     fn ensure_loaded_matches_canonical_leaf_profile(
         common: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<()> {
-        let cfg = &common.config;
         let expected = CircuitConfig::standard_recursion_config();
 
-        if cfg.security_bits != CANONICAL_LEAF_SECURITY_BITS
-            || cfg.security_bits != expected.security_bits
-            || cfg.zero_knowledge != expected.zero_knowledge
-            || cfg.num_wires != expected.num_wires
-            || cfg.num_routed_wires != expected.num_routed_wires
-            || cfg.num_constants != expected.num_constants
-            || cfg.use_base_arithmetic_gate != expected.use_base_arithmetic_gate
-            || cfg.num_challenges != expected.num_challenges
-            || cfg.max_quotient_degree_factor != expected.max_quotient_degree_factor
-            || cfg.fri_config != expected.fri_config
-        {
+        if expected.security_bits < MIN_LEAF_SECURITY_BITS {
             return Err(anyhow!(
-                "loaded verifier circuit config does not match the canonical Wormhole leaf config \
-                 (security_bits loaded={}, expected={})",
-                cfg.security_bits,
-                CANONICAL_LEAF_SECURITY_BITS
+                "canonical recursion config provides only {} security bits, below the required minimum of {}",
+                expected.security_bits,
+                MIN_LEAF_SECURITY_BITS
             ));
         }
 
-        if common.num_public_inputs != CANONICAL_LEAF_NUM_PUBLIC_INPUTS {
+        if common.config != expected {
+            return Err(anyhow!(
+                "loaded verifier circuit config does not match the canonical Wormhole leaf config \
+                 (security_bits loaded={}, expected={})",
+                common.config.security_bits,
+                expected.security_bits
+            ));
+        }
+
+        if common.num_public_inputs != PUBLIC_INPUTS_FELTS_LEN {
             return Err(anyhow!(
                 "loaded verifier common data has {} public inputs, expected {} for the canonical Wormhole leaf circuit",
                 common.num_public_inputs,
-                CANONICAL_LEAF_NUM_PUBLIC_INPUTS
+                PUBLIC_INPUTS_FELTS_LEN
             ));
         }
 

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -38,7 +38,8 @@ use std::path::Path;
 
 // Re-export types from qp-plonky2-verifier
 pub use qp_plonky2_verifier::{
-    CommonCircuitData, ProofWithPublicInputs, VerifierCircuitData, VerifierOnlyCircuitData, C, D, F,
+    CircuitConfig, CommonCircuitData, ProofWithPublicInputs, VerifierCircuitData,
+    VerifierOnlyCircuitData, C, D, F,
 };
 
 use qp_plonky2_verifier::field::types::PrimeField64;
@@ -47,7 +48,7 @@ use qp_plonky2_verifier::util::serialization::DefaultGateSerializer;
 // Re-export input types from qp-wormhole-inputs
 pub use qp_wormhole_inputs::{
     BlockData, BytesDigest, PrivateBatchPublicInputs, PublicBatchPublicInputs, PublicCircuitInputs,
-    PublicInputsByAccount,
+    PublicInputsByAccount, CANONICAL_LEAF_NUM_PUBLIC_INPUTS, CANONICAL_LEAF_SECURITY_BITS,
 };
 
 /// Parse public inputs from a proof.
@@ -98,6 +99,9 @@ pub struct WormholeVerifier {
 
 impl WormholeVerifier {
     /// Creates a new [`WormholeVerifier`] from verifier and common data bytes.
+    ///
+    /// Rejects artifacts whose embedded `CircuitConfig` does not match the canonical
+    /// Wormhole leaf security profile (`security_bits`, ZK mode, FRI parameters, etc.).
     pub fn new_from_bytes(verifier_bytes: &[u8], common_bytes: &[u8]) -> anyhow::Result<Self> {
         let verifier_only = VerifierOnlyCircuitData::from_bytes(verifier_bytes.to_vec())
             .map_err(|e| anyhow!("failed to deserialize verifier data: {}", e))?;
@@ -105,12 +109,50 @@ impl WormholeVerifier {
         let common = CommonCircuitData::from_bytes(common_bytes.to_vec(), &DefaultGateSerializer)
             .map_err(|e| anyhow!("failed to deserialize common circuit data: {}", e))?;
 
+        Self::ensure_loaded_matches_canonical_leaf_profile(&common)?;
+
         let circuit_data = VerifierCircuitData {
             verifier_only,
             common,
         };
 
         Ok(Self { circuit_data })
+    }
+
+    fn ensure_loaded_matches_canonical_leaf_profile(
+        common: &CommonCircuitData<F, D>,
+    ) -> anyhow::Result<()> {
+        let cfg = &common.config;
+        let expected = CircuitConfig::standard_recursion_config();
+
+        if cfg.security_bits != CANONICAL_LEAF_SECURITY_BITS
+            || cfg.security_bits != expected.security_bits
+            || cfg.zero_knowledge != expected.zero_knowledge
+            || cfg.num_wires != expected.num_wires
+            || cfg.num_routed_wires != expected.num_routed_wires
+            || cfg.num_constants != expected.num_constants
+            || cfg.use_base_arithmetic_gate != expected.use_base_arithmetic_gate
+            || cfg.num_challenges != expected.num_challenges
+            || cfg.max_quotient_degree_factor != expected.max_quotient_degree_factor
+            || cfg.fri_config != expected.fri_config
+        {
+            return Err(anyhow!(
+                "loaded verifier circuit config does not match the canonical Wormhole leaf config \
+                 (security_bits loaded={}, expected={})",
+                cfg.security_bits,
+                CANONICAL_LEAF_SECURITY_BITS
+            ));
+        }
+
+        if common.num_public_inputs != CANONICAL_LEAF_NUM_PUBLIC_INPUTS {
+            return Err(anyhow!(
+                "loaded verifier common data has {} public inputs, expected {} for the canonical Wormhole leaf circuit",
+                common.num_public_inputs,
+                CANONICAL_LEAF_NUM_PUBLIC_INPUTS
+            ));
+        }
+
+        Ok(())
     }
 
     /// Creates a new [`WormholeVerifier`] from a verifier and common data files.


### PR DESCRIPTION
## Summary

Fixes all three high-severity findings from the July 2026 V12 audit:

- **#97068** — Gate private-batch `volume_fee_bps` equality on `is_dummy` and take the fee reference from the first non-dummy slot, so fixed-fee dummy padding no longer breaks partial batches.
- **#97069** — Pin leaf / private-batch / public-batch artifact loaders (and the leaf prover/verifier) to canonical circuit rebuilds and approved configs, rejecting substituted or weakened artifacts.
- **#97072** — Redact spend-authorizing secrets in `Debug` for `CircuitInputs`, `PrivateCircuitInputs`, `Nullifier`, and `UnspendableAccount`.

Supersedes #151 with stronger canonical pinning (full common + verifier-only byte compare against fixed configs, not just PI-count / min `security_bits` checks).

## Test plan

- [x] `cargo check` on changed crates
- [x] Private-batch circuit unit tests (11/11)
- [x] Aggregator integration tests (9/9)
- [x] Prover tests including canonical rejection
- [x] Debug redaction unit test