### PR TITLE
fix: V12 medium-severity audit findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ dependencies = [
  "criterion",
  "qp-plonky2-verifier",
  "qp-wormhole-inputs",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1189,6 +1190,7 @@ dependencies = [
  "qp-wormhole-inputs",
  "rand 0.8.6",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 qp-plonky2 = { version = "1.5.1", default-features = false, features = ["std"] }
 qp-poseidon-core = { version = "2.1.0", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+tiny-keccak = { version = "2.0.2", default-features = false, features = ["keccak"] }
 
 [workspace.package]
 authors = ["Quantus Network"]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,6 +16,9 @@ qp-wormhole-inputs = { version = "3.0.0", path = "../wormhole/inputs", default-f
 rand = { version = "0.8", default-features = false, features = ["alloc"], optional = true }
 serde = { workspace = true }
 
+[dev-dependencies]
+serde_json = "1"
+
 [features]
 default = ["std"]
 std = [

--- a/common/src/circuit.rs
+++ b/common/src/circuit.rs
@@ -1,4 +1,6 @@
-use alloc::{string::String, vec::Vec};
+use alloc::{format, string::String, vec::Vec};
+use core::fmt;
+use core::marker::PhantomData;
 use plonky2::{
     field::goldilocks_field::GoldilocksField,
     iop::witness::PartialWitness,
@@ -7,6 +9,7 @@ use plonky2::{
         config::PoseidonGoldilocksConfig,
     },
 };
+use serde::de::{self, Deserializer, Error, SeqAccess, Visitor};
 use serde::Deserialize;
 
 // Plonky2 setup parameters.
@@ -14,12 +17,261 @@ pub const D: usize = 2; // D=2 provides 100-bits of security
 pub type C = PoseidonGoldilocksConfig;
 pub type F = GoldilocksField; // Goldilocks field
 
+/// Maximum number of hex-encoded storage-proof nodes accepted in [`TransferProofJson`].
+pub const MAX_STORAGE_PROOF_NODES: usize = 1024;
+/// Maximum hex-string length of one storage-proof node.
+pub const MAX_STORAGE_PROOF_NODE_HEX_LEN: usize = 1 << 20;
+/// Maximum aggregate hex-string length across all storage-proof nodes.
+pub const MAX_STORAGE_PROOF_HEX_BYTES: usize = 1 << 20;
+/// Maximum number of Merkle indices accepted in [`TransferProofJson`].
+pub const MAX_MERKLE_INDICES: usize = 1024;
+/// Maximum byte length of the hex `state_root` string in [`TransferProofJson`].
+pub const MAX_STATE_ROOT_HEX_LEN: usize = 64;
+
 #[derive(Debug, Deserialize)]
 pub struct TransferProofJson {
     pub transfer_count: u64,
-    pub state_root: String,         // hex (no 0x)
+    #[serde(deserialize_with = "deserialize_bounded_state_root")]
+    pub state_root: String, // hex (no 0x)
+    #[serde(deserialize_with = "deserialize_bounded_storage_proof")]
     pub storage_proof: Vec<String>, // hex-encoded nodes
+    #[serde(deserialize_with = "deserialize_bounded_indices")]
     pub indices: Vec<usize>,
+}
+
+impl TransferProofJson {
+    /// Validate the decoded transfer proof bounds.
+    ///
+    /// `#[serde(deserialize_with)]` already caps each field at deserialization time;
+    /// this is a convenience check for callers that construct the struct directly.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.state_root.len() > MAX_STATE_ROOT_HEX_LEN {
+            return Err(format!(
+                "state_root exceeds {} bytes",
+                MAX_STATE_ROOT_HEX_LEN
+            ));
+        }
+        if self.storage_proof.len() > MAX_STORAGE_PROOF_NODES {
+            return Err(format!(
+                "storage_proof exceeds {} nodes",
+                MAX_STORAGE_PROOF_NODES
+            ));
+        }
+        let mut total_storage_proof_bytes = 0usize;
+        for (index, node) in self.storage_proof.iter().enumerate() {
+            if node.len() > MAX_STORAGE_PROOF_NODE_HEX_LEN {
+                return Err(format!(
+                    "storage_proof node {} exceeds {} bytes",
+                    index, MAX_STORAGE_PROOF_NODE_HEX_LEN
+                ));
+            }
+            total_storage_proof_bytes = total_storage_proof_bytes
+                .checked_add(node.len())
+                .ok_or_else(|| String::from("storage_proof total byte length overflow"))?;
+            if total_storage_proof_bytes > MAX_STORAGE_PROOF_HEX_BYTES {
+                return Err(format!(
+                    "storage_proof exceeds {} total bytes",
+                    MAX_STORAGE_PROOF_HEX_BYTES
+                ));
+            }
+        }
+        if self.indices.len() > MAX_MERKLE_INDICES {
+            return Err(format!("indices exceeds {} entries", MAX_MERKLE_INDICES));
+        }
+        Ok(())
+    }
+}
+
+/// Deserialize a hex `state_root` string, rejecting inputs longer than
+/// [`MAX_STATE_ROOT_HEX_LEN`] before allocating the owned `String`.
+fn deserialize_bounded_state_root<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StateRootVisitor;
+    impl<'de> Visitor<'de> for StateRootVisitor {
+        type Value = String;
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "a hex state_root string of at most {} bytes",
+                MAX_STATE_ROOT_HEX_LEN
+            )
+        }
+        fn visit_str<E: Error>(self, v: &str) -> Result<String, E> {
+            if v.len() > MAX_STATE_ROOT_HEX_LEN {
+                return Err(E::custom(format!(
+                    "state_root exceeds {} bytes",
+                    MAX_STATE_ROOT_HEX_LEN
+                )));
+            }
+            Ok(String::from(v))
+        }
+        fn visit_string<E: Error>(self, v: String) -> Result<String, E> {
+            if v.len() > MAX_STATE_ROOT_HEX_LEN {
+                return Err(E::custom(format!(
+                    "state_root exceeds {} bytes",
+                    MAX_STATE_ROOT_HEX_LEN
+                )));
+            }
+            Ok(v)
+        }
+    }
+    deserializer.deserialize_str(StateRootVisitor)
+}
+
+/// Deserialize a `Vec<T>` from a sequence, stopping and failing once the element
+/// count exceeds `max` so oversized inputs are rejected before the full allocation.
+fn deserialize_bounded_vec<'de, T, D>(
+    deserializer: D,
+    max: usize,
+    label: &'static str,
+) -> Result<Vec<T>, D::Error>
+where
+    T: de::Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    struct BoundedSeqVisitor<T> {
+        max: usize,
+        label: &'static str,
+        _phantom: PhantomData<T>,
+    }
+    impl<'de, T: de::Deserialize<'de>> Visitor<'de> for BoundedSeqVisitor<T> {
+        type Value = Vec<T>;
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "a sequence of at most {} items ({})",
+                self.max, self.label
+            )
+        }
+        fn visit_seq<A>(self, mut seq: A) -> Result<Vec<T>, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let cap = seq.size_hint().unwrap_or(0).min(self.max);
+            let mut out = Vec::with_capacity(cap);
+            while let Some(item) = seq.next_element()? {
+                if out.len() >= self.max {
+                    return Err(A::Error::custom(format!(
+                        "{} exceeds {} items",
+                        self.label, self.max
+                    )));
+                }
+                out.push(item);
+            }
+            Ok(out)
+        }
+    }
+    deserializer.deserialize_seq(BoundedSeqVisitor {
+        max,
+        label,
+        _phantom: PhantomData,
+    })
+}
+
+fn deserialize_bounded_storage_proof<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct BoundedStorageNode(String);
+
+    impl<'de> de::Deserialize<'de> for BoundedStorageNode {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct NodeVisitor;
+            impl Visitor<'_> for NodeVisitor {
+                type Value = BoundedStorageNode;
+
+                fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    write!(
+                        f,
+                        "a storage-proof hex string of at most {} bytes",
+                        MAX_STORAGE_PROOF_NODE_HEX_LEN
+                    )
+                }
+
+                fn visit_str<E: Error>(self, value: &str) -> Result<Self::Value, E> {
+                    if value.len() > MAX_STORAGE_PROOF_NODE_HEX_LEN {
+                        return Err(E::custom(format!(
+                            "storage_proof node exceeds {} bytes",
+                            MAX_STORAGE_PROOF_NODE_HEX_LEN
+                        )));
+                    }
+                    Ok(BoundedStorageNode(String::from(value)))
+                }
+
+                fn visit_string<E: Error>(self, value: String) -> Result<Self::Value, E> {
+                    if value.len() > MAX_STORAGE_PROOF_NODE_HEX_LEN {
+                        return Err(E::custom(format!(
+                            "storage_proof node exceeds {} bytes",
+                            MAX_STORAGE_PROOF_NODE_HEX_LEN
+                        )));
+                    }
+                    Ok(BoundedStorageNode(value))
+                }
+            }
+
+            deserializer.deserialize_str(NodeVisitor)
+        }
+    }
+
+    struct StorageProofVisitor;
+    impl<'de> Visitor<'de> for StorageProofVisitor {
+        type Value = Vec<String>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(
+                f,
+                "at most {} storage-proof nodes totaling at most {} bytes",
+                MAX_STORAGE_PROOF_NODES, MAX_STORAGE_PROOF_HEX_BYTES
+            )
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: SeqAccess<'de>,
+        {
+            let cap = seq.size_hint().unwrap_or(0).min(MAX_STORAGE_PROOF_NODES);
+            let mut out = Vec::with_capacity(cap);
+            let mut total_bytes = 0usize;
+
+            while out.len() < MAX_STORAGE_PROOF_NODES {
+                let Some(BoundedStorageNode(node)) = seq.next_element()? else {
+                    return Ok(out);
+                };
+                total_bytes = total_bytes
+                    .checked_add(node.len())
+                    .ok_or_else(|| A::Error::custom("storage_proof total byte length overflow"))?;
+                if total_bytes > MAX_STORAGE_PROOF_HEX_BYTES {
+                    return Err(A::Error::custom(format!(
+                        "storage_proof exceeds {} total bytes",
+                        MAX_STORAGE_PROOF_HEX_BYTES
+                    )));
+                }
+                out.push(node);
+            }
+
+            if seq.next_element::<de::IgnoredAny>()?.is_some() {
+                return Err(A::Error::custom(format!(
+                    "storage_proof exceeds {} items",
+                    MAX_STORAGE_PROOF_NODES
+                )));
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_seq(StorageProofVisitor)
+}
+
+fn deserialize_bounded_indices<'de, D>(deserializer: D) -> Result<Vec<usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    deserialize_bounded_vec(deserializer, MAX_MERKLE_INDICES, "indices")
 }
 
 /// Circuit config for leaf wormhole proofs (non-ZK).
@@ -80,4 +332,35 @@ pub trait CircuitFragment {
         pw: &mut PartialWitness<F>,
         targets: Self::Targets,
     ) -> anyhow::Result<()>;
+}
+
+#[cfg(test)]
+mod transfer_proof_json_tests {
+    use super::*;
+
+    #[test]
+    fn storage_proof_deserialization_rejects_oversized_node() {
+        let oversized = "a".repeat(MAX_STORAGE_PROOF_NODE_HEX_LEN + 1);
+        let json = format!(
+            r#"{{"transfer_count":1,"state_root":"00","storage_proof":["{}"],"indices":[]}}"#,
+            oversized
+        );
+        let err = serde_json::from_str::<TransferProofJson>(&json).unwrap_err();
+        assert!(err.to_string().contains("storage_proof node exceeds"));
+    }
+
+    #[test]
+    fn direct_validation_rejects_oversized_storage_proof_total() {
+        let proof = TransferProofJson {
+            transfer_count: 1,
+            state_root: String::from("00"),
+            storage_proof: vec![
+                "a".repeat(MAX_STORAGE_PROOF_HEX_BYTES / 2 + 1),
+                "b".repeat(MAX_STORAGE_PROOF_HEX_BYTES / 2 + 1),
+            ],
+            indices: vec![],
+        };
+        let err = proof.validate().unwrap_err();
+        assert!(err.contains("total bytes"));
+    }
 }

--- a/common/src/serialization.rs
+++ b/common/src/serialization.rs
@@ -21,6 +21,13 @@ use crate::circuit::F;
 
 const BIT_32_LIMB_MASK: u64 = 0xFFFF_FFFF;
 
+/// Maximum input length accepted by the public bytes<->felts serialization helpers.
+/// Bounds heap allocation for untrusted caller-supplied data so a single oversized
+/// request cannot exhaust the process (audit #97066).
+pub const MAX_SERIALIZED_BYTES: usize = 1 << 20; // 1 MiB
+/// Maximum felt count accepted by [`felts_to_bytes`].
+pub const MAX_SERIALIZED_FELTS: usize = (MAX_SERIALIZED_BYTES + BYTES_PER_FELT) / BYTES_PER_FELT;
+
 // ============================================================================
 // Internal helpers for Plonky2 GoldilocksField conversion
 // ============================================================================
@@ -110,24 +117,34 @@ pub fn try_felts_to_u64(felts: [F; FELTS_PER_U64]) -> Result<u64, String> {
 ///
 /// Uses 4 bytes per field element with a terminator marker (0x01) appended,
 /// ensuring different-length inputs always produce different field element sequences.
-pub fn bytes_to_felts(input: &[u8]) -> Vec<F> {
-    qp_poseidon_core::serialization::bytes_to_u64s(input)
+///
+/// Returns an error if `input.len()` exceeds [`MAX_SERIALIZED_BYTES`].
+pub fn bytes_to_felts(input: &[u8]) -> Result<Vec<F>, &'static str> {
+    if input.len() > MAX_SERIALIZED_BYTES {
+        return Err("bytes_to_felts: input exceeds maximum serialized length");
+    }
+    Ok(qp_poseidon_core::serialization::bytes_to_u64s(input)
         .into_iter()
         .map(from_u64)
-        .collect()
+        .collect())
 }
 
 /// Convert field elements back to variable-length bytes.
 ///
 /// Inverse of `bytes_to_felts`. Returns an error if the input doesn't have
-/// a valid terminator marker.
+/// a valid terminator marker or exceeds [`MAX_SERIALIZED_FELTS`].
 pub fn felts_to_bytes(input: &[F]) -> Result<Vec<u8>, &'static str> {
+    if input.len() > MAX_SERIALIZED_FELTS {
+        return Err("felts_to_bytes: input exceeds maximum serialized length");
+    }
     let u64s: Vec<u64> = input.iter().map(|f| to_u64(*f)).collect();
     qp_poseidon_core::serialization::u64s_to_bytes(&u64s)
 }
 
 /// Convert a string to field elements.
-pub fn string_to_felts(input: &str) -> Vec<F> {
+///
+/// Returns an error if the UTF-8 byte length exceeds [`MAX_SERIALIZED_BYTES`].
+pub fn string_to_felts(input: &str) -> Result<Vec<F>, &'static str> {
     bytes_to_felts(input.as_bytes())
 }
 
@@ -142,11 +159,18 @@ pub fn string_to_felts(input: &str) -> Vec<F> {
 ///
 /// Use this for trie node hashing where collision resistance is provided by the
 /// trie structure rather than the encoding.
-pub fn bytes_to_felts_compact(input: &[u8]) -> Vec<F> {
-    qp_poseidon_core::serialization::bytes_to_u64s_compact(input)
-        .into_iter()
-        .map(from_u64)
-        .collect()
+///
+/// Returns an error if `input.len()` exceeds [`MAX_SERIALIZED_BYTES`].
+pub fn bytes_to_felts_compact(input: &[u8]) -> Result<Vec<F>, &'static str> {
+    if input.len() > MAX_SERIALIZED_BYTES {
+        return Err("bytes_to_felts_compact: input exceeds maximum serialized length");
+    }
+    Ok(
+        qp_poseidon_core::serialization::bytes_to_u64s_compact(input)
+            .into_iter()
+            .map(from_u64)
+            .collect(),
+    )
 }
 
 // ============================================================================
@@ -222,10 +246,19 @@ mod tests {
         ];
 
         for original in test_cases {
-            let felts = bytes_to_felts(&original);
+            let felts = bytes_to_felts(&original).unwrap();
             let reconstructed = felts_to_bytes(&felts).unwrap();
             assert_eq!(original, reconstructed);
         }
+    }
+
+    #[test]
+    fn test_maximum_bytes_round_trip() {
+        let original = vec![0x5au8; MAX_SERIALIZED_BYTES];
+        let felts = bytes_to_felts(&original).unwrap();
+        assert_eq!(felts.len(), MAX_SERIALIZED_FELTS);
+        let reconstructed = felts_to_bytes(&felts).unwrap();
+        assert_eq!(reconstructed, original);
     }
 
     #[test]

--- a/common/src/utils.rs
+++ b/common/src/utils.rs
@@ -44,18 +44,18 @@ pub fn felts_to_u64(felts: [F; FELTS_PER_U64]) -> Result<u64, String> {
 }
 
 /// Encodes a string into field elements.
-pub fn string_to_felts(input: &str) -> Vec<F> {
-    serialization::string_to_felts(input)
+pub fn string_to_felts(input: &str) -> Result<Vec<F>, String> {
+    serialization::string_to_felts(input).map_err(|e| e.to_string())
 }
 
 /// Converts bytes to field elements (4 bytes/felt + terminator).
-pub fn bytes_to_felts(input: &[u8]) -> Vec<F> {
-    serialization::bytes_to_felts(input)
+pub fn bytes_to_felts(input: &[u8]) -> Result<Vec<F>, String> {
+    serialization::bytes_to_felts(input).map_err(|e| e.to_string())
 }
 
 /// Converts bytes to field elements using compact encoding (8 bytes/felt).
-pub fn bytes_to_felts_compact(input: &[u8]) -> Vec<F> {
-    serialization::bytes_to_felts_compact(input)
+pub fn bytes_to_felts_compact(input: &[u8]) -> Result<Vec<F>, String> {
+    serialization::bytes_to_felts_compact(input).map_err(|e| e.to_string())
 }
 
 /// Converts field elements back to bytes.

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -8,6 +8,7 @@
 //! - bounded proof buffers
 
 use anyhow::{anyhow, bail, Context, Result};
+use plonky2::field::types::PrimeField64;
 use plonky2::plonk::{
     circuit_data::{CommonCircuitData, VerifierCircuitData},
     proof::ProofWithPublicInputs,
@@ -29,6 +30,9 @@ use crate::{
         ensure_proof_public_input_len, ensure_verifier_data_matches_canonical, leaf_proof_asset_id,
         load_canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
         load_verifier_data_from_bytes,
+    },
+    private_batch::circuit::constants::{
+        aggregated_output, ASSET_ID_START, BLOCK_HASH_START, LEAF_PI_LEN, VOLUME_FEE_BPS_START,
     },
     private_batch::prover::PrivateBatchProver,
     CircuitBinsConfig,
@@ -53,6 +57,15 @@ pub trait AggregationBackend: Send + Sync {
 
     /// Aggregate buffered proofs into a single proof.
     fn aggregate(&mut self) -> Result<Proof>;
+
+    /// Remove and return all buffered proofs, leaving the queue empty.
+    ///
+    /// Recovery escape hatch: admission checks in `push_proof` mirror the
+    /// aggregation circuits' cross-slot constraints, but if the two ever drift
+    /// (or aggregation fails for any other deterministic reason), this lets an
+    /// operator recover the queue without dropping the backend — and requeue
+    /// any still-good proofs via `push_proof`.
+    fn drain_buffer(&mut self) -> Vec<Proof>;
 
     /// Verify an aggregated proof produced by this backend.
     fn verify(&self, _proof: Proof) -> Result<()> {
@@ -112,18 +125,145 @@ fn load_public_batch_verifier_from_bins(
     Ok(loaded)
 }
 
-/// Length-check and verify a proof against the given canonical verifier data,
-/// then queue it. Since the backends only drain their queue on successful
-/// aggregation (#97067), a single invalid proof accepted here would make every
-/// aggregate() retry fail on the same poisoned batch, wedging the aggregator
-/// permanently.
+/// Batch-consistency metadata read from a proof's public inputs.
+///
+/// Mirrors the fields the aggregation circuits constrain across a batch, so
+/// admission can reject combinations that would deterministically fail proving.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SlotMetadata {
+    asset_id: u64,
+    volume_fee_bps: u64,
+    block_hash: [u64; 4],
+}
+
+impl SlotMetadata {
+    /// Wrapper-level dummy sentinel: all-zero block hash.
+    fn is_dummy(&self) -> bool {
+        self.block_hash == [0u64; 4]
+    }
+}
+
+/// Read batch metadata from a leaf proof's public inputs.
+fn leaf_slot_metadata(proof: &Proof) -> Result<SlotMetadata> {
+    let pis = &proof.public_inputs;
+    if pis.len() != LEAF_PI_LEN {
+        bail!(
+            "leaf proof public input length mismatch: expected {}, got {}",
+            LEAF_PI_LEN,
+            pis.len()
+        );
+    }
+    Ok(SlotMetadata {
+        asset_id: pis[ASSET_ID_START].to_canonical_u64(),
+        volume_fee_bps: pis[VOLUME_FEE_BPS_START].to_canonical_u64(),
+        block_hash: core::array::from_fn(|i| pis[BLOCK_HASH_START + i].to_canonical_u64()),
+    })
+}
+
+/// Read batch metadata from a private-batch aggregated proof's public inputs.
+fn private_batch_slot_metadata(proof: &Proof) -> Result<SlotMetadata> {
+    let pis = &proof.public_inputs;
+    if pis.len() < aggregated_output::HEADER_LEN {
+        bail!(
+            "private-batch proof public inputs too short: expected at least {}, got {}",
+            aggregated_output::HEADER_LEN,
+            pis.len()
+        );
+    }
+    Ok(SlotMetadata {
+        asset_id: pis[aggregated_output::ASSET_ID_OFFSET].to_canonical_u64(),
+        volume_fee_bps: pis[aggregated_output::VOLUME_FEE_BPS_OFFSET].to_canonical_u64(),
+        block_hash: core::array::from_fn(|i| {
+            pis[aggregated_output::BLOCK_HASH_OFFSET + i].to_canonical_u64()
+        }),
+    })
+}
+
+/// Check that a new proof's batch metadata is compatible with every queued proof,
+/// mirroring the aggregation circuits' cross-slot constraints:
+///
+/// - block hash and volume_fee_bps must match between non-dummy slots
+///   (dummies are exempt in both circuits),
+/// - asset_id must match unconditionally when `asset_dummy_exempt` is false
+///   (the private-batch circuit enforces asset equality across ALL slots,
+///   dummies included), or only between non-dummies when true (the public-batch
+///   circuit exempts dummy inners).
+///
+/// NOTE: this must be kept in lockstep with the circuits' cross-slot
+/// constraints. If they drift (a new circuit constraint without a matching
+/// admission check), a stuck queue can be recovered via
+/// `AggregationBackend::drain_buffer`.
+fn ensure_batch_metadata_compatible(
+    new: &SlotMetadata,
+    queued: &[SlotMetadata],
+    asset_dummy_exempt: bool,
+    label: &str,
+) -> Result<()> {
+    for existing in queued {
+        let either_dummy = new.is_dummy() || existing.is_dummy();
+
+        if !(asset_dummy_exempt && either_dummy) && new.asset_id != existing.asset_id {
+            bail!(
+                "refusing to queue batch-incompatible {}: asset_id {} does not match \
+                 queued asset_id {} (the batch circuit enforces asset consistency)",
+                label,
+                new.asset_id,
+                existing.asset_id
+            );
+        }
+
+        if !either_dummy {
+            if new.block_hash != existing.block_hash {
+                bail!(
+                    "refusing to queue batch-incompatible {}: block_hash {:?} does not match \
+                     queued block_hash {:?} (the batch circuit enforces block consistency)",
+                    label,
+                    new.block_hash,
+                    existing.block_hash
+                );
+            }
+            if new.volume_fee_bps != existing.volume_fee_bps {
+                bail!(
+                    "refusing to queue batch-incompatible {}: volume_fee_bps {} does not match \
+                     queued volume_fee_bps {} (the batch circuit enforces fee consistency)",
+                    label,
+                    new.volume_fee_bps,
+                    existing.volume_fee_bps
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate a proof and queue it. Since the backends only drain their queue on
+/// successful aggregation (#97067), anything admitted here that would make the
+/// batch fail proving deterministically (an invalid proof, or a valid proof
+/// whose metadata the circuit's cross-slot constraints reject) would wedge the
+/// aggregator: every aggregate() retry would fail on the same poisoned batch.
+///
+/// Checks run cheapest-first: capacity, PI length, batch-metadata
+/// compatibility, then cryptographic verification.
 fn verify_and_push(
     verifier: &VerifierCircuitData<F, C, D>,
     buf: &mut ProofBuffer,
     proof: Proof,
     label: &str,
+    extract_metadata: fn(&Proof) -> Result<SlotMetadata>,
+    asset_dummy_exempt: bool,
 ) -> Result<()> {
+    if buf.is_full() {
+        bail!("proof buffer is full (capacity = {})", buf.cap());
+    }
     ensure_proof_public_input_len(&proof, verifier.common.num_public_inputs, label)?;
+
+    let new_metadata = extract_metadata(&proof)?;
+    let queued_metadata: Vec<SlotMetadata> = buf
+        .iter()
+        .map(extract_metadata)
+        .collect::<Result<Vec<_>>>()?;
+    ensure_batch_metadata_compatible(&new_metadata, &queued_metadata, asset_dummy_exempt, label)?;
+
     verifier.verify(proof.clone()).map_err(|e| {
         anyhow!(
             "refusing to queue invalid {}: verification failed: {}",
@@ -159,6 +299,14 @@ impl ProofBuffer {
 
     fn cap(&self) -> usize {
         self.cap
+    }
+
+    fn is_full(&self) -> bool {
+        self.buf.len() >= self.cap
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &Proof> {
+        self.buf.iter()
     }
 
     fn push(&mut self, proof: Proof) -> Result<()> {
@@ -236,6 +384,9 @@ impl AggregationBackend for PublicBatchAggregator {
             &mut self.buf,
             proof,
             "private-batch aggregated proof",
+            private_batch_slot_metadata,
+            // The public-batch circuit exempts dummy inners from asset checks.
+            true,
         )
     }
 
@@ -276,6 +427,10 @@ impl AggregationBackend for PublicBatchAggregator {
             let _ = self.buf.take_all();
         }
         result
+    }
+
+    fn drain_buffer(&mut self) -> Vec<Proof> {
+        self.buf.take_all()
     }
 
     fn verify(&self, proof: Proof) -> Result<()> {
@@ -351,7 +506,16 @@ impl PrivateBatchAggregator {
 
 impl AggregationBackend for PrivateBatchAggregator {
     fn push_proof(&mut self, proof: Proof) -> Result<()> {
-        verify_and_push(&self.leaf_verifier, &mut self.buf, proof, "leaf proof")
+        verify_and_push(
+            &self.leaf_verifier,
+            &mut self.buf,
+            proof,
+            "leaf proof",
+            leaf_slot_metadata,
+            // The private-batch circuit enforces asset equality across ALL
+            // slots, dummies included.
+            false,
+        )
     }
 
     fn buffer_len(&self) -> usize {
@@ -401,6 +565,10 @@ impl AggregationBackend for PrivateBatchAggregator {
         result
     }
 
+    fn drain_buffer(&mut self) -> Vec<Proof> {
+        self.buf.take_all()
+    }
+
     fn verify(&self, proof: Proof) -> Result<()> {
         self.verifier
             .verify(proof)
@@ -411,6 +579,113 @@ impl AggregationBackend for PrivateBatchAggregator {
         match circuit_type {
             CircuitType::Root => Ok(self.verifier.common.clone()),
             CircuitType::Leaf => Ok(self.leaf_verifier.common.clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn real(asset_id: u64, volume_fee_bps: u64, block: u64) -> SlotMetadata {
+        SlotMetadata {
+            asset_id,
+            volume_fee_bps,
+            block_hash: [block, 0, 0, 0],
+        }
+    }
+
+    fn dummy(asset_id: u64, volume_fee_bps: u64) -> SlotMetadata {
+        SlotMetadata {
+            asset_id,
+            volume_fee_bps,
+            block_hash: [0; 4],
+        }
+    }
+
+    #[test]
+    fn compatible_real_proofs_are_accepted() {
+        let queued = [real(0, 10, 1), real(0, 10, 1)];
+        for asset_dummy_exempt in [false, true] {
+            ensure_batch_metadata_compatible(&real(0, 10, 1), &queued, asset_dummy_exempt, "test")
+                .expect("identical metadata must be compatible");
+        }
+    }
+
+    #[test]
+    fn empty_queue_accepts_anything() {
+        ensure_batch_metadata_compatible(&real(7, 99, 3), &[], false, "test")
+            .expect("first proof in an empty queue is always compatible");
+    }
+
+    #[test]
+    fn mismatched_block_hash_between_real_proofs_is_rejected() {
+        let err =
+            ensure_batch_metadata_compatible(&real(0, 10, 2), &[real(0, 10, 1)], false, "test")
+                .expect_err("real proofs over different blocks must be rejected");
+        assert!(
+            err.to_string().contains("block_hash"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn mismatched_fee_between_real_proofs_is_rejected() {
+        let err =
+            ensure_batch_metadata_compatible(&real(0, 20, 1), &[real(0, 10, 1)], false, "test")
+                .expect_err("real proofs with different fees must be rejected");
+        assert!(
+            err.to_string().contains("volume_fee_bps"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn dummy_is_exempt_from_block_and_fee_checks() {
+        for asset_dummy_exempt in [false, true] {
+            ensure_batch_metadata_compatible(
+                &dummy(0, 999),
+                &[real(0, 10, 1)],
+                asset_dummy_exempt,
+                "test",
+            )
+            .expect("dummies are exempt from block/fee consistency");
+        }
+    }
+
+    #[test]
+    fn leaf_mode_rejects_asset_mismatch_even_for_dummies() {
+        // The private-batch circuit enforces asset equality across ALL slots,
+        // dummies included, so leaf admission must be strict.
+        let err = ensure_batch_metadata_compatible(&dummy(5, 10), &[dummy(0, 10)], false, "test")
+            .expect_err("leaf-mode asset checks must include dummies");
+        assert!(
+            err.to_string().contains("asset_id"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn public_batch_mode_exempts_dummies_from_asset_checks() {
+        // The public-batch circuit exempts dummy inners from asset consistency.
+        ensure_batch_metadata_compatible(&dummy(5, 10), &[real(0, 10, 1)], true, "test")
+            .expect("public-batch mode exempts dummies from asset checks");
+    }
+
+    #[test]
+    fn mismatched_asset_between_real_proofs_is_rejected_in_both_modes() {
+        for asset_dummy_exempt in [false, true] {
+            let err = ensure_batch_metadata_compatible(
+                &real(5, 10, 1),
+                &[real(0, 10, 1)],
+                asset_dummy_exempt,
+                "test",
+            )
+            .expect_err("real proofs with different assets must be rejected");
+            assert!(
+                err.to_string().contains("asset_id"),
+                "unexpected error: {err}"
+            );
         }
     }
 }

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -12,12 +12,15 @@ use plonky2::plonk::{
     circuit_data::{CommonCircuitData, VerifierCircuitData},
     proof::ProofWithPublicInputs,
 };
-use qp_wormhole_inputs::BytesDigest;
+use qp_wormhole_inputs::{public_batch_pi::AGGREGATOR_ADDRESS_LEN, BytesDigest};
 use std::path::{Path, PathBuf};
 
 use std::fs;
 
-use zk_circuits_common::circuit::{C, D, F};
+use zk_circuits_common::{
+    circuit::{C, D, F},
+    utils::try_4_felts_to_bytes,
+};
 
 use crate::public_batch::prover::{PublicBatchInputs, PublicBatchProver};
 use crate::{
@@ -104,7 +107,7 @@ fn load_public_batch_verifier_from_bins(
         private_batch,
         num_private_batch_proofs,
         num_leaf_proofs,
-    );
+    )?;
     ensure_verifier_data_matches_canonical(&loaded, &canonical, "public_batch")?;
     Ok(loaded)
 }
@@ -147,6 +150,14 @@ impl ProofBuffer {
     /// Take all currently buffered proofs (clears buffer).
     fn take_all(&mut self) -> Vec<Proof> {
         std::mem::take(&mut self.buf)
+    }
+
+    /// Clone all currently buffered proofs without clearing the buffer.
+    ///
+    /// Used by the aggregation backends to attempt commit/prove over a copy so
+    /// that a failed aggregation leaves the queued proofs intact (#97067).
+    fn clone_all(&self) -> Vec<Proof> {
+        self.buf.clone()
     }
 }
 
@@ -219,26 +230,52 @@ impl AggregationBackend for PublicBatchAggregator {
             bail!("there are no private-batch proofs to aggregate");
         }
 
-        // Partial batches are fine: PublicBatchProver::commit pads with the dummy
-        // private-batch proof template (no shuffle - forwarding stays order-preserving
-        // so the chain can attribute each segment to its inner proof).
-        let batch = self.buf.take_all();
+        // Aggregate over a clone of the queue so a failed commit/prove leaves the
+        // queued proofs intact for retry instead of dropping them (#97067).
+        let batch = self.buf.clone_all();
 
-        // Load the public-batch prover
+        // Load the public-batch prover (failures here don't touch the queue).
         let prover = PublicBatchProver::new_from_binaries_dir(&self.bins_dir)
             .context("failed to load prebuilt public-batch prover")?;
 
-        let prover = prover
+        // Partial batches are fine: PublicBatchProver::commit pads with the dummy
+        // private-batch proof template (no shuffle - forwarding stays order-preserving
+        // so the chain can attribute each segment to its inner proof).
+        let result = prover
             .commit(PublicBatchInputs {
                 proofs: batch,
                 aggregator_address: self.aggregator_address,
             })
-            .context("failed to commit private-batch proofs to public-batch prover")?;
+            .context("failed to commit private-batch proofs to public-batch prover")
+            .and_then(|committed| committed.prove().context("public-batch proving failed"));
 
-        prover.prove().context("public-batch proving failed")
+        if result.is_ok() {
+            // Only drain the queue once aggregation fully succeeds.
+            let _ = self.buf.take_all();
+        }
+        result
     }
 
     fn verify(&self, proof: Proof) -> Result<()> {
+        // Bind the proof's exposed aggregator address to the configured one before
+        // accepting it: the public-batch circuit exposes the address as a public
+        // input, so without this check a valid proof produced under a different
+        // aggregator identity would be accepted here (#96981).
+        ensure_proof_public_input_len(
+            &proof,
+            self.verifier.common.num_public_inputs,
+            "public-batch proof",
+        )?;
+        let proof_aggregator_address =
+            try_4_felts_to_bytes(&proof.public_inputs[..AGGREGATOR_ADDRESS_LEN])
+                .context("failed to parse public-batch aggregator address from proof")?;
+        if proof_aggregator_address != self.aggregator_address {
+            bail!(
+                "public-batch proof aggregator address {:?} does not match configured aggregator address {:?}",
+                proof_aggregator_address,
+                self.aggregator_address
+            );
+        }
         self.verifier
             .verify(proof)
             .map_err(|e| anyhow!("public-batch aggregated proof verification failed: {}", e))
@@ -309,11 +346,14 @@ impl AggregationBackend for PrivateBatchAggregator {
             bail!("there are no leaf proofs to aggregate");
         }
 
+        // Aggregate over a clone of the queue so a failed preflight/commit/prove
+        // leaves the queued proofs intact for retry instead of dropping them (#97067).
+        let proofs = self.buf.clone_all();
+
         // Private-batch prover commit does padding/shuffling/dummy-nullifier-preimage handling,
         // so we can pass any non-empty batch. The wrapper's same-block / same-asset invariants are
         // intentional protocol rules and remain enforced in-circuit; this preflight only rejects
         // malformed or dummy-padding-incompatible inputs earlier.
-        let proofs = self.buf.take_all();
         if proofs.len() < self.batch_size() {
             for (idx, proof) in proofs.iter().enumerate() {
                 let asset_id = leaf_proof_asset_id(proof)?;
@@ -328,11 +368,16 @@ impl AggregationBackend for PrivateBatchAggregator {
         }
 
         let prover = self.build_prover()?;
-        let prover = prover
+        let result = prover
             .commit(proofs)
-            .context("failed to commit leaf proofs to private-batch aggregation prover")?;
+            .context("failed to commit leaf proofs to private-batch aggregation prover")
+            .and_then(|committed| committed.prove().context("private-batch proving failed"));
 
-        prover.prove().context("private-batch proving failed")
+        if result.is_ok() {
+            // Only drain the queue once aggregation fully succeeds.
+            let _ = self.buf.take_all();
+        }
+        result
     }
 
     fn verify(&self, proof: Proof) -> Result<()> {

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -112,6 +112,28 @@ fn load_public_batch_verifier_from_bins(
     Ok(loaded)
 }
 
+/// Length-check and verify a proof against the given canonical verifier data,
+/// then queue it. Since the backends only drain their queue on successful
+/// aggregation (#97067), a single invalid proof accepted here would make every
+/// aggregate() retry fail on the same poisoned batch, wedging the aggregator
+/// permanently.
+fn verify_and_push(
+    verifier: &VerifierCircuitData<F, C, D>,
+    buf: &mut ProofBuffer,
+    proof: Proof,
+    label: &str,
+) -> Result<()> {
+    ensure_proof_public_input_len(&proof, verifier.common.num_public_inputs, label)?;
+    verifier.verify(proof.clone()).map_err(|e| {
+        anyhow!(
+            "refusing to queue invalid {}: verification failed: {}",
+            label,
+            e
+        )
+    })?;
+    buf.push(proof)
+}
+
 /// A small bounded buffer helper so the backends don't duplicate capacity checks / draining logic.
 #[derive(Debug)]
 struct ProofBuffer {
@@ -209,24 +231,12 @@ impl PublicBatchAggregator {
 
 impl AggregationBackend for PublicBatchAggregator {
     fn push_proof(&mut self, proof: Proof) -> Result<()> {
-        ensure_proof_public_input_len(
-            &proof,
-            self.private_batch_verifier.common.num_public_inputs,
+        verify_and_push(
+            &self.private_batch_verifier,
+            &mut self.buf,
+            proof,
             "private-batch aggregated proof",
-        )?;
-        // Verify the proof before queuing it. Since the queue is only drained on
-        // successful aggregation (#97067), a single invalid proof accepted here
-        // would otherwise make every aggregate() retry fail on the same poisoned
-        // batch, wedging the aggregator permanently.
-        self.private_batch_verifier
-            .verify(proof.clone())
-            .map_err(|e| {
-                anyhow!(
-                    "refusing to queue invalid private-batch proof: verification failed: {}",
-                    e
-                )
-            })?;
-        self.buf.push(proof)
+        )
     }
 
     fn buffer_len(&self) -> usize {
@@ -341,22 +351,7 @@ impl PrivateBatchAggregator {
 
 impl AggregationBackend for PrivateBatchAggregator {
     fn push_proof(&mut self, proof: Proof) -> Result<()> {
-        ensure_proof_public_input_len(
-            &proof,
-            self.leaf_verifier.common.num_public_inputs,
-            "leaf proof",
-        )?;
-        // Verify the proof before queuing it. Since the queue is only drained on
-        // successful aggregation (#97067), a single invalid proof accepted here
-        // would otherwise make every aggregate() retry fail on the same poisoned
-        // batch, wedging the aggregator permanently.
-        self.leaf_verifier.verify(proof.clone()).map_err(|e| {
-            anyhow!(
-                "refusing to queue invalid leaf proof: verification failed: {}",
-                e
-            )
-        })?;
-        self.buf.push(proof)
+        verify_and_push(&self.leaf_verifier, &mut self.buf, proof, "leaf proof")
     }
 
     fn buffer_len(&self) -> usize {

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -169,8 +169,8 @@ pub struct PublicBatchAggregator {
     bins_dir: PathBuf,
     aggregator_address: BytesDigest,
     buf: ProofBuffer,
-    /// Canonical-pinned private-batch common data (inner proofs), loaded once at construction.
-    private_batch_common: CommonCircuitData<F, D>,
+    /// Canonical-pinned private-batch verifier data (inner proofs), loaded once at construction.
+    private_batch_verifier: VerifierCircuitData<F, C, D>,
     /// Canonical-pinned public-batch verifier data, loaded once at construction.
     verifier: VerifierCircuitData<F, C, D>,
 }
@@ -201,7 +201,7 @@ impl PublicBatchAggregator {
             bins_dir,
             aggregator_address,
             buf: ProofBuffer::new(num_private_batch_proofs),
-            private_batch_common: private_batch.common,
+            private_batch_verifier: private_batch,
             verifier,
         })
     }
@@ -211,9 +211,21 @@ impl AggregationBackend for PublicBatchAggregator {
     fn push_proof(&mut self, proof: Proof) -> Result<()> {
         ensure_proof_public_input_len(
             &proof,
-            self.private_batch_common.num_public_inputs,
+            self.private_batch_verifier.common.num_public_inputs,
             "private-batch aggregated proof",
         )?;
+        // Verify the proof before queuing it. Since the queue is only drained on
+        // successful aggregation (#97067), a single invalid proof accepted here
+        // would otherwise make every aggregate() retry fail on the same poisoned
+        // batch, wedging the aggregator permanently.
+        self.private_batch_verifier
+            .verify(proof.clone())
+            .map_err(|e| {
+                anyhow!(
+                    "refusing to queue invalid private-batch proof: verification failed: {}",
+                    e
+                )
+            })?;
         self.buf.push(proof)
     }
 
@@ -284,7 +296,7 @@ impl AggregationBackend for PublicBatchAggregator {
     fn load_common_data(&self, circuit_type: CircuitType) -> Result<CommonCircuitData<F, D>> {
         match circuit_type {
             CircuitType::Root => Ok(self.verifier.common.clone()),
-            CircuitType::Leaf => Ok(self.private_batch_common.clone()),
+            CircuitType::Leaf => Ok(self.private_batch_verifier.common.clone()),
         }
     }
 }
@@ -296,8 +308,8 @@ impl AggregationBackend for PublicBatchAggregator {
 pub struct PrivateBatchAggregator {
     bins_dir: PathBuf,
     buf: ProofBuffer,
-    /// Canonical-pinned leaf common data, loaded once at construction.
-    leaf_common: CommonCircuitData<F, D>,
+    /// Canonical-pinned leaf verifier data, loaded once at construction.
+    leaf_verifier: VerifierCircuitData<F, C, D>,
     /// Canonical-pinned private-batch verifier data, loaded once at construction.
     verifier: VerifierCircuitData<F, C, D>,
 }
@@ -316,7 +328,7 @@ impl PrivateBatchAggregator {
         Ok(Self {
             bins_dir,
             buf: ProofBuffer::new(num_leaf_proofs),
-            leaf_common: leaf.common,
+            leaf_verifier: leaf,
             verifier,
         })
     }
@@ -329,7 +341,21 @@ impl PrivateBatchAggregator {
 
 impl AggregationBackend for PrivateBatchAggregator {
     fn push_proof(&mut self, proof: Proof) -> Result<()> {
-        ensure_proof_public_input_len(&proof, self.leaf_common.num_public_inputs, "leaf proof")?;
+        ensure_proof_public_input_len(
+            &proof,
+            self.leaf_verifier.common.num_public_inputs,
+            "leaf proof",
+        )?;
+        // Verify the proof before queuing it. Since the queue is only drained on
+        // successful aggregation (#97067), a single invalid proof accepted here
+        // would otherwise make every aggregate() retry fail on the same poisoned
+        // batch, wedging the aggregator permanently.
+        self.leaf_verifier.verify(proof.clone()).map_err(|e| {
+            anyhow!(
+                "refusing to queue invalid leaf proof: verification failed: {}",
+                e
+            )
+        })?;
         self.buf.push(proof)
     }
 
@@ -389,7 +415,7 @@ impl AggregationBackend for PrivateBatchAggregator {
     fn load_common_data(&self, circuit_type: CircuitType) -> Result<CommonCircuitData<F, D>> {
         match circuit_type {
             CircuitType::Root => Ok(self.verifier.common.clone()),
-            CircuitType::Leaf => Ok(self.leaf_common.clone()),
+            CircuitType::Leaf => Ok(self.leaf_verifier.common.clone()),
         }
     }
 }

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -9,6 +9,7 @@ use plonky2::{
     },
     util::serialization::DefaultGateSerializer,
 };
+use qp_wormhole_inputs::validate_proof_count;
 use wormhole_circuit::circuit::circuit_logic::WormholeCircuit;
 use zk_circuits_common::circuit::{
     wormhole_leaf_circuit_config, wormhole_private_batch_circuit_config,
@@ -61,7 +62,7 @@ pub fn load_canonical_private_batch_verifier_data(
     num_leaf_proofs: usize,
 ) -> Result<VerifierCircuitData<F, C, D>> {
     let loaded = load_verifier_data_from_bytes(common_bytes, verifier_only_bytes, "private_batch")?;
-    let canonical = canonical_private_batch_verifier_data(leaf, num_leaf_proofs);
+    let canonical = canonical_private_batch_verifier_data(leaf, num_leaf_proofs)?;
     ensure_verifier_data_matches_canonical(&loaded, &canonical, "private_batch")?;
     Ok(loaded)
 }
@@ -147,29 +148,29 @@ pub fn canonical_leaf_verifier_data() -> VerifierCircuitData<F, C, D> {
 pub fn canonical_private_batch_verifier_data(
     leaf: &VerifierCircuitData<F, C, D>,
     num_leaf_proofs: usize,
-) -> VerifierCircuitData<F, C, D> {
-    PrivateBatchCircuit::new(
+) -> Result<VerifierCircuitData<F, C, D>> {
+    Ok(PrivateBatchCircuit::new(
         wormhole_private_batch_circuit_config(),
         &leaf.common,
         &leaf.verifier_only,
         num_leaf_proofs,
-    )
-    .build_verifier()
+    )?
+    .build_verifier())
 }
 
 pub fn canonical_public_batch_verifier_data(
     private_batch: &VerifierCircuitData<F, C, D>,
     num_private_batch_proofs: usize,
     num_leaf_proofs: usize,
-) -> VerifierCircuitData<F, C, D> {
-    PublicBatchCircuit::new(
+) -> Result<VerifierCircuitData<F, C, D>> {
+    Ok(PublicBatchCircuit::new(
         wormhole_public_batch_circuit_config(),
         private_batch.common.clone(),
         &private_batch.verifier_only,
         num_private_batch_proofs,
         num_leaf_proofs,
-    )
-    .build_verifier()
+    )?
+    .build_verifier())
 }
 
 pub fn ensure_proof_public_input_len(
@@ -218,12 +219,7 @@ pub fn private_batch_num_leaves_from_padded_pi_len(pi_len: usize) -> Result<usiz
     }
 
     let num_leaves = payload_len / LEAF_PI_LEN;
-    if num_leaves == 0 {
-        return Err(anyhow!(
-            "private-batch aggregated public input length {} encodes zero leaves",
-            pi_len
-        ));
-    }
+    validate_proof_count(num_leaves, "private-batch num_leaves")?;
 
     Ok(num_leaves)
 }

--- a/wormhole/aggregator/src/config.rs
+++ b/wormhole/aggregator/src/config.rs
@@ -1,17 +1,18 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
+pub use qp_wormhole_inputs::validate_proof_count;
 use serde::{Deserialize, Serialize};
 use std::fs::write;
 use std::path::Path;
 
-/// Maximum allowed proof count to prevent excessive memory/CPU consumption.
-/// This is a reasonable upper bound - aggregating more than 1024 proofs per layer
-/// would result in impractically large circuits.
+/// Maximum number of proofs aggregated per layer.
 ///
-/// In practice, even ~64 proofs is near the practical limit on commodity hardware
-/// (current benches test up to 49). The 1024 cap is "obviously safe" headroom.
-/// Any future need to raise this limit would require a coordinated artifact
-/// regeneration across all deployments.
-pub const MAX_PROOF_COUNT: usize = 1024;
+/// Re-exported from `qp_wormhole_inputs` (the single source of truth) so every
+/// build/parse entry point applies the same bound. Lowered from the previous
+/// 1024 headroom to the documented practical per-layer limit (benches currently
+/// exercise up to 49 proofs): accepting the old 1024 cap let a single valid
+/// artifact-generation request drive circuit construction whose work scales
+/// quadratically/multiplicatively with the count (audit #97021).
+pub use qp_wormhole_inputs::MAX_PROOF_COUNT;
 
 /// Configuration stored alongside circuit binaries (config.json).
 /// This struct is used by both circuit-builder (to save config) and
@@ -44,29 +45,11 @@ impl CircuitBinsConfig {
     /// Validate the config values.
     ///
     /// # Errors
-    /// Returns an error if proof counts are zero or exceed reasonable bounds.
+    /// Returns an error if proof counts are zero or exceed `MAX_PROOF_COUNT`.
     pub fn validate(&self) -> Result<()> {
-        if self.num_leaf_proofs == 0 {
-            bail!("num_leaf_proofs must be > 0");
-        }
-        if self.num_leaf_proofs > MAX_PROOF_COUNT {
-            bail!(
-                "num_leaf_proofs ({}) exceeds maximum allowed ({})",
-                self.num_leaf_proofs,
-                MAX_PROOF_COUNT
-            );
-        }
+        validate_proof_count(self.num_leaf_proofs, "num_leaf_proofs")?;
         if let Some(n) = self.num_private_batch_proofs {
-            if n == 0 {
-                bail!("num_private_batch_proofs must be > 0 when specified");
-            }
-            if n > MAX_PROOF_COUNT {
-                bail!(
-                    "num_private_batch_proofs ({}) exceeds maximum allowed ({})",
-                    n,
-                    MAX_PROOF_COUNT
-                );
-            }
+            validate_proof_count(n, "num_private_batch_proofs")?;
         }
         Ok(())
     }

--- a/wormhole/aggregator/src/lib.rs
+++ b/wormhole/aggregator/src/lib.rs
@@ -8,7 +8,7 @@ pub mod public_batch;
 #[cfg(feature = "profile")]
 pub mod profile;
 
-pub use config::{CircuitBinsConfig, MAX_PROOF_COUNT};
+pub use config::{validate_proof_count, CircuitBinsConfig, MAX_PROOF_COUNT};
 pub use dummy_proof::{
     build_dummy_circuit_inputs, generate_dummy_proof, DUMMY_BLOCK_HASH, DUMMY_EXIT_ACCOUNT,
 };

--- a/wormhole/aggregator/src/private_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/build.rs
@@ -9,6 +9,7 @@ use plonky2::{
     plonk::circuit_data::{CommonCircuitData, VerifierOnlyCircuitData},
     util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer},
 };
+use qp_wormhole_inputs::validate_proof_count;
 use std::{
     fs::{create_dir_all, write},
     path::Path,
@@ -24,6 +25,8 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     include_prover: bool,
 ) -> Result<()> {
     let output_path = output_dir.as_ref();
+    // Bound the per-layer count before any circuit construction (#97021, #97070).
+    validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
     create_dir_all(output_path)?;
 
     println!(
@@ -39,7 +42,7 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
         &leaf_common,
         &leaf_verifier_only,
         num_leaf_proofs,
-    );
+    )?;
 
     let agg_targets = agg_circuit.targets();
     let circuit_data = agg_circuit.build_circuit();

--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -11,6 +11,7 @@
 //! The leaf verifier key is baked in as constants at circuit build time to prevent
 //! verifier key substitution attacks.
 
+use anyhow::Result;
 use plonky2::{
     field::types::Field,
     hash::poseidon2::Poseidon2Hash,
@@ -24,6 +25,7 @@ use plonky2::{
         proof::ProofWithPublicInputsTarget,
     },
 };
+use qp_wormhole_inputs::validate_proof_count;
 
 use zk_circuits_common::{
     circuit::{C, D, F},
@@ -56,13 +58,14 @@ impl PrivateBatchCircuit {
     /// Build a monolithic private-batch aggregation circuit that verifies `n_leaf` wormhole leaf proofs.
     ///
     /// The `leaf_verifier_only` is baked in as constants to prevent verifier key substitution.
+    /// Returns an error when `n_leaf` is outside the supported range.
     pub fn new(
         config: CircuitConfig,
         leaf_common: &CommonCircuitData<F, D>,
         leaf_verifier_only: &VerifierOnlyCircuitData<C, D>,
         n_leaf: usize,
-    ) -> Self {
-        assert!(n_leaf > 0, "n_leaf must be > 0");
+    ) -> Result<Self> {
+        validate_proof_count(n_leaf, "n_leaf")?;
 
         let mut builder = CircuitBuilder::<F, D>::new(config);
 
@@ -92,7 +95,7 @@ impl PrivateBatchCircuit {
         // Build the wormhole-specific wrapper logic directly in this circuit.
         build_private_batch_constraints(&mut builder, &targets, n_leaf);
 
-        Self { builder, targets }
+        Ok(Self { builder, targets })
     }
 
     pub fn targets(&self) -> PrivateBatchCircuitTargets {
@@ -453,7 +456,7 @@ mod tests {
             &leaf_common,
             &leaf_verifier_only,
             n_leaf,
-        );
+        )?;
         let targets = agg_circuit.targets();
         let prover_data = agg_circuit.build_prover();
 
@@ -466,7 +469,7 @@ mod tests {
         // Build verifier data from the same config/leaf common so we can verify the result.
         // NOTE: Must use the same leaf_verifier_only to get matching circuit digest
         let verifier_data =
-            PrivateBatchCircuit::new(agg_config, &leaf_common, &leaf_verifier_only, n_leaf)
+            PrivateBatchCircuit::new(agg_config, &leaf_common, &leaf_verifier_only, n_leaf)?
                 .build_verifier();
 
         Ok((agg_proof, verifier_data))
@@ -1613,7 +1616,8 @@ mod tests {
             &legit_circuit.common,
             &legit_circuit.verifier_only, // SECURITY: Baked as constants
             1,
-        );
+        )
+        .unwrap();
         let private_batch_targets = private_batch_circuit.targets();
         let private_batch_data = private_batch_circuit.build_circuit();
 
@@ -1672,7 +1676,8 @@ mod tests {
             &legit_circuit.common,
             &legit_circuit.verifier_only,
             1,
-        );
+        )
+        .unwrap();
         let private_batch_targets = private_batch_circuit.targets();
         let private_batch_data = private_batch_circuit.build_circuit();
 

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -67,7 +67,7 @@ impl PrivateBatchProver {
         num_leaf_proofs: usize,
         dummy_proof_template: ProofWithPublicInputs<F, C, D>,
     ) -> Result<Self> {
-        validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
+        // Proof-count bounds are enforced by PrivateBatchCircuit::new.
         let agg_circuit = PrivateBatchCircuit::new(
             agg_circuit_config,
             &leaf_common,

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -24,6 +24,7 @@ use rand::seq::SliceRandom;
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
 
+use qp_wormhole_inputs::validate_proof_count;
 use zk_circuits_common::{
     circuit::{wormhole_private_batch_circuit_config, C, D, F},
     utils::bytes_to_digest,
@@ -36,7 +37,10 @@ use crate::{
     },
     dummy_proof::{generate_random_nullifier_preimage, load_dummy_proof},
     private_batch::{
-        circuit::circuit_logic::{PrivateBatchCircuit, PrivateBatchCircuitTargets},
+        circuit::{
+            circuit_logic::{PrivateBatchCircuit, PrivateBatchCircuitTargets},
+            constants::LEAF_PI_LEN,
+        },
         prover::witness::fill_private_batch_witness,
     },
 };
@@ -54,30 +58,32 @@ impl PrivateBatchProver {
     /// Build a fresh private-batch aggregation prover from circuit definitions.
     ///
     /// In production, prefer `new_from_binaries_dir(...)` to load prebuilt circuits.
+    /// Returns an error when `num_leaf_proofs` is outside the supported range.
     pub fn new(
         agg_circuit_config: CircuitConfig,
         leaf_common: CommonCircuitData<F, D>,
         leaf_verifier_only: &VerifierOnlyCircuitData<C, D>,
         num_leaf_proofs: usize,
         dummy_proof_template: ProofWithPublicInputs<F, C, D>,
-    ) -> Self {
+    ) -> Result<Self> {
+        validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
         let agg_circuit = PrivateBatchCircuit::new(
             agg_circuit_config,
             &leaf_common,
             leaf_verifier_only,
             num_leaf_proofs,
-        );
+        )?;
 
         let targets = Some(agg_circuit.targets());
         let circuit_data = agg_circuit.build_prover();
 
-        Self {
+        Ok(Self {
             circuit_data,
             partial_witness: PartialWitness::new(),
             targets,
             num_leaf_proofs,
             dummy_proof_template,
-        }
+        })
     }
 
     /// Create a private-batch aggregation prover from serialized bytes.
@@ -102,6 +108,11 @@ impl PrivateBatchProver {
             _phantom: Default::default(),
         };
 
+        // Validate the batch count at the public byte-loading boundary so a zero
+        // or oversized count returns an error instead of panicking inside the
+        // circuit builder (#97027, #97070).
+        validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
+
         // 1) Load and pin leaf verifier data to the canonical Wormhole leaf circuit.
         let leaf_verifier_data =
             load_canonical_leaf_verifier_data(leaf_common_bytes, leaf_verifier_only_bytes)?;
@@ -113,7 +124,7 @@ impl PrivateBatchProver {
             &leaf_verifier_data.common,
             &leaf_verifier_data.verifier_only,
             num_leaf_proofs,
-        );
+        )?;
         let targets = Some(circuit.targets());
         let canonical_agg = circuit.build_verifier();
 
@@ -239,10 +250,28 @@ impl PrivateBatchProver {
             );
         }
 
-        // If we're going to pad with dummy proofs (asset_id = 0), ensure real proofs are asset_id=0.
+        // If we're going to pad with dummy proofs (asset_id = 0), real proofs must
+        // also use asset_id = 0 because the private-batch circuit enforces asset_id
+        // equality across all proofs.
         let num_dummies_needed = self.num_leaf_proofs.saturating_sub(proofs.len());
-        if num_dummies_needed > 0 {
-            assert_dummy_padding_asset_id_compatible(&proofs)?;
+
+        // Validate every real proof's public-input length up front, regardless of
+        // whether padding is needed, so a malformed full batch is rejected at the
+        // API boundary instead of panicking inside witness assignment (#97073).
+        for (idx, proof) in proofs.iter().enumerate() {
+            ensure_proof_public_input_len(proof, LEAF_PI_LEN, "leaf proof")?;
+            if num_dummies_needed > 0 {
+                let real_asset_id =
+                    leaf_proof_asset_id(proof).map_err(|e| anyhow!("leaf proof {}: {}", idx, e))?;
+                if real_asset_id != 0 {
+                    bail!(
+                        "real proof {} has asset_id={}, but dummy proofs use asset_id=0. \
+                         All proofs must have the same asset_id for aggregation when padding is required.",
+                        idx,
+                        real_asset_id
+                    );
+                }
+            }
         }
 
         // Pad with dummy proofs
@@ -283,32 +312,6 @@ impl PrivateBatchProver {
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
-
-/// If we're padding with dummy proofs (`asset_id = 0`), real proofs must also use `asset_id = 0`
-/// because the private-batch circuit enforces asset_id equality across all proofs.
-fn assert_dummy_padding_asset_id_compatible(
-    proofs: &[ProofWithPublicInputs<F, C, D>],
-) -> Result<()> {
-    for (idx, proof) in proofs.iter().enumerate() {
-        ensure_proof_public_input_len(
-            proof,
-            crate::private_batch::circuit::constants::LEAF_PI_LEN,
-            "leaf proof",
-        )?;
-        let real_asset_id = leaf_proof_asset_id(proof)?;
-
-        if real_asset_id != 0 {
-            bail!(
-                "real proof {} has asset_id={}, but dummy proofs use asset_id=0. \
-                 All proofs must have the same asset_id for aggregation when padding is required.",
-                idx,
-                real_asset_id
-            );
-        }
-    }
-
-    Ok(())
-}
 
 /// Generate a dummy nullifier preimage for every slot.
 ///

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -9,11 +9,12 @@
 
 use anyhow::{anyhow, bail, Context, Result};
 use plonky2::{
+    field::types::PrimeField64,
     iop::witness::PartialWitness,
     plonk::{
         circuit_data::{
             CircuitConfig, CommonCircuitData, ProverCircuitData, ProverOnlyCircuitData,
-            VerifierOnlyCircuitData,
+            VerifierCircuitData, VerifierOnlyCircuitData,
         },
         proof::ProofWithPublicInputs,
     },
@@ -24,7 +25,7 @@ use rand::seq::SliceRandom;
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
 
-use qp_wormhole_inputs::validate_proof_count;
+use qp_wormhole_inputs::{validate_proof_count, BytesDigest, PublicCircuitInputs};
 use zk_circuits_common::{
     circuit::{wormhole_private_batch_circuit_config, C, D, F},
     utils::bytes_to_digest,
@@ -145,6 +146,12 @@ impl PrivateBatchProver {
         let dummy_proof_template =
             load_dummy_proof(dummy_proof_bytes.to_vec(), &leaf_verifier_data.common)
                 .map_err(|e| anyhow!("failed to deserialize dummy proof: {}", e))?;
+
+        // Verify the template is a valid leaf proof carrying the strong dummy
+        // sentinel (zero block hash AND zero outputs), so a poisoned padding
+        // template cannot inject a real payout into every partial batch. This
+        // mirrors the public-batch template check (#97026).
+        verify_dummy_leaf_template(&dummy_proof_template, &leaf_verifier_data)?;
 
         Ok(Self {
             circuit_data: ProverCircuitData {
@@ -313,6 +320,51 @@ impl PrivateBatchProver {
 // Helpers
 // -----------------------------------------------------------------------------
 
+/// Verify that the dummy leaf proof template is a valid leaf proof carrying the
+/// strong dummy sentinel: `block_hash == 0` AND both output amounts zero.
+///
+/// The private-batch circuit only treats `block_hash == 0` slots as dummies, and
+/// its exit-dedup gadget sums output amounts across matching exit accounts. If a
+/// poisoned `dummy_proof.bin` contained a *real* proof (non-zero block hash or
+/// outputs), every empty slot in a partial batch would replay that payout. This
+/// mirrors `verify_dummy_private_batch_template` at the public-batch layer (#97026).
+fn verify_dummy_leaf_template(
+    template: &ProofWithPublicInputs<F, C, D>,
+    leaf_verifier: &VerifierCircuitData<F, C, D>,
+) -> Result<()> {
+    // Check the sentinel first (cheap, and independently testable); a template
+    // is only acceptable if BOTH the sentinel and cryptographic verification pass.
+    let u64s: Vec<u64> = template
+        .public_inputs
+        .iter()
+        .map(|f| f.to_canonical_u64())
+        .collect();
+    let pis = PublicCircuitInputs::try_from_u64_slice(&u64s)
+        .context("failed to parse dummy leaf proof template public inputs")?;
+
+    if pis.block_hash != BytesDigest::default() {
+        bail!(
+            "dummy leaf proof template has non-zero block_hash {:?}; \
+             padding templates must carry the all-zero block-hash sentinel",
+            pis.block_hash
+        );
+    }
+    if pis.output_amount_1 != 0 || pis.output_amount_2 != 0 {
+        bail!(
+            "dummy leaf proof template has non-zero output amounts ({}, {}); \
+             padding templates must contribute zero to every exit slot",
+            pis.output_amount_1,
+            pis.output_amount_2
+        );
+    }
+
+    leaf_verifier
+        .verify(template.clone())
+        .map_err(|e| anyhow!("dummy leaf proof template failed verification: {}", e))?;
+
+    Ok(())
+}
+
 /// Generate a dummy nullifier preimage for every slot.
 ///
 /// The private-batch circuit hashes these for dummy slots (`block_hash == 0`) and ignores them
@@ -321,4 +373,63 @@ fn generate_dummy_nullifier_pre_images_for_slots(n_slots: usize) -> Vec<[F; 4]> 
     (0..n_slots)
         .map(|_| bytes_to_digest(generate_random_nullifier_preimage()))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use plonky2::field::types::Field;
+    use qp_wormhole_inputs::{
+        BLOCK_HASH_START_INDEX, NULLIFIER_START_INDEX, OUTPUT_AMOUNT_1_INDEX,
+        PUBLIC_INPUTS_FELTS_LEN,
+    };
+    use test_helpers::fake_leaf::{build_fake_leaf_circuit, prove_fake_leaf};
+
+    #[test]
+    fn dummy_template_with_zero_sentinel_is_accepted() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let template = prove_fake_leaf(&leaf, &targets, [F::ZERO; PUBLIC_INPUTS_FELTS_LEN]);
+        verify_dummy_leaf_template(&template, &leaf.verifier_data())
+            .expect("all-zero sentinel template must be accepted");
+    }
+
+    #[test]
+    fn dummy_template_with_nonzero_block_hash_is_rejected() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let mut pis = [F::ZERO; PUBLIC_INPUTS_FELTS_LEN];
+        pis[BLOCK_HASH_START_INDEX] = F::ONE;
+        let template = prove_fake_leaf(&leaf, &targets, pis);
+        let err = verify_dummy_leaf_template(&template, &leaf.verifier_data()).unwrap_err();
+        assert!(
+            err.to_string().contains("non-zero block_hash"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn dummy_template_with_nonzero_payout_is_rejected() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let mut pis = [F::ZERO; PUBLIC_INPUTS_FELTS_LEN];
+        pis[OUTPUT_AMOUNT_1_INDEX] = F::from_canonical_u32(5);
+        let template = prove_fake_leaf(&leaf, &targets, pis);
+        let err = verify_dummy_leaf_template(&template, &leaf.verifier_data()).unwrap_err();
+        assert!(
+            err.to_string().contains("non-zero output amounts"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn dummy_template_failing_cryptographic_verification_is_rejected() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let mut template = prove_fake_leaf(&leaf, &targets, [F::ZERO; PUBLIC_INPUTS_FELTS_LEN]);
+        // Sentinel-neutral mutation (nullifier felt): the sentinel checks pass but
+        // the proof no longer verifies against its mutated public inputs.
+        template.public_inputs[NULLIFIER_START_INDEX] = F::ONE;
+        let err = verify_dummy_leaf_template(&template, &leaf.verifier_data()).unwrap_err();
+        assert!(
+            err.to_string().contains("failed verification"),
+            "got: {err}"
+        );
+    }
 }

--- a/wormhole/aggregator/src/profile.rs
+++ b/wormhole/aggregator/src/profile.rs
@@ -74,7 +74,8 @@ mod tests {
                 &leaf_common,
                 &leaf_verifier_only,
                 num_leaves,
-            );
+            )
+            .unwrap();
 
             // Print gate counts before building
             println!("Gates before build: {}", private_batch_circuit.num_gates());
@@ -121,7 +122,8 @@ mod tests {
             &leaf_data.common,
             &leaf_data.verifier_only,
             private_batch_num_leaves,
-        );
+        )
+        .unwrap();
         let private_batch_data = private_batch_circuit.build_circuit();
         let private_batch_common = private_batch_data.common.clone();
         let private_batch_verifier_only = private_batch_data.verifier_only.clone();
@@ -147,7 +149,8 @@ mod tests {
                 &private_batch_verifier_only,
                 num_l0_proofs,
                 private_batch_num_leaves,
-            );
+            )
+            .unwrap();
 
             // Print gate counts before building
             println!("Gates before build: {}", public_batch_circuit.num_gates());
@@ -206,7 +209,8 @@ mod tests {
                 &leaf_common,
                 &leaf_verifier_only,
                 num_leaves,
-            );
+            )
+            .unwrap();
             let private_batch_data = private_batch_circuit.build_circuit();
 
             println!(

--- a/wormhole/aggregator/src/public_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/build.rs
@@ -13,6 +13,7 @@ use plonky2::plonk::circuit_data::{
 };
 use plonky2::util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer};
 
+use qp_wormhole_inputs::validate_proof_count;
 use zk_circuits_common::circuit::{wormhole_public_batch_circuit_config, C, D, F};
 
 use crate::common::utils::private_batch_num_leaves_from_padded_pi_len;
@@ -25,6 +26,8 @@ pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
     include_prover: bool,
 ) -> Result<()> {
     let output_dir = output_dir.as_ref();
+    // Bound the per-layer count before any circuit construction (#97021, #97070).
+    validate_proof_count(num_private_batch_proofs, "num_private_batch_proofs")?;
     create_dir_all(output_dir)
         .with_context(|| format!("Failed to create output dir {}", output_dir.display()))?;
 
@@ -44,7 +47,7 @@ pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
         &private_batch_verifier_only,
         num_private_batch_proofs,
         private_batch_num_leaves,
-    );
+    )?;
 
     let circuit_data = public_batch_circuit.build_circuit();
     let verifier_data = circuit_data.verifier_data();

--- a/wormhole/aggregator/src/public_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/circuit_logic.rs
@@ -3,6 +3,7 @@
 //! Verifies N private-batch aggregated proofs and emits a public-batch aggregated proof.
 //! The private-batch verifier key is baked in as constants to prevent verifier key substitution.
 
+use anyhow::{ensure, Result};
 use plonky2::{
     field::types::Field,
     iop::target::{BoolTarget, Target},
@@ -15,6 +16,7 @@ use plonky2::{
         proof::ProofWithPublicInputsTarget,
     },
 };
+use qp_wormhole_inputs::validate_proof_count;
 
 use zk_circuits_common::{
     circuit::{C, D, F},
@@ -45,24 +47,25 @@ impl PublicBatchCircuit {
     /// Build a monolithic public-batch aggregation circuit that verifies `n_inner` private-batch aggregated proofs.
     ///
     /// The `private_batch_verifier_only` is baked in as constants to prevent verifier key substitution.
+    /// Returns an error for unsupported counts or an inconsistent private-batch PI shape.
     pub fn new(
         config: CircuitConfig,
         private_batch_common: CommonCircuitData<F, D>,
         private_batch_verifier_only: &VerifierOnlyCircuitData<C, D>,
         n_inner: usize,
         private_batch_num_leaves: usize,
-    ) -> Self {
-        assert!(n_inner > 0, "n_inner must be > 0");
-        assert!(
-            private_batch_num_leaves > 0,
-            "private_batch_num_leaves must be > 0"
-        );
+    ) -> Result<Self> {
+        validate_proof_count(n_inner, "n_inner")?;
+        validate_proof_count(private_batch_num_leaves, "private_batch_num_leaves")?;
 
         let expected_l0_pi_len = pbc::private_batch_pi_len(private_batch_num_leaves);
 
-        debug_assert_eq!(
-            private_batch_common.num_public_inputs,
-            expected_l0_pi_len,
+        // Runtime (not debug-only) shape check: the public-batch circuit indexes
+        // fixed offsets derived from `private_batch_num_leaves` into each inner
+        // proof's public inputs, so a mismatch must fail loudly instead of going
+        // out of bounds in release builds (#97071).
+        ensure!(
+            private_batch_common.num_public_inputs == expected_l0_pi_len,
             "private_batch_common.num_public_inputs ({}) != expected private_batch PI len ({}) for private_batch_num_leaves={}",
             private_batch_common.num_public_inputs,
             expected_l0_pi_len,
@@ -91,7 +94,7 @@ impl PublicBatchCircuit {
         // Build wrapper constraints and register public inputs.
         build_public_batch_constraints(&mut builder, &targets, n_inner, private_batch_num_leaves);
 
-        Self { builder, targets }
+        Ok(Self { builder, targets })
     }
 
     pub fn targets(&self) -> PublicBatchCircuitTargets {
@@ -170,7 +173,9 @@ fn build_public_batch_constraints(
         .map(|p| p.public_inputs.as_slice())
         .collect();
 
-    debug_assert!(private_batch_pi_targets
+    // Runtime shape check: each inner proof's PI slice must match the private-batch
+    // PI length derived from `private_batch_num_leaves` before fixed-offset indexing.
+    assert!(private_batch_pi_targets
         .iter()
         .all(|pis| pis.len() == private_batch_pi_len));
 
@@ -509,7 +514,8 @@ mod tests {
             &leaf_common,
             &leaf_verifier_only,
             NUM_LEAVES,
-        );
+        )
+        .unwrap();
         let private_batch_targets = private_batch_circuit.targets();
         let private_batch_data = private_batch_circuit.build_circuit();
 
@@ -540,7 +546,8 @@ mod tests {
             &private_batch_data.verifier_only,
             N_INNER,
             NUM_LEAVES,
-        );
+        )
+        .unwrap();
         let public_batch_targets = public_batch_circuit.targets();
         let public_batch_data = public_batch_circuit.build_circuit();
 
@@ -703,7 +710,8 @@ mod tests {
             &leaf_data.common,
             &leaf_data.verifier_only,
             NUM_LEAVES,
-        );
+        )
+        .unwrap();
         let private_batch_targets = private_batch_circuit.targets();
         let private_batch_data = private_batch_circuit.build_circuit();
 
@@ -744,7 +752,8 @@ mod tests {
             &private_batch_data.verifier_only,
             N_INNER,
             NUM_LEAVES,
-        );
+        )
+        .unwrap();
         let public_batch_targets = public_batch_circuit.targets();
         let public_batch_data = public_batch_circuit.build_circuit();
 
@@ -891,7 +900,8 @@ mod tests {
             &leaf_data.common,
             &leaf_data.verifier_only,
             NUM_LEAVES,
-        );
+        )
+        .unwrap();
         let private_batch_targets = private_batch_circuit.targets();
         let private_batch_data = private_batch_circuit.build_circuit();
 
@@ -908,7 +918,8 @@ mod tests {
             &private_batch_data.verifier_only,
             N_INNER,
             NUM_LEAVES,
-        );
+        )
+        .unwrap();
         let public_batch_targets = public_batch_circuit.targets();
         let public_batch_data = public_batch_circuit.build_circuit();
 

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -73,8 +73,7 @@ impl PublicBatchProver {
         private_batch_num_leaves: usize,
         dummy_proof_template: ProofWithPublicInputs<F, C, D>,
     ) -> Result<Self> {
-        validate_proof_count(num_private_batch_proofs, "num_private_batch_proofs")?;
-        validate_proof_count(private_batch_num_leaves, "private_batch_num_leaves")?;
+        // Proof-count bounds are enforced by PublicBatchCircuit::new.
         let public_batch_circuit = PublicBatchCircuit::new(
             public_batch_circuit_config,
             private_batch_common,

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -4,19 +4,20 @@
 //! verifier key substitution attacks.
 
 use anyhow::{anyhow, bail, Context, Result};
+use plonky2::field::types::PrimeField64;
 #[cfg(feature = "std")]
 use plonky2::{
     iop::witness::PartialWitness,
     plonk::{
         circuit_data::{
             CircuitConfig, CommonCircuitData, ProverCircuitData, ProverOnlyCircuitData,
-            VerifierOnlyCircuitData,
+            VerifierCircuitData, VerifierOnlyCircuitData,
         },
         proof::ProofWithPublicInputs,
     },
     util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer},
 };
-use qp_wormhole_inputs::BytesDigest;
+use qp_wormhole_inputs::{validate_proof_count, BytesDigest, PrivateBatchPublicInputs};
 
 #[cfg(feature = "std")]
 use std::{fs, path::Path};
@@ -29,10 +30,13 @@ use zk_circuits_common::{
 use crate::{
     common::utils::{
         canonical_leaf_verifier_data, ensure_common_matches_canonical,
-        load_canonical_private_batch_verifier_data,
+        ensure_proof_public_input_len, load_canonical_private_batch_verifier_data,
     },
     public_batch::{
-        circuit::circuit_logic::{PublicBatchCircuit, PublicBatchCircuitTargets},
+        circuit::{
+            circuit_logic::{PublicBatchCircuit, PublicBatchCircuitTargets},
+            constants::private_batch_pi_len,
+        },
         prover::witness::fill_public_batch_witness,
     },
 };
@@ -59,6 +63,7 @@ impl PublicBatchProver {
     /// Build a fresh public-batch aggregation prover from circuit definitions.
     ///
     /// In production, prefer `new_from_binaries_dir(...)` to load prebuilt circuits.
+    /// Returns an error when either proof count is outside the supported range.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         public_batch_circuit_config: CircuitConfig,
@@ -67,25 +72,27 @@ impl PublicBatchProver {
         num_private_batch_proofs: usize,
         private_batch_num_leaves: usize,
         dummy_proof_template: ProofWithPublicInputs<F, C, D>,
-    ) -> Self {
+    ) -> Result<Self> {
+        validate_proof_count(num_private_batch_proofs, "num_private_batch_proofs")?;
+        validate_proof_count(private_batch_num_leaves, "private_batch_num_leaves")?;
         let public_batch_circuit = PublicBatchCircuit::new(
             public_batch_circuit_config,
             private_batch_common,
             private_batch_verifier_only,
             num_private_batch_proofs,
             private_batch_num_leaves,
-        );
+        )?;
 
         let targets = Some(public_batch_circuit.targets());
         let circuit_data = public_batch_circuit.build_prover();
 
-        Self {
+        Ok(Self {
             circuit_data,
             partial_witness: PartialWitness::new(),
             targets,
             num_private_batch_proofs,
             dummy_proof_template,
-        }
+        })
     }
 
     /// Create a public-batch prover from serialized bytes.
@@ -104,6 +111,12 @@ impl PublicBatchProver {
 
         let (num_leaf_proofs, num_private_batch_proofs) = config;
 
+        // Validate batch counts at the public byte-loading boundary so a zero or
+        // oversized config returns an error instead of panicking inside the
+        // circuit builder (#97027, #97070).
+        validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
+        validate_proof_count(num_private_batch_proofs, "num_private_batch_proofs")?;
+
         // 1) Load and pin private-batch verifier data to the canonical circuit.
         let private_batch_verifier_data = load_canonical_private_batch_verifier_data(
             private_batch_common_bytes,
@@ -111,6 +124,20 @@ impl PublicBatchProver {
             &canonical_leaf_verifier_data(),
             num_leaf_proofs,
         )?;
+
+        // Ensure the loaded private-batch artifact's public-input shape matches the
+        // caller-supplied leaf count before building the public-batch circuit, which
+        // indexes fixed offsets derived from that count (#97071).
+        let expected_l0_pi_len = private_batch_pi_len(num_leaf_proofs);
+        if private_batch_verifier_data.common.num_public_inputs != expected_l0_pi_len {
+            bail!(
+                "private-batch common data has {} public inputs, expected {} for num_leaf_proofs={}; \
+                 refusing to build a public-batch circuit over an inconsistent private-batch artifact",
+                private_batch_verifier_data.common.num_public_inputs,
+                expected_l0_pi_len,
+                num_leaf_proofs,
+            );
+        }
 
         // 2) Reconstruct the canonical public-batch circuit once: it provides both the
         // witness targets and the canonical common data used to pin the prebuilt artifacts.
@@ -120,7 +147,7 @@ impl PublicBatchProver {
             &private_batch_verifier_data.verifier_only,
             num_private_batch_proofs,
             num_leaf_proofs,
-        );
+        )?;
         let targets = Some(circuit.targets());
         let canonical_public = circuit.build_verifier();
 
@@ -147,6 +174,11 @@ impl PublicBatchProver {
             &private_batch_verifier_data.common,
         )
         .map_err(|e| anyhow!("failed to deserialize dummy private-batch proof: {}", e))?;
+
+        // Verify the template is a valid all-dummy private-batch proof (zero
+        // block-hash sentinel and zero forwarded payouts) so a poisoned padding
+        // template cannot inject real exits into partial public batches (#97026).
+        verify_dummy_private_batch_template(&dummy_proof_template, &private_batch_verifier_data)?;
 
         Ok(Self {
             circuit_data: ProverCircuitData {
@@ -253,6 +285,16 @@ impl PublicBatchProver {
             );
         }
 
+        let expected_pi_len = targets
+            .private_batch_proofs
+            .first()
+            .map(|proof| proof.public_inputs.len())
+            .ok_or_else(|| anyhow!("public-batch circuit has no private-batch proof targets"))?;
+        for (index, proof) in proofs.iter().enumerate() {
+            ensure_proof_public_input_len(proof, expected_pi_len, "private-batch proof")
+                .with_context(|| format!("private-batch proof {} is malformed", index))?;
+        }
+
         // Pad partial batches with the dummy template. No shuffle: forwarding is
         // order-preserving by design (per-segment attribution on-chain).
         let num_dummies_needed = self.num_private_batch_proofs - proofs.len();
@@ -274,5 +316,150 @@ impl PublicBatchProver {
         self.circuit_data
             .prove(self.partial_witness)
             .map_err(|e| anyhow!("Failed to prove public-batch aggregation circuit: {}", e))
+    }
+}
+
+/// Verify that the dummy private-batch proof template is a valid all-dummy
+/// private-batch proof carrying the zero block-hash sentinel and zero forwarded
+/// payouts, so poisoned padding cannot inject real exits into partial public
+/// batches (#97026).
+fn verify_dummy_private_batch_template(
+    template: &ProofWithPublicInputs<F, C, D>,
+    private_batch_verifier: &VerifierCircuitData<F, C, D>,
+) -> Result<()> {
+    private_batch_verifier
+        .verify(template.clone())
+        .map_err(|e| {
+            anyhow!(
+                "dummy private-batch proof template failed verification: {}",
+                e
+            )
+        })?;
+
+    let u64s: Vec<u64> = template
+        .public_inputs
+        .iter()
+        .map(|f| f.to_canonical_u64())
+        .collect();
+    let pis = PrivateBatchPublicInputs::try_from_u64_slice(&u64s)
+        .context("failed to parse dummy private-batch proof public inputs")?;
+
+    if pis.block_data.block_hash != BytesDigest::default() {
+        bail!(
+            "dummy private-batch proof template has non-zero block_hash {:?}; \
+             padding templates must carry the all-zero block-hash sentinel",
+            pis.block_data.block_hash
+        );
+    }
+    for (i, slot) in pis.account_data.iter().enumerate() {
+        if slot.summed_output_amount != 0 {
+            bail!(
+                "dummy private-batch proof template forwards non-zero payout at slot {} ({}); \
+                 padding templates must contribute zero to every exit slot",
+                i,
+                slot.summed_output_amount
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::private_batch::circuit::circuit_logic::PrivateBatchCircuit;
+    use crate::private_batch::prover::PrivateBatchProver;
+    use plonky2::field::types::Field;
+    use qp_wormhole_inputs::MAX_PROOF_COUNT;
+    use test_helpers::fake_leaf::{build_fake_leaf_circuit, prove_fake_leaf};
+    use zk_circuits_common::circuit::{wormhole_private_batch_circuit_config, F};
+
+    #[test]
+    fn direct_constructors_reject_oversized_counts() {
+        let (leaf, leaf_targets) = build_fake_leaf_circuit();
+        let fake_proof = prove_fake_leaf(&leaf, &leaf_targets, [F::ZERO; 21]);
+
+        let err = PrivateBatchProver::new(
+            wormhole_private_batch_circuit_config(),
+            leaf.common.clone(),
+            &leaf.verifier_only,
+            MAX_PROOF_COUNT + 1,
+            fake_proof.clone(),
+        )
+        .expect_err("oversized direct private-batch prover count must be rejected");
+        assert!(err.to_string().contains("exceeds maximum"));
+
+        let err = PublicBatchProver::new(
+            wormhole_public_batch_circuit_config(),
+            leaf.common.clone(),
+            &leaf.verifier_only,
+            MAX_PROOF_COUNT + 1,
+            1,
+            fake_proof,
+        )
+        .expect_err("oversized direct public-batch prover count must be rejected");
+        assert!(err.to_string().contains("exceeds maximum"));
+
+        let err = PrivateBatchCircuit::new(
+            wormhole_private_batch_circuit_config(),
+            &leaf.common,
+            &leaf.verifier_only,
+            MAX_PROOF_COUNT + 1,
+        )
+        .err()
+        .expect("oversized private-batch count must be rejected");
+        assert!(err.to_string().contains("exceeds maximum"));
+
+        let err = PublicBatchCircuit::new(
+            wormhole_public_batch_circuit_config(),
+            leaf.common.clone(),
+            &leaf.verifier_only,
+            MAX_PROOF_COUNT + 1,
+            1,
+        )
+        .err()
+        .expect("oversized public-batch count must be rejected");
+        assert!(err.to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn commit_rejects_malformed_private_batch_pi_without_panicking() {
+        let (leaf, leaf_targets) = build_fake_leaf_circuit();
+        let fake_proof = prove_fake_leaf(&leaf, &leaf_targets, [F::ZERO; 21]);
+        let private_batch = PrivateBatchCircuit::new(
+            wormhole_private_batch_circuit_config(),
+            &leaf.common,
+            &leaf.verifier_only,
+            1,
+        )
+        .unwrap()
+        .build_verifier();
+
+        let prover = PublicBatchProver::new(
+            wormhole_public_batch_circuit_config(),
+            private_batch.common.clone(),
+            &private_batch.verifier_only,
+            1,
+            1,
+            fake_proof.clone(),
+        )
+        .unwrap();
+
+        let mut malformed = fake_proof;
+        malformed.public_inputs.pop();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            prover.commit(PublicBatchInputs {
+                proofs: vec![malformed],
+                aggregator_address: BytesDigest::default(),
+            })
+        }));
+        assert!(
+            result.is_ok(),
+            "commit must not panic on malformed PI length"
+        );
+        let err = result.unwrap().unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("private-batch proof 0 is malformed"));
     }
 }

--- a/wormhole/circuit-builder/src/main.rs
+++ b/wormhole/circuit-builder/src/main.rs
@@ -25,11 +25,11 @@ struct Args {
     #[arg(short, long, default_value = "generated-bins")]
     output: String,
 
-    /// Number of leaf proofs aggregated into a single private-batch proof (must be 1-1024)
+    /// Number of leaf proofs aggregated into a single private-batch proof (must be 1-64)
     #[arg(short, long, value_parser = parse_proof_count)]
     num_leaf_proofs: usize,
 
-    /// Number of inner private-batch proofs aggregated into a single public-batch proof (must be 1-1024 if specified)
+    /// Number of inner private-batch proofs aggregated into a single public-batch proof (must be 1-64 if specified)
     /// Omit this flag to only generate private-batch artifacts.
     #[arg(short, long, value_parser = parse_proof_count)]
     num_private_batch_proofs: Option<usize>,

--- a/wormhole/circuit/src/block_header/header.rs
+++ b/wormhole/circuit/src/block_header/header.rs
@@ -105,7 +105,10 @@ impl HeaderInputs {
             state_root: bytes_to_digest(state_root),
             extrinsics_root: bytes_to_digest(extrinsics_root),
             zk_tree_root: bytes_to_digest(zk_tree_root),
-            digest: bytes_to_felts(digest).try_into().unwrap(),
+            digest: bytes_to_felts(digest)
+                .map_err(|e| anyhow::anyhow!("failed to encode digest logs: {}", e))?
+                .try_into()
+                .unwrap(),
         })
     }
     pub fn block_hash(&self) -> BytesDigest {

--- a/wormhole/circuit/src/circuit.rs
+++ b/wormhole/circuit/src/circuit.rs
@@ -282,7 +282,8 @@ pub mod circuit_logic {
         // Nullifier validation: nullifier == H(H(salt + secret + transfer_count))
         // Skip this validation for dummy proofs (block_hash == 0 AND outputs == 0).
         // This allows dummy proofs to use random nullifiers for better privacy.
-        let salt_felts = string_to_felts(NULLIFIER_SALT);
+        let salt_felts =
+            string_to_felts(NULLIFIER_SALT).expect("NULLIFIER_SALT within serialization cap");
         let mut nullifier_preimage = Vec::new();
         for &f in salt_felts.iter() {
             nullifier_preimage.push(builder.constant(f));

--- a/wormhole/circuit/src/inputs.rs
+++ b/wormhole/circuit/src/inputs.rs
@@ -10,14 +10,15 @@ use zk_circuits_common::utils::{try_4_felts_to_bytes, BytesDigest};
 use zk_circuits_common::zk_merkle::SIBLINGS_PER_LEVEL;
 
 // Import public input types and constants from wormhole_inputs (single source of truth)
+use qp_wormhole_inputs::{
+    validate_proof_count, ASSET_ID_INDEX, BLOCK_HASH_END_INDEX, BLOCK_HASH_START_INDEX,
+    BLOCK_NUMBER_INDEX, EXIT_ACCOUNT_1_END_INDEX, EXIT_ACCOUNT_1_START_INDEX,
+    EXIT_ACCOUNT_2_END_INDEX, EXIT_ACCOUNT_2_START_INDEX, NULLIFIER_END_INDEX,
+    NULLIFIER_START_INDEX, OUTPUT_AMOUNT_1_INDEX, OUTPUT_AMOUNT_2_INDEX, PUBLIC_INPUTS_FELTS_LEN,
+    VOLUME_FEE_BPS_INDEX,
+};
 pub use qp_wormhole_inputs::{
     BlockData, PrivateBatchPublicInputs, PublicCircuitInputs, PublicInputsByAccount,
-};
-use qp_wormhole_inputs::{
-    ASSET_ID_INDEX, BLOCK_HASH_END_INDEX, BLOCK_HASH_START_INDEX, BLOCK_NUMBER_INDEX,
-    EXIT_ACCOUNT_1_END_INDEX, EXIT_ACCOUNT_1_START_INDEX, EXIT_ACCOUNT_2_END_INDEX,
-    EXIT_ACCOUNT_2_START_INDEX, NULLIFIER_END_INDEX, NULLIFIER_START_INDEX, OUTPUT_AMOUNT_1_INDEX,
-    OUTPUT_AMOUNT_2_INDEX, PUBLIC_INPUTS_FELTS_LEN, VOLUME_FEE_BPS_INDEX,
 };
 
 /// Inputs required to commit to the wormhole circuit.
@@ -204,10 +205,7 @@ impl ParsePrivateBatchPublicInputs for PrivateBatchPublicInputs {
             })?;
 
         let n_leaf = payload_len / PUBLIC_INPUTS_FELTS_LEN;
-        // This invariant is enforced because an aggregator should never legitimately
-        // produce a PI vector with zero leaf proofs. See audit finding M-3: "Public-batch
-        // has no dummy bypass; all-dummy private-batch batches break aggregation".
-        anyhow::ensure!(n_leaf > 0, "AggregatedPI: need at least one leaf proof");
+        validate_proof_count(n_leaf, "AggregatedPI: n_leaf")?;
 
         // Helper to read a u32 from a felt
         let read_u32 = |f: GoldilocksField| -> anyhow::Result<u32> {
@@ -324,8 +322,8 @@ mod tests {
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(
-            err_msg.contains("at least one leaf"),
-            "Expected 'at least one leaf' error, got: {}",
+            err_msg.contains("must be > 0"),
+            "Expected a 'must be > 0' error, got: {}",
             err_msg
         );
     }

--- a/wormhole/circuit/src/nullifier.rs
+++ b/wormhole/circuit/src/nullifier.rs
@@ -81,7 +81,8 @@ impl Nullifier {
     pub fn from_preimage(secret: BytesDigest, transfer_count: u64) -> Self {
         let mut preimage = Vec::new();
 
-        let salt = string_to_felts(NULLIFIER_SALT);
+        let salt =
+            string_to_felts(NULLIFIER_SALT).expect("NULLIFIER_SALT within serialization cap");
         let secret_felts = bytes_to_digest(secret);
         let transfer_count_felts = u64_to_felts(transfer_count);
 
@@ -196,10 +197,13 @@ impl FieldElementCodec for Nullifier {
             .map_err(|_| anyhow::anyhow!("Failed to deserialize nullifier secret"))?;
         offset += SECRET_NUM_TARGETS;
 
-        // Deserialize transfer_count
+        // Deserialize transfer_count, enforcing the 32-bit limb invariant so a
+        // later `to_bytes` cannot panic on attacker-supplied oversized limbs (#97064).
         let transfer_count = elements[offset..offset + TRANSFER_COUNT_NUM_TARGETS]
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to deserialize nullifier transfer_count"))?;
+        felts_to_u64(transfer_count)
+            .map_err(|e| anyhow::anyhow!("invalid nullifier transfer_count felts: {}", e))?;
 
         Ok(Self {
             hash,
@@ -275,7 +279,8 @@ pub fn add_nullifier_validation(targets: &NullifierTargets, builder: &mut Circui
     use plonky2::hash::poseidon2::Poseidon2Hash;
     use zk_circuits_common::utils::string_to_felts;
 
-    let salt_felts = string_to_felts(NULLIFIER_SALT);
+    let salt_felts =
+        string_to_felts(NULLIFIER_SALT).expect("NULLIFIER_SALT within serialization cap");
     let mut nullifier_preimage = Vec::new();
     for &f in salt_felts.iter() {
         nullifier_preimage.push(builder.constant(f));
@@ -288,4 +293,31 @@ pub fn add_nullifier_validation(targets: &NullifierTargets, builder: &mut Circui
         builder.hash_n_to_hash_no_pad_p2::<Poseidon2Hash>(inner_hash.elements.to_vec());
 
     builder.connect_hashes(targets.hash, computed_nullifier);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Nullifier;
+    use plonky2::field::types::Field;
+    use qp_wormhole_inputs::BytesDigest;
+    use zk_circuits_common::{circuit::F, codec::FieldElementCodec};
+
+    #[test]
+    fn from_field_elements_rejects_oversized_transfer_count_limbs() {
+        // `to_bytes` treats transfer_count as 32-bit limbs, so `from_field_elements`
+        // must reject oversized limbs up front instead of letting a later
+        // `to_bytes` panic (#97064).
+        let valid = Nullifier::from_preimage(BytesDigest::new_unchecked([7u8; 32]), 42);
+        let mut felts = valid.to_field_elements();
+        let last = felts.len() - 1;
+        felts[last] = F::from_noncanonical_u64(0x1_0000_0000);
+
+        let err = Nullifier::from_field_elements(&felts)
+            .expect_err("oversized transfer_count limb must be rejected");
+        assert!(
+            err.to_string()
+                .contains("invalid nullifier transfer_count felts"),
+            "got: {err}"
+        );
+    }
 }

--- a/wormhole/circuit/src/unspendable_account.rs
+++ b/wormhole/circuit/src/unspendable_account.rs
@@ -56,7 +56,9 @@ impl UnspendableAccount {
 
         // Build preimage: salt + secret
         let mut preimage = Vec::new();
-        preimage.extend(string_to_felts(UNSPENDABLE_SALT));
+        preimage.extend(
+            string_to_felts(UNSPENDABLE_SALT).expect("UNSPENDABLE_SALT within serialization cap"),
+        );
         preimage.extend(&secret_felts);
 
         if preimage.len() != PREIMAGE_NUM_TARGETS {
@@ -184,7 +186,8 @@ impl CircuitFragment for UnspendableAccount {
         Self::Targets { account_id, secret }: &Self::Targets,
         builder: &mut CircuitBuilder<F, D>,
     ) {
-        let salt = string_to_felts(UNSPENDABLE_SALT);
+        let salt =
+            string_to_felts(UNSPENDABLE_SALT).expect("UNSPENDABLE_SALT within serialization cap");
         let mut preimage = Vec::new();
         for felt in salt {
             preimage.push(builder.constant(felt));

--- a/wormhole/inputs/src/lib.rs
+++ b/wormhole/inputs/src/lib.rs
@@ -12,7 +12,7 @@ extern crate alloc;
 use alloc::fmt;
 use alloc::format;
 use alloc::vec::Vec;
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail, Context};
 use core::ops::Deref;
 
 /// Number of bytes in a digest (32 bytes = 256 bits)
@@ -36,6 +36,33 @@ pub const PUBLIC_INPUTS_FELTS_LEN: usize = 21;
 /// Guards against a qp-plonky2 upgrade silently weakening
 /// `CircuitConfig::standard_recursion_config()` below this floor.
 pub const MIN_LEAF_SECURITY_BITS: usize = 100;
+
+/// Maximum number of proofs aggregated per layer. Bounds circuit-construction,
+/// proving, and public-input parsing work to the documented practical per-layer
+/// limit (benches currently exercise up to 49 proofs). This is the single source
+/// of truth re-exported by the aggregator config; every externally supplied or
+/// length-derived batch dimension must be validated against it before any
+/// allocation, arithmetic, or circuit construction.
+pub const MAX_PROOF_COUNT: usize = 64;
+
+/// Validate that a per-layer proof count is in the canonical `1..=MAX_PROOF_COUNT` range.
+///
+/// Centralizes the batch-size bound so every build/parse entry point applies the
+/// same cap before doing work that scales with the count.
+pub fn validate_proof_count(count: usize, label: &str) -> anyhow::Result<()> {
+    if count == 0 {
+        bail!("{} must be > 0", label);
+    }
+    if count > MAX_PROOF_COUNT {
+        bail!(
+            "{} ({}) exceeds maximum allowed ({})",
+            label,
+            count,
+            MAX_PROOF_COUNT
+        );
+    }
+    Ok(())
+}
 
 // Index constants for parsing public inputs
 pub const ASSET_ID_INDEX: usize = 0;
@@ -266,6 +293,43 @@ pub mod public_batch_pi {
             + num_private_batch_proofs * exit_slots_per_inner(num_leaf_proofs) * EXIT_SLOT_LEN
             + num_private_batch_proofs * nullifiers_per_inner(num_leaf_proofs) * 4
     }
+
+    /// Checked variant of [`pi_len`]: returns `None` on overflow instead of wrapping.
+    ///
+    /// Use this (plus [`super::validate_proof_count`]) when the dimensions come
+    /// from untrusted input; [`pi_len`] is unchecked and may wrap for huge counts.
+    #[inline]
+    pub const fn try_pi_len(
+        num_private_batch_proofs: usize,
+        num_leaf_proofs: usize,
+    ) -> Option<usize> {
+        let slots = match num_leaf_proofs.checked_mul(2) {
+            Some(s) => s,
+            None => return None,
+        };
+        let nulls = num_leaf_proofs;
+        let exit_felts = match num_private_batch_proofs.checked_mul(slots) {
+            Some(v) => match v.checked_mul(EXIT_SLOT_LEN) {
+                Some(e) => e,
+                None => return None,
+            },
+            None => return None,
+        };
+        let null_felts = match num_private_batch_proofs.checked_mul(nulls) {
+            Some(v) => match v.checked_mul(4) {
+                Some(n) => n,
+                None => return None,
+            },
+            None => return None,
+        };
+        match HEADER_LEN.checked_add(exit_felts) {
+            Some(v) => match v.checked_add(null_felts) {
+                Some(total) => Some(total),
+                None => None,
+            },
+            None => None,
+        }
+    }
 }
 
 /// Helper to convert 4 u64 values (hash output) to a BytesDigest.
@@ -380,14 +444,7 @@ impl PrivateBatchPublicInputs {
 
         // Number of leaf proofs (N) is derived from the padded total PI length.
         let n_leaf = payload_len / PUBLIC_INPUTS_FELTS_LEN;
-
-        if n_leaf == 0 {
-            bail!(
-                "AggregatedPI: n_leaf is 0 (pis.len()={}, PUBLIC_INPUTS_FELTS_LEN={})",
-                pis.len(),
-                PUBLIC_INPUTS_FELTS_LEN
-            );
-        }
+        validate_proof_count(n_leaf, "AggregatedPI: n_leaf")?;
 
         let block_hash = hash_u64s_to_bytes_digest(&pis[3..7])
             .context("AggregatedPI: parsing block_hash from indices 3..7")?;
@@ -502,14 +559,21 @@ impl PublicBatchPublicInputs {
         num_leaf_proofs: usize,
     ) -> anyhow::Result<Self> {
         use public_batch_pi::{
-            exit_slots_per_inner, nullifiers_per_inner, pi_len, AGGREGATOR_ADDRESS_LEN, HEADER_LEN,
+            exit_slots_per_inner, nullifiers_per_inner, try_pi_len, AGGREGATOR_ADDRESS_LEN,
+            HEADER_LEN,
         };
 
-        if num_private_batch_proofs == 0 || num_leaf_proofs == 0 {
-            bail!("PublicBatchPI: num_private_batch_proofs and num_leaf_proofs must be > 0");
-        }
+        validate_proof_count(num_private_batch_proofs, "num_private_batch_proofs")?;
+        validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
 
-        let expected_len = pi_len(num_private_batch_proofs, num_leaf_proofs);
+        let expected_len =
+            try_pi_len(num_private_batch_proofs, num_leaf_proofs).ok_or_else(|| {
+                anyhow!(
+                    "PublicBatchPI: layout length overflow (n_inner={}, n_leaves={})",
+                    num_private_batch_proofs,
+                    num_leaf_proofs
+                )
+            })?;
         if pis.len() != expected_len {
             bail!(
                 "PublicBatchPI: expected {} felts (n_inner={}, n_leaves={}), got {}",
@@ -522,7 +586,12 @@ impl PublicBatchPublicInputs {
 
         let slots_per_inner = exit_slots_per_inner(num_leaf_proofs);
         let nulls_per_inner = nullifiers_per_inner(num_leaf_proofs);
-        let total_exit_slots_expected = (num_private_batch_proofs * slots_per_inner) as u32;
+        let total_exit_slots_expected = u32::try_from(
+            num_private_batch_proofs
+                .checked_mul(slots_per_inner)
+                .ok_or_else(|| anyhow!("PublicBatchPI: exit slot count overflow"))?,
+        )
+        .context("PublicBatchPI: total_exit_slots exceeds u32")?;
 
         let aggregator_address = hash_u64s_to_bytes_digest(&pis[0..AGGREGATOR_ADDRESS_LEN])
             .context("PublicBatchPI: parsing aggregator_address")?;
@@ -557,7 +626,9 @@ impl PublicBatchPublicInputs {
         };
 
         let mut cursor = HEADER_LEN;
-        let total_slots = num_private_batch_proofs * slots_per_inner;
+        let total_slots = num_private_batch_proofs
+            .checked_mul(slots_per_inner)
+            .ok_or_else(|| anyhow!("PublicBatchPI: exit slot count overflow"))?;
         let mut account_data = Vec::with_capacity(total_slots);
         for i in 0..total_slots {
             let summed_output_amount: u32 = pis[cursor]
@@ -575,7 +646,9 @@ impl PublicBatchPublicInputs {
             });
         }
 
-        let total_nullifiers = num_private_batch_proofs * nulls_per_inner;
+        let total_nullifiers = num_private_batch_proofs
+            .checked_mul(nulls_per_inner)
+            .ok_or_else(|| anyhow!("PublicBatchPI: nullifier count overflow"))?;
         let mut nullifiers = Vec::with_capacity(total_nullifiers);
         for i in 0..total_nullifiers {
             let n = hash_u64s_to_bytes_digest(&pis[cursor..cursor + 4])
@@ -584,7 +657,13 @@ impl PublicBatchPublicInputs {
             nullifiers.push(n);
         }
 
-        debug_assert_eq!(cursor, expected_len);
+        if cursor != expected_len {
+            bail!(
+                "PublicBatchPI: cursor mismatch - consumed {} felts, expected {}",
+                cursor,
+                expected_len
+            );
+        }
 
         Ok(PublicBatchPublicInputs {
             aggregator_address,
@@ -600,7 +679,11 @@ impl PublicBatchPublicInputs {
 
 #[cfg(test)]
 mod tests {
-    use super::{PrivateBatchPublicInputs, PUBLIC_INPUTS_FELTS_LEN};
+    use super::public_batch_pi;
+    use super::{
+        validate_proof_count, PrivateBatchPublicInputs, PublicBatchPublicInputs, MAX_PROOF_COUNT,
+        PUBLIC_INPUTS_FELTS_LEN,
+    };
 
     #[test]
     fn aggregated_public_inputs_reject_malformed_padded_length() {
@@ -622,5 +705,33 @@ mod tests {
         assert_eq!(parsed.block_data.block_number, 42);
         assert_eq!(parsed.account_data.len(), 2);
         assert_eq!(parsed.nullifiers.len(), 1);
+    }
+
+    #[test]
+    fn aggregated_public_inputs_reject_oversized_leaf_count() {
+        // A length-derived n_leaf above MAX_PROOF_COUNT must be rejected rather than
+        // driving unbounded allocation (#97052, #97070).
+        let n = MAX_PROOF_COUNT + 1;
+        let pis = vec![0u64; 8 + n * PUBLIC_INPUTS_FELTS_LEN];
+        let err = PrivateBatchPublicInputs::try_from_u64_slice(&pis).unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum"), "got: {err}");
+    }
+
+    #[test]
+    fn public_batch_parser_rejects_oversized_counts() {
+        // Counts whose product would wrap the layout arithmetic must be rejected by
+        // the MAX_PROOF_COUNT cap instead of panicking or wrapping to an empty batch.
+        let header = vec![0u64; public_batch_pi::HEADER_LEN];
+        let err = PublicBatchPublicInputs::try_from_u64_slice(&header, 1usize << 63, 1)
+            .expect_err("oversized inner count must be rejected");
+        assert!(err.to_string().contains("exceeds maximum"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_proof_count_enforces_canonical_range() {
+        assert!(validate_proof_count(0, "x").is_err());
+        assert!(validate_proof_count(MAX_PROOF_COUNT + 1, "x").is_err());
+        assert!(validate_proof_count(1, "x").is_ok());
+        assert!(validate_proof_count(MAX_PROOF_COUNT, "x").is_ok());
     }
 }

--- a/wormhole/memprof/src/main.rs
+++ b/wormhole/memprof/src/main.rs
@@ -21,6 +21,7 @@ mod workload;
 
 use anyhow::Result;
 use clap::Parser;
+use wormhole_aggregator::validate_proof_count;
 
 use crate::config::{default_agg_config, default_leaf_config, print_config_summary, AggConfigArgs};
 use crate::report::PhaseReport;
@@ -73,6 +74,18 @@ struct Args {
     agg_cfg: AggConfigArgs,
 }
 
+fn validate_workload_counts(num_leaf_proofs: usize, real_proofs: usize) -> Result<()> {
+    validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
+    if real_proofs > num_leaf_proofs {
+        anyhow::bail!(
+            "--real-proofs ({}) must be <= --num-leaf-proofs ({})",
+            real_proofs,
+            num_leaf_proofs
+        );
+    }
+    Ok(())
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
     eprintln!("wormhole-memprof: args = {:#?}", args);
@@ -106,13 +119,9 @@ fn main() -> Result<()> {
 
     let num_leaf_proofs = args.num_leaf_proofs;
     let real_proofs = args.real_proofs.unwrap_or(num_leaf_proofs);
-    if real_proofs > num_leaf_proofs {
-        anyhow::bail!(
-            "--real-proofs ({}) must be <= --num-leaf-proofs ({})",
-            real_proofs,
-            num_leaf_proofs
-        );
-    }
+    // Bound the circuit dimension before construction while permitting an
+    // all-dummy profiling run (`real_proofs == 0`).
+    validate_workload_counts(num_leaf_proofs, real_proofs)?;
 
     let mut report = PhaseReport::new(args.sample_period_ms)?;
 
@@ -155,4 +164,20 @@ fn main() -> Result<()> {
 
     report.finish_and_print(args.peak_target_mb)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_workload_counts;
+
+    #[test]
+    fn zero_real_proofs_is_valid_for_all_dummy_profile() {
+        validate_workload_counts(7, 0).unwrap();
+    }
+
+    #[test]
+    fn invalid_circuit_dimension_or_real_count_is_rejected() {
+        assert!(validate_workload_counts(0, 0).is_err());
+        assert!(validate_workload_counts(7, 8).is_err());
+    }
 }

--- a/wormhole/memprof/src/workload.rs
+++ b/wormhole/memprof/src/workload.rs
@@ -108,7 +108,7 @@ pub fn aggregate_fresh(
         &leaf.verifier_only,
         num_leaf_proofs,
         leaf.dummy_proof.clone(),
-    );
+    )?;
     report.phase_end()?;
 
     report.phase_start("agg_commit")?;
@@ -138,7 +138,7 @@ pub fn build_agg_circuit_only(
         &leaf.verifier_only,
         num_leaf_proofs,
         leaf.dummy_proof.clone(),
-    );
+    )?;
     report.phase_end()?;
     Ok(())
 }

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -3,11 +3,14 @@
 use circuit_builder::generate_all_circuit_binaries;
 use plonky2::field::types::Field;
 use plonky2::plonk::proof::ProofWithPublicInputs;
-use qp_wormhole_inputs::PublicCircuitInputs;
+use qp_wormhole_inputs::{BytesDigest, PublicCircuitInputs};
 use std::path::Path;
 use std::sync::Once;
 use test_helpers::TestInputs;
-use wormhole_aggregator::aggregator::{AggregationBackend, PrivateBatchAggregator};
+use wormhole_aggregator::aggregator::{
+    AggregationBackend, PrivateBatchAggregator, PublicBatchAggregator,
+};
+use wormhole_aggregator::private_batch::prover::PrivateBatchProver;
 use wormhole_circuit::inputs::{CircuitInputs, ParsePublicInputs};
 use wormhole_prover::WormholeProver;
 use zk_circuits_common::circuit::{C, D, F};
@@ -15,8 +18,10 @@ use zk_circuits_common::circuit::{C, D, F};
 use crate::aggregator::circuit_config;
 
 const TEST_OUTPUT_DIR: &str = "tmp-test-bins";
+const PUBLIC_TEST_OUTPUT_DIR: &str = "tmp-test-public-bins";
 
 static TEST_INIT: Once = Once::new();
+static PUBLIC_TEST_INIT: Once = Once::new();
 
 extern "C" fn cleanup_test_output_dir() {
     // Best-effort cleanup (don’t panic during shutdown)
@@ -48,6 +53,21 @@ fn make_leaf_proof(inputs: &CircuitInputs) -> ProofWithPublicInputs<F, C, D> {
 fn make_aggregator() -> PrivateBatchAggregator {
     setup_test_binaries();
     PrivateBatchAggregator::new(TEST_OUTPUT_DIR).unwrap()
+}
+
+fn make_private_batch_prover() -> PrivateBatchProver {
+    setup_test_binaries();
+    PrivateBatchProver::new_from_binaries_dir(Path::new(TEST_OUTPUT_DIR))
+        .expect("Failed to load private-batch prover from generated binaries")
+}
+
+fn setup_public_test_binaries() {
+    PUBLIC_TEST_INIT.call_once(|| {
+        // Smallest public-batch circuit (1 inner private-batch of 1 leaf) to keep
+        // artifact generation fast.
+        generate_all_circuit_binaries(PUBLIC_TEST_OUTPUT_DIR, true, 1, Some(1))
+            .expect("Failed to generate public-batch test circuit binaries");
+    });
 }
 
 #[test]
@@ -258,4 +278,77 @@ fn aggregate_proofs_from_separate_prover_instances_hex_serialized() {
         .expect("Aggregated proof verification failed");
 
     println!("=== Test passed ===");
+}
+
+#[test]
+fn private_batch_commit_rejects_malformed_full_batch_at_api_boundary() {
+    setup_test_binaries();
+    // A full 2-proof batch where one proof has the wrong public-input length must
+    // be rejected at the API boundary instead of panicking in witness assignment.
+    // Previously the length check ran only when dummy padding was needed (#97073).
+    let mut malformed = make_leaf_proof(&CircuitInputs::test_inputs_0());
+    malformed.public_inputs.pop();
+    let valid = make_leaf_proof(&CircuitInputs::test_inputs_0());
+
+    let prover = make_private_batch_prover();
+    let err = prover.commit(vec![malformed, valid]).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("leaf proof public input length mismatch"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn public_batch_verify_rejects_proof_bound_to_a_different_aggregator_address() {
+    setup_public_test_binaries();
+    let dir = Path::new(PUBLIC_TEST_OUTPUT_DIR);
+
+    // Build a real private-batch proof to feed the public-batch aggregator.
+    let leaf = {
+        let prover =
+            WormholeProver::new_from_files(&dir.join("prover.bin"), &dir.join("common.bin"))
+                .expect("load leaf prover");
+        prover
+            .commit(&CircuitInputs::test_inputs_0())
+            .unwrap()
+            .prove()
+            .unwrap()
+    };
+    let private_batch_proof = {
+        let mut agg = PrivateBatchAggregator::new(dir).expect("private aggregator");
+        agg.push_proof(leaf).unwrap();
+        agg.aggregate().expect("private aggregate")
+    };
+
+    let address_a = BytesDigest::try_from([1u8; 32]).expect("valid address a");
+    let address_b = BytesDigest::try_from([2u8; 32]).expect("valid address b");
+    assert_ne!(address_a, address_b, "sanity: addresses must differ");
+
+    // Produce a public-batch proof bound to address_a (this also exercises the
+    // dummy-template verification + count/shape validation in new_from_bytes).
+    let public_batch_proof = {
+        let mut agg = PublicBatchAggregator::new(dir, address_a).expect("public aggregator a");
+        agg.push_proof(private_batch_proof.clone()).unwrap();
+        agg.aggregate().expect("public aggregate")
+    };
+
+    // The producing backend accepts its own proof.
+    PublicBatchAggregator::new(dir, address_a)
+        .expect("public aggregator a")
+        .verify(public_batch_proof.clone())
+        .expect("same-address proof must verify");
+
+    // A backend configured for a different aggregator address must reject it (#96981).
+    let err = PublicBatchAggregator::new(dir, address_b)
+        .expect("public aggregator b")
+        .verify(public_batch_proof)
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("does not match configured aggregator address"),
+        "got: {err}"
+    );
+
+    let _ = std::fs::remove_dir_all(dir);
 }

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -6,7 +6,7 @@ use plonky2::plonk::proof::ProofWithPublicInputs;
 use qp_wormhole_inputs::{BytesDigest, PublicCircuitInputs};
 use std::path::Path;
 use std::sync::Once;
-use test_helpers::TestInputs;
+use test_helpers::{compute_zk_leaf_hash, TestInputs};
 use wormhole_aggregator::aggregator::{
     AggregationBackend, PrivateBatchAggregator, PublicBatchAggregator,
 };
@@ -213,6 +213,66 @@ fn push_proof_rejects_invalid_proof_and_queue_stays_usable() {
     // The aggregator remains fully usable: a valid proof pushes and aggregates.
     let valid = make_leaf_proof(&CircuitInputs::test_inputs_0());
     aggregator.push_proof(valid).unwrap();
+    let aggregated = aggregator.aggregate().expect("aggregation must succeed");
+    aggregator
+        .verify(aggregated)
+        .expect("aggregated proof should verify");
+}
+
+#[test]
+fn push_proof_rejects_batch_incompatible_proof_and_buffer_is_recoverable() {
+    setup_test_binaries();
+    // Two individually valid proofs whose metadata the private-batch circuit's
+    // cross-slot constraints reject (different asset_ids) must not both be
+    // admitted: aggregate() would fail deterministically and, since the queue
+    // only drains on success (#97067), every retry would fail on the same
+    // batch, wedging the aggregator permanently.
+    let proof_asset_0 = make_leaf_proof(&CircuitInputs::test_inputs_0());
+
+    // A cryptographically valid proof for asset_id=5: same fixture, but the
+    // asset is part of the ZK leaf hash, so the tree root must be recomputed.
+    let proof_asset_5 = {
+        let mut inputs = CircuitInputs::test_inputs_0();
+        inputs.public.asset_id = 5;
+        inputs.private.zk_tree_root = compute_zk_leaf_hash(
+            &inputs.private.unspendable_account,
+            inputs.private.transfer_count,
+            5,
+            inputs.private.input_amount,
+        );
+        make_leaf_proof(&inputs)
+    };
+
+    let mut aggregator = make_aggregator();
+    aggregator.push_proof(proof_asset_0).unwrap();
+
+    // Sanity: the incompatible proof is valid on its own; only the combination
+    // with the queued asset-0 proof is rejected.
+    let err = aggregator.push_proof(proof_asset_5.clone()).unwrap_err();
+    assert!(
+        err.to_string().contains("batch-incompatible") && err.to_string().contains("asset_id"),
+        "got: {err}"
+    );
+    assert_eq!(
+        aggregator.buffer_len(),
+        1,
+        "rejected proof must not be queued; queued proof must be retained"
+    );
+
+    // Recovery path: drain the queue and requeue as the operator sees fit.
+    // The incompatible proof is admitted once the conflicting one is gone.
+    let drained = aggregator.drain_buffer();
+    assert_eq!(drained.len(), 1);
+    assert_eq!(aggregator.buffer_len(), 0);
+    aggregator.push_proof(proof_asset_5).unwrap();
+
+    // The backend stays fully usable: requeue the drained proof set and
+    // aggregate it successfully.
+    let recovered = aggregator.drain_buffer();
+    assert_eq!(recovered.len(), 1);
+    for proof in drained {
+        aggregator.push_proof(proof).unwrap();
+    }
     let aggregated = aggregator.aggregate().expect("aggregation must succeed");
     aggregator
         .verify(aggregated)

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -173,18 +173,50 @@ fn aggregate_half_full_proof_array_into_tree() {
 }
 
 #[test]
-fn aggregate_rejects_nonzero_asset_id_when_dummy_padding_is_needed() {
+fn commit_rejects_nonzero_asset_id_when_dummy_padding_is_needed() {
     setup_test_binaries();
+    // Tampering with asset_id invalidates the proof cryptographically, so the
+    // aggregator now rejects it at push time (see below). The asset-id padding
+    // preflight is still reachable through the prover's commit API, which does
+    // not verify proofs itself.
     let mut proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
     proof.public_inputs[0] = F::from_canonical_u64(1);
 
-    let mut aggregator = make_aggregator();
-    aggregator.push_proof(proof).unwrap();
+    let prover = make_private_batch_prover();
+    let err = prover.commit(vec![proof]).unwrap_err();
+    assert!(err.to_string().contains("dummy proofs use asset_id=0"));
+}
 
-    let err = aggregator.aggregate().unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("dummy padding requires all real proofs to use asset_id=0"));
+#[test]
+fn push_proof_rejects_invalid_proof_and_queue_stays_usable() {
+    setup_test_binaries();
+    // An invalid proof (correct PI length, tampered contents) must be rejected at
+    // push time. Since aggregate() only drains the queue on success (#97067), a
+    // poisoned proof accepted into the queue would make every retry fail on the
+    // same batch, wedging the aggregator permanently.
+    let mut tampered = make_leaf_proof(&CircuitInputs::test_inputs_0());
+    tampered.public_inputs[0] = F::from_canonical_u64(1);
+
+    let mut aggregator = make_aggregator();
+    let err = aggregator.push_proof(tampered).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("refusing to queue invalid leaf proof"),
+        "got: {err}"
+    );
+    assert_eq!(
+        aggregator.buffer_len(),
+        0,
+        "rejected proof must not be queued"
+    );
+
+    // The aggregator remains fully usable: a valid proof pushes and aggregates.
+    let valid = make_leaf_proof(&CircuitInputs::test_inputs_0());
+    aggregator.push_proof(valid).unwrap();
+    let aggregated = aggregator.aggregate().expect("aggregation must succeed");
+    aggregator
+        .verify(aggregated)
+        .expect("aggregated proof should verify");
 }
 
 /// This simulates a CLI-ish flow without prebuilt binaries:

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -300,6 +300,58 @@ fn private_batch_commit_rejects_malformed_full_batch_at_api_boundary() {
 }
 
 #[test]
+fn private_batch_prover_rejects_poisoned_dummy_template() {
+    setup_test_binaries();
+    // A tampered dummy_proof.bin must be rejected when the prover loads its
+    // binaries. Otherwise the poisoned template would be padded into every
+    // partial batch, replaying its payout once per empty slot via the circuit's
+    // exit-dedup sum (leaf-level analogue of #97026).
+    let poisoned_dir = Path::new("tmp-test-bins-poisoned-dummy");
+    let _ = std::fs::remove_dir_all(poisoned_dir);
+    std::fs::create_dir_all(poisoned_dir).unwrap();
+    for entry in std::fs::read_dir(TEST_OUTPUT_DIR).unwrap() {
+        let entry = entry.unwrap();
+        std::fs::copy(entry.path(), poisoned_dir.join(entry.file_name())).unwrap();
+    }
+
+    // Sentinel-neutral tampering: block_hash and outputs stay zero, so only the
+    // cryptographic check can catch it.
+    let mut poisoned = make_leaf_proof(&CircuitInputs::test_inputs_0());
+    poisoned.public_inputs[4] = F::from_canonical_u64(0xdead_beef); // nullifier felt
+    std::fs::write(poisoned_dir.join("dummy_proof.bin"), poisoned.to_bytes()).unwrap();
+
+    let err = PrivateBatchProver::new_from_binaries_dir(poisoned_dir)
+        .expect_err("poisoned dummy template must be rejected at load time");
+    assert!(
+        err.to_string()
+            .contains("dummy leaf proof template failed verification"),
+        "got: {err}"
+    );
+
+    // A template with a non-zero payout must be rejected by the sentinel check.
+    let mut nonzero_payout = make_leaf_proof(&CircuitInputs::test_inputs_0());
+    nonzero_payout.public_inputs[1] = F::from_canonical_u64(7); // output_amount_1
+    std::fs::write(
+        poisoned_dir.join("dummy_proof.bin"),
+        nonzero_payout.to_bytes(),
+    )
+    .unwrap();
+
+    let err = PrivateBatchProver::new_from_binaries_dir(poisoned_dir)
+        .expect_err("non-zero-payout dummy template must be rejected at load time");
+    assert!(
+        err.to_string().contains("non-zero output amounts"),
+        "got: {err}"
+    );
+
+    // The pristine directory still loads fine (sanity check).
+    PrivateBatchProver::new_from_binaries_dir(Path::new(TEST_OUTPUT_DIR))
+        .expect("pristine binaries must still load");
+
+    let _ = std::fs::remove_dir_all(poisoned_dir);
+}
+
+#[test]
 fn public_batch_verify_rejects_proof_bound_to_a_different_aggregator_address() {
     setup_public_test_binaries();
     let dir = Path::new(PUBLIC_TEST_OUTPUT_DIR);

--- a/wormhole/tests/src/verifier/verifier_tests.rs
+++ b/wormhole/tests/src/verifier/verifier_tests.rs
@@ -1,7 +1,7 @@
 use plonky2::plonk::circuit_data::CircuitConfig;
 use plonky2::plonk::proof::ProofWithPublicInputs;
 use qp_wormhole_inputs::{EXIT_ACCOUNT_1_END_INDEX, EXIT_ACCOUNT_1_START_INDEX};
-use test_helpers::TestInputs;
+use test_helpers::{fake_leaf::build_fake_leaf_circuit, TestInputs};
 use wormhole_circuit::circuit::circuit_logic::WormholeCircuit;
 use wormhole_circuit::inputs::CircuitInputs;
 use wormhole_circuit::substrate_account::SubstrateAccount;
@@ -59,6 +59,24 @@ fn borrowed_verify_keeps_proof_available() {
     verifier.verify_ref(&verifier_proof).unwrap();
 
     assert_eq!(proof.public_inputs.len(), 21);
+}
+
+#[test]
+fn verifier_loader_rejects_same_profile_substituted_circuit() {
+    // This fake circuit deliberately uses the same recursion config and the same
+    // 21-public-input shape as Wormhole, but enforces only three range checks.
+    let (fake, _) = build_fake_leaf_circuit();
+    assert_eq!(fake.common.config, CIRCUIT_CONFIG);
+    assert_eq!(fake.common.num_public_inputs, 21);
+
+    let verifier_bytes = fake.verifier_only.to_bytes().unwrap();
+    let common_bytes = fake
+        .common
+        .to_bytes(&plonky2::util::serialization::DefaultGateSerializer)
+        .unwrap();
+    let err = WormholeVerifier::new_from_bytes(&verifier_bytes, &common_bytes)
+        .expect_err("same-profile substituted circuit must be rejected");
+    assert!(err.to_string().contains("does not match the canonical"));
 }
 
 #[test]

--- a/wormhole/tests/tests/encoding_safety.rs
+++ b/wormhole/tests/tests/encoding_safety.rs
@@ -74,7 +74,7 @@ proptest! {
     /// Round trip: `felts_to_bytes ∘ bytes_to_felts = id` for arbitrary bytes.
     #[test]
     fn edge_encoding_round_trips(input in prop::collection::vec(any::<u8>(), 0..96)) {
-        let felts = bytes_to_felts(&input);
+        let felts = bytes_to_felts(&input).unwrap();
         let recovered = felts_to_bytes(&felts).expect("valid terminator");
         prop_assert_eq!(recovered, input);
     }
@@ -86,14 +86,14 @@ proptest! {
         y in prop::collection::vec(any::<u8>(), 0..96),
     ) {
         prop_assume!(x != y);
-        prop_assert_ne!(bytes_to_felts(&x), bytes_to_felts(&y));
+        prop_assert_ne!(bytes_to_felts(&x).unwrap(), bytes_to_felts(&y).unwrap());
     }
 
     /// No field reduction at the edges: every limb is a 32-bit value (< 2^32),
     /// hence canonical (`feltOf_id_of_lt_2pow32` in the Lean spec).
     #[test]
     fn edge_encoding_limbs_are_32_bit(input in prop::collection::vec(any::<u8>(), 0..96)) {
-        for f in bytes_to_felts(&input) {
+        for f in bytes_to_felts(&input).unwrap() {
             prop_assert!(f.to_canonical_u64() < (1u64 << 32));
         }
     }

--- a/wormhole/tests/tests/spec_differential.rs
+++ b/wormhole/tests/tests/spec_differential.rs
@@ -120,7 +120,7 @@ fn wa_matches_double_hash(
 ) {
     let secret = secret_from_limbs([a, b, c, d]);
 
-    let mut preimage: Vec<F> = string_to_felts(UNSPENDABLE_SALT).to_vec();
+    let mut preimage: Vec<F> = string_to_felts(UNSPENDABLE_SALT).unwrap();
     preimage.extend_from_slice(&bytes_to_digest(secret));
     let expected = hh(&preimage);
 
@@ -139,7 +139,7 @@ fn nullifier_matches_double_hash(
 ) {
     let secret = secret_from_limbs([a, b, c, d]);
 
-    let mut preimage: Vec<F> = string_to_felts(NULLIFIER_SALT).to_vec();
+    let mut preimage: Vec<F> = string_to_felts(NULLIFIER_SALT).unwrap();
     preimage.extend_from_slice(&bytes_to_digest(secret));
     preimage.extend(u64_to_felts(transfer_count));
     let expected = hh(&preimage);
@@ -423,7 +423,7 @@ proptest! {
         preimage.extend_from_slice(&ser_bytes_to_digest(&state_b));
         preimage.extend_from_slice(&ser_bytes_to_digest(&extrinsics_b));
         preimage.extend_from_slice(&ser_bytes_to_digest(&zk_tree_b));
-        preimage.extend(bytes_to_felts(&digest_arr));
+        preimage.extend(bytes_to_felts(&digest_arr).unwrap());
         let expected = h(&preimage);
 
         prop_assert_eq!(actual, expected);

--- a/wormhole/verifier/Cargo.toml
+++ b/wormhole/verifier/Cargo.toml
@@ -11,6 +11,7 @@ version.workspace = true
 anyhow = { workspace = true }
 qp-plonky2-verifier = { version = "1.5.1", default-features = false }
 qp-wormhole-inputs = { version = "3.0.0", path = "../inputs", default-features = false }
+tiny-keccak = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -44,6 +44,7 @@ pub use qp_plonky2_verifier::{
 
 use qp_plonky2_verifier::field::types::PrimeField64;
 use qp_plonky2_verifier::util::serialization::DefaultGateSerializer;
+use tiny_keccak::{Hasher, Keccak};
 
 // Re-export input types from qp-wormhole-inputs
 pub use qp_wormhole_inputs::{
@@ -97,12 +98,50 @@ pub struct WormholeVerifier {
     pub circuit_data: VerifierCircuitData<F, C, D>,
 }
 
+// Keccak-256 commitments to the byte-exact canonical leaf artifacts produced by
+// `WormholeCircuit::new(CircuitConfig::standard_recursion_config())` with
+// qp-plonky2 1.5.1. The integration tests rebuild the circuit and fail if a
+// deliberate circuit change requires these commitments to be updated.
+const CANONICAL_LEAF_VERIFIER_KECCAK256: [u8; 32] = [
+    0xa5, 0x15, 0xe4, 0x89, 0x85, 0x4d, 0xf6, 0xfe, 0x4e, 0xfa, 0x0c, 0x61, 0xf1, 0x9c, 0x32, 0xd2,
+    0xa5, 0x2c, 0x6b, 0x35, 0x47, 0x96, 0x4e, 0x98, 0x69, 0xb0, 0x7e, 0xc6, 0x85, 0x71, 0x7c, 0xf4,
+];
+const CANONICAL_LEAF_COMMON_KECCAK256: [u8; 32] = [
+    0xb5, 0x80, 0xc3, 0x1c, 0x06, 0xd1, 0x8c, 0x63, 0x48, 0x17, 0x09, 0x51, 0x63, 0x50, 0x29, 0xff,
+    0xb1, 0x82, 0x2e, 0xf0, 0x26, 0x37, 0xe8, 0xd8, 0x51, 0x2d, 0x8a, 0xbb, 0x79, 0x74, 0x80, 0xe3,
+];
+
+fn keccak256(input: &[u8]) -> [u8; 32] {
+    let mut output = [0u8; 32];
+    let mut hasher = Keccak::v256();
+    hasher.update(input);
+    hasher.finalize(&mut output);
+    output
+}
+
 impl WormholeVerifier {
     /// Creates a new [`WormholeVerifier`] from verifier and common data bytes.
     ///
-    /// Rejects artifacts whose embedded `CircuitConfig` does not match the canonical
-    /// Wormhole leaf security profile (`security_bits`, ZK mode, FRI parameters, etc.).
+    /// Rejects artifacts unless both serialized inputs match the byte-exact
+    /// canonical Wormhole leaf artifacts. The decoded config and public-input
+    /// shape are checked again as defense in depth.
     pub fn new_from_bytes(verifier_bytes: &[u8], common_bytes: &[u8]) -> anyhow::Result<Self> {
+        let verifier_hash = keccak256(verifier_bytes);
+        if verifier_hash != CANONICAL_LEAF_VERIFIER_KECCAK256 {
+            return Err(anyhow!(
+                "loaded verifier-only artifact does not match the canonical Wormhole leaf circuit (keccak256={:02x?})",
+                verifier_hash
+            ));
+        }
+
+        let common_hash = keccak256(common_bytes);
+        if common_hash != CANONICAL_LEAF_COMMON_KECCAK256 {
+            return Err(anyhow!(
+                "loaded common artifact does not match the canonical Wormhole leaf circuit (keccak256={:02x?})",
+                common_hash
+            ));
+        }
+
         let verifier_only = VerifierOnlyCircuitData::from_bytes(verifier_bytes.to_vec())
             .map_err(|e| anyhow!("failed to deserialize verifier data: {}", e))?;
 


### PR DESCRIPTION
## Summary

Addresses all **11 medium-severity findings** from the V12 audit. Replaces #153 with a focused code-only diff (~1,100 lines vs the prior ~15,000 line audit-inflated PR).

Stacks on top of the high-severity fixes in #152 (`fix/audit-july-2026-high`).

| # | Finding | Fix |
|---|---------|-----|
| 96981 | Aggregator address not verified | `PublicBatchAggregator::verify` now rejects proofs whose `aggregator_address` ≠ configured address before running the verifier |
| 97021 | Oversized batch counts exhaust builder | `MAX_PROOF_COUNT` 1024→64; single source of truth in `qp_wormhole_inputs` |
| 97026 | Unchecked dummy proof padding | `PublicBatchProver::new_from_bytes` verifies dummy template with private-batch verifier; asserts zero block-hash sentinel + zero payouts |
| 97027 | Zero batch sizes panic | `validate_proof_count` returns `Err` instead of panicking; debug asserts upgraded to release asserts |
| 97052 | Unchecked batch-count overflow | Checked `try_pi_len` + checked derived counts + checked u32 cast |
| 97064 | Nullifier deserialization panics | `from_field_elements` validates 32-bit limb range up front via `felts_to_u64` |
| 97066 | Unbounded public APIs (allocation DoS) | `bytes_to_felts`/`felts_to_bytes` enforce 1 MiB cap; `TransferProofJson` gets bounded deserialization + `validate()` |
| 97067 | Queued proofs poisoned on failure | Aggregate over a clone; only drain buffer on success |
| 97070 | Batch-size inputs bypass global cap | `validate_proof_count` at every entry point: parsers, builders, provers, CLI |
| 97071 | Unchecked private-batch PI shape | `new_from_bytes` validates `num_public_inputs == private_batch_pi_len(num_leaf_proofs)` |
| 97073 | Full-batch commits skip length validation | `commit` validates every proof's PI length up front; asset-id check folded into same loop |

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- `cargo check -p qp-wormhole-verifier --no-default-features` — no-std clean
- `cargo test --workspace` — 146 passed, 0 failed

## Test plan

- [x] Formatting clean
- [x] Clippy clean (deny warnings)
- [x] no-std verifier compiles
- [x] Full workspace tests pass (146 passed, 0 failed, 13 ignored)
- [x] CI passes on push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proof verification, aggregation queues, and batch-size limits across the wormhole stack; behavior changes (stricter rejects, lower max batch size) could affect deployments that relied on 1024 or unverified push paths.
> 
> **Overview**
> Hardens wormhole aggregation, parsing, and serialization against **V12 medium-severity audit** issues: DoS from unbounded inputs, poisoned queues, weak dummy padding, and missing identity checks.
> 
> **Batch limits and validation** — `MAX_PROOF_COUNT` moves to **64** in `qp_wormhole_inputs` with shared `validate_proof_count` used at config load, circuit builders, provers, parsers, and CLI. Public-batch layout math gains checked `try_pi_len` and overflow-safe derived counts.
> 
> **Aggregation behavior** — `push_proof` **cryptographically verifies** inner proofs before queuing. `aggregate` runs on a **buffer clone** and only **drains** on success. `PublicBatchAggregator::verify` compares the proof’s **aggregator address** to the configured one before accepting.
> 
> **Dummy templates** — Leaf and private-batch padding templates are **verified** at load with **zero block-hash / zero payout** sentinels so tampered `dummy_proof.bin` cannot inject payouts into partial batches.
> 
> **Allocation bounds** — `bytes_to_felts` / related helpers return `Result` with a **1 MiB** cap; `TransferProofJson` gets bounded serde deserialization and `validate()`.
> 
> **Other** — Nullifier `from_field_elements` rejects oversized transfer-count limbs; leaf verifier loader pins artifacts via **Keccak-256** of canonical bytes; circuit constructors return `Result` instead of panicking on bad counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5b10d9e55efad059585d301ea7c2063667a106f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->