### PR TITLE
refactor: replace aggregation queues with a keyed proof pool

### DIFF
--- a/wormhole/aggregator/benches/aggregator.rs
+++ b/wormhole/aggregator/benches/aggregator.rs
@@ -2,14 +2,18 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use plonky2::plonk::circuit_data::CommonCircuitData;
 use plonky2::plonk::proof::ProofWithPublicInputs;
 use plonky2::util::serialization::DefaultGateSerializer;
-use qp_wormhole_aggregator::aggregator::{
-    AggregationBackend, PrivateBatchAggregator, PublicBatchAggregator,
+use qp_wormhole_aggregator::aggregator::PublicBatchAggregator;
+use qp_wormhole_aggregator::common::utils::{
+    canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
 };
 use qp_wormhole_aggregator::config::CircuitBinsConfig;
 use qp_wormhole_aggregator::dummy_proof::load_dummy_proof;
 use qp_wormhole_aggregator::private_batch::circuit::build::generate_private_batch_circuit_binaries;
+use qp_wormhole_aggregator::private_batch::prover::PrivateBatchProver;
 use qp_wormhole_aggregator::public_batch::circuit::build::generate_public_batch_circuit_binaries;
+use qp_wormhole_aggregator::public_batch::prover::{PublicBatchInputs, PublicBatchProver};
 use qp_wormhole_inputs::BytesDigest;
+use std::path::Path;
 use zk_circuits_common::circuit::{C, D, F};
 
 /// Generate dummy proofs from the circuit config (no external files needed).
@@ -30,14 +34,18 @@ fn load_dummy_leaf_proof() -> Proof {
         .expect("Failed to deserialize common circuit data");
     load_dummy_proof(proof_bytes, &common).expect("Failed to load dummy proof from bytes")
 }
-// Implement a helper to generate a dummy private-batch proof with "PUBLIC_BATCH_INNER_NUM_LEAVES"
+
+fn make_private_prover() -> PrivateBatchProver {
+    PrivateBatchProver::new_from_binaries_dir(Path::new(BINS_DIR))
+        .expect("Failed to load private-batch prover from binaries dir")
+}
+
+/// Generate a dummy private-batch proof over "PUBLIC_BATCH_INNER_NUM_LEAVES" dummy leaves.
 fn generate_dummy_private_batch_proof() -> Proof {
     let dummy_leaf_proof = load_dummy_leaf_proof();
-    let mut aggregator = PrivateBatchAggregator::new(BINS_DIR).unwrap();
-    for _ in 0..PUBLIC_BATCH_INNER_NUM_LEAVES {
-        aggregator.push_proof(dummy_leaf_proof.clone()).unwrap();
-    }
-    aggregator.aggregate().unwrap()
+    make_private_prover()
+        .aggregate(vec![dummy_leaf_proof; PUBLIC_BATCH_INNER_NUM_LEAVES])
+        .unwrap()
 }
 
 // A macro for creating an aggregation benchmark with a specified number of leaf proofs.
@@ -46,7 +54,7 @@ macro_rules! aggregate_proofs_benchmark {
         pub fn $fn_name(c: &mut Criterion) {
             let proof = load_dummy_leaf_proof();
 
-            // Call "generate_private_batch_circuit_binaries" before we instantiate a new wormhole aggregator,
+            // Call "generate_private_batch_circuit_binaries" before we instantiate a new prover,
             // to ensure the binaries represent the circuit with the correct number of leaf proofs.
             generate_private_batch_circuit_binaries(BINS_DIR, $num_leaf_proofs, true).expect(
                 "Failed to generate private_batch circuit binaries for aggregation benchmark",
@@ -60,14 +68,12 @@ macro_rules! aggregate_proofs_benchmark {
             c.bench_function(&format!("aggregate_proofs_{}", $num_leaf_proofs), |b| {
                 b.iter_batched(
                     || {
-                        let mut aggregator = PrivateBatchAggregator::new(BINS_DIR).unwrap();
-                        for proof in std::iter::repeat(proof.clone()).take($num_leaf_proofs) {
-                            aggregator.push_proof(proof).unwrap();
-                        }
-                        aggregator
+                        let prover = make_private_prover();
+                        let proofs = vec![proof.clone(); $num_leaf_proofs];
+                        (prover, proofs)
                     },
-                    |mut aggregator| {
-                        aggregator.aggregate().unwrap();
+                    |(prover, proofs)| {
+                        prover.aggregate(proofs).unwrap();
                     },
                     criterion::BatchSize::SmallInput,
                 );
@@ -81,8 +87,6 @@ macro_rules! verify_aggregate_proof_benchmark {
         pub fn $fn_name(c: &mut Criterion) {
             let proof = load_dummy_leaf_proof();
 
-            // Call "generate_private_batch_circuit_binaries" before we instantiate a new wormhole aggregator,
-            // to ensure the binaries represent the circuit with the correct number of leaf proofs.
             generate_private_batch_circuit_binaries(BINS_DIR, $num_leaf_proofs, true).expect(
                 "Failed to generate private_batch circuit binaries for aggregation benchmark",
             );
@@ -92,20 +96,28 @@ macro_rules! verify_aggregate_proof_benchmark {
                 .save(BINS_DIR)
                 .expect("Failed to save circuit bins config for aggregation benchmark");
 
+            let leaf = canonical_leaf_verifier_data();
+            let verifier = load_canonical_private_batch_verifier_data(
+                &std::fs::read(format!("{}/private_batch_common.bin", BINS_DIR))
+                    .expect("Failed to read private_batch common bytes"),
+                &std::fs::read(format!("{}/private_batch_verifier.bin", BINS_DIR))
+                    .expect("Failed to read private_batch verifier bytes"),
+                &leaf,
+                $num_leaf_proofs,
+            )
+            .expect("Failed to load private-batch verifier data");
+
             c.bench_function(
                 &format!("verify_aggregate_proof_{}", $num_leaf_proofs),
                 |b| {
                     b.iter_batched(
                         || {
-                            let mut aggregator = PrivateBatchAggregator::new(BINS_DIR).unwrap();
-                            for proof in std::iter::repeat(proof.clone()).take($num_leaf_proofs) {
-                                aggregator.push_proof(proof).unwrap();
-                            }
-
-                            (aggregator.aggregate().unwrap(), aggregator)
+                            make_private_prover()
+                                .aggregate(vec![proof.clone(); $num_leaf_proofs])
+                                .unwrap()
                         },
-                        |(aggregated_proof, aggregator)| {
-                            aggregator.verify(aggregated_proof).unwrap();
+                        |aggregated_proof| {
+                            verifier.verify(aggregated_proof).unwrap();
                         },
                         criterion::BatchSize::SmallInput,
                     );
@@ -141,6 +153,10 @@ macro_rules! prove_public_batch_benchmark {
             let aggregator_address = BytesDigest::try_from(LAYER1_AGGREGATOR_ADDRESS)
                 .expect("Failed to create aggregator address bytes digest");
 
+            // The prover is driven directly: the benchmark batch reuses one dummy
+            // private-batch proof N times, which the ProofPool would reject as
+            // duplicate nullifiers (and generating N distinct private batches
+            // would dwarf the benchmark setup).
             c.bench_function(
                 &format!(
                     "prove_public_batch_{}_l0leaves_{}",
@@ -149,17 +165,21 @@ macro_rules! prove_public_batch_benchmark {
                 |b| {
                     b.iter_batched(
                         || {
-                            let mut aggregator =
-                                PublicBatchAggregator::new(BINS_DIR, aggregator_address).unwrap();
-                            for proof in
-                                std::iter::repeat(proof.clone()).take($num_private_batch_proofs)
-                            {
-                                aggregator.push_proof(proof).unwrap();
-                            }
-                            aggregator
+                            let prover =
+                                PublicBatchProver::new_from_binaries_dir(Path::new(BINS_DIR))
+                                    .expect("Failed to load public-batch prover");
+                            let proofs = vec![proof.clone(); $num_private_batch_proofs];
+                            (prover, proofs)
                         },
-                        |mut aggregator| {
-                            aggregator.aggregate().unwrap();
+                        |(prover, proofs)| {
+                            prover
+                                .commit(PublicBatchInputs {
+                                    proofs,
+                                    aggregator_address,
+                                })
+                                .unwrap()
+                                .prove()
+                                .unwrap();
                         },
                         criterion::BatchSize::SmallInput,
                     );
@@ -195,6 +215,8 @@ macro_rules! verify_public_batch_benchmark {
 
             let aggregator_address = BytesDigest::try_from(LAYER1_AGGREGATOR_ADDRESS)
                 .expect("Failed to create aggregator address bytes digest");
+            let aggregator = PublicBatchAggregator::new(BINS_DIR, aggregator_address)
+                .expect("Failed to create public-batch aggregator");
 
             c.bench_function(
                 &format!(
@@ -204,16 +226,17 @@ macro_rules! verify_public_batch_benchmark {
                 |b| {
                     b.iter_batched(
                         || {
-                            let mut aggregator =
-                                PublicBatchAggregator::new(BINS_DIR, aggregator_address).unwrap();
-                            for proof in
-                                std::iter::repeat(proof.clone()).take($num_private_batch_proofs)
-                            {
-                                aggregator.push_proof(proof).unwrap();
-                            }
-                            (aggregator.aggregate().unwrap(), aggregator)
+                            PublicBatchProver::new_from_binaries_dir(Path::new(BINS_DIR))
+                                .expect("Failed to load public-batch prover")
+                                .commit(PublicBatchInputs {
+                                    proofs: vec![proof.clone(); $num_private_batch_proofs],
+                                    aggregator_address,
+                                })
+                                .unwrap()
+                                .prove()
+                                .unwrap()
                         },
-                        |(aggregated_proof, aggregator)| {
+                        |aggregated_proof| {
                             aggregator.verify(aggregated_proof).unwrap();
                         },
                         criterion::BatchSize::SmallInput,

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -1,83 +1,46 @@
-//! High-level aggregation orchestrator backends.
+//! Delegated (public-batch) aggregation service.
 //!
-//! - PrivateBatchAggregator: client/privacy-preserving aggregation (pads/shuffles inside PrivateBatchProver::commit).
-//! - PublicBatchAggregator: delegated aggregation ( expects full batches of private-batch proofs).
+//! [`PublicBatchAggregator`] is the miner-facing component: it pools
+//! private-batch proofs received from untrusted clients (admission-verified and
+//! bucketed by batch compatibility, see [`crate::pool`]) and aggregates one
+//! bucket at a time into a public-batch proof bound to this aggregator's
+//! address.
 //!
-//! Shared utilities:
-//! - verifier loading from {common.bin, verifier.bin}
-//! - bounded proof buffers
+//! Client-side (private-batch) aggregation intentionally has no queue: a client
+//! knows its own full leaf set up front, so it uses
+//! [`PrivateBatchProver::aggregate`](crate::private_batch::prover::PrivateBatchProver::aggregate)
+//! directly.
 
 use anyhow::{anyhow, bail, Context, Result};
-use plonky2::field::types::PrimeField64;
 use plonky2::plonk::{
     circuit_data::{CommonCircuitData, VerifierCircuitData},
     proof::ProofWithPublicInputs,
 };
 use qp_wormhole_inputs::{public_batch_pi::AGGREGATOR_ADDRESS_LEN, BytesDigest};
-use std::path::{Path, PathBuf};
-
+use std::collections::HashSet;
 use std::fs;
+use std::path::{Path, PathBuf};
 
 use zk_circuits_common::{
     circuit::{C, D, F},
     utils::try_4_felts_to_bytes,
 };
 
+use crate::pool::{BatchKey, BucketStats, PoolLimits, ProofPool};
 use crate::public_batch::prover::{PublicBatchInputs, PublicBatchProver};
 use crate::{
     common::utils::{
         canonical_leaf_verifier_data, canonical_public_batch_verifier_data,
-        ensure_proof_public_input_len, ensure_verifier_data_matches_canonical, leaf_proof_asset_id,
-        load_canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
-        load_verifier_data_from_bytes,
+        ensure_proof_public_input_len, ensure_verifier_data_matches_canonical,
+        load_canonical_private_batch_verifier_data, load_verifier_data_from_bytes,
     },
-    private_batch::circuit::constants::{
-        aggregated_output, ASSET_ID_START, BLOCK_HASH_START, LEAF_PI_LEN, VOLUME_FEE_BPS_START,
-    },
-    private_batch::prover::PrivateBatchProver,
     CircuitBinsConfig,
 };
 
 type Proof = ProofWithPublicInputs<F, C, D>;
-pub enum CircuitType {
-    Root,
-    Leaf,
-}
-
-/// Generic trait that both private-batch and public-batch backends implement.
-pub trait AggregationBackend: Send + Sync {
-    /// Push a proof into the backend's internal buffer.
-    fn push_proof(&mut self, proof: Proof) -> Result<()>;
-
-    /// Current number of proofs buffered.
-    fn buffer_len(&self) -> usize;
-
-    /// Batch size (capacity) for this backend.
-    fn batch_size(&self) -> usize;
-
-    /// Aggregate buffered proofs into a single proof.
-    fn aggregate(&mut self) -> Result<Proof>;
-
-    /// Remove and return all buffered proofs, leaving the queue empty.
-    ///
-    /// Recovery escape hatch: admission checks in `push_proof` mirror the
-    /// aggregation circuits' cross-slot constraints, but if the two ever drift
-    /// (or aggregation fails for any other deterministic reason), this lets an
-    /// operator recover the queue without dropping the backend — and requeue
-    /// any still-good proofs via `push_proof`.
-    fn drain_buffer(&mut self) -> Vec<Proof>;
-
-    /// Verify an aggregated proof produced by this backend.
-    fn verify(&self, _proof: Proof) -> Result<()> {
-        bail!("this aggregation backend does not implement verification")
-    }
-
-    /// Load common circuit data for this backend's circuit type (leaf or root).
-    fn load_common_data(&self, circuit_type: CircuitType) -> Result<CommonCircuitData<F, D>>;
-}
 
 // ============================================================================
-// Shared helpers
+// Verifier-loading helpers
 // ============================================================================
 
 fn read_bin(bins_dir: &Path, file: &str) -> Result<Vec<u8>> {
@@ -85,22 +48,15 @@ fn read_bin(bins_dir: &Path, file: &str) -> Result<Vec<u8>> {
         .with_context(|| format!("failed to read {}", bins_dir.join(file).display()))
 }
 
-fn load_leaf_verifier_from_bins(bins_dir: &Path) -> Result<VerifierCircuitData<F, C, D>> {
-    load_canonical_leaf_verifier_data(
-        &read_bin(bins_dir, "common.bin")?,
-        &read_bin(bins_dir, "verifier.bin")?,
-    )
-}
-
 fn load_private_batch_verifier_from_bins(
     bins_dir: &Path,
-    leaf: &VerifierCircuitData<F, C, D>,
     num_leaf_proofs: usize,
 ) -> Result<VerifierCircuitData<F, C, D>> {
+    let leaf = canonical_leaf_verifier_data();
     load_canonical_private_batch_verifier_data(
         &read_bin(bins_dir, "private_batch_common.bin")?,
         &read_bin(bins_dir, "private_batch_verifier.bin")?,
-        leaf,
+        &leaf,
         num_leaf_proofs,
     )
 }
@@ -125,241 +81,40 @@ fn load_public_batch_verifier_from_bins(
     Ok(loaded)
 }
 
-/// Batch-consistency metadata read from a proof's public inputs.
-///
-/// Mirrors the fields the aggregation circuits constrain across a batch, so
-/// admission can reject combinations that would deterministically fail proving.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct SlotMetadata {
-    asset_id: u64,
-    volume_fee_bps: u64,
-    block_hash: [u64; 4],
-}
-
-impl SlotMetadata {
-    /// Wrapper-level dummy sentinel: all-zero block hash.
-    fn is_dummy(&self) -> bool {
-        self.block_hash == [0u64; 4]
-    }
-}
-
-/// Read batch metadata from a leaf proof's public inputs.
-fn leaf_slot_metadata(proof: &Proof) -> Result<SlotMetadata> {
-    let pis = &proof.public_inputs;
-    if pis.len() != LEAF_PI_LEN {
-        bail!(
-            "leaf proof public input length mismatch: expected {}, got {}",
-            LEAF_PI_LEN,
-            pis.len()
-        );
-    }
-    Ok(SlotMetadata {
-        asset_id: pis[ASSET_ID_START].to_canonical_u64(),
-        volume_fee_bps: pis[VOLUME_FEE_BPS_START].to_canonical_u64(),
-        block_hash: core::array::from_fn(|i| pis[BLOCK_HASH_START + i].to_canonical_u64()),
-    })
-}
-
-/// Read batch metadata from a private-batch aggregated proof's public inputs.
-fn private_batch_slot_metadata(proof: &Proof) -> Result<SlotMetadata> {
-    let pis = &proof.public_inputs;
-    if pis.len() < aggregated_output::HEADER_LEN {
-        bail!(
-            "private-batch proof public inputs too short: expected at least {}, got {}",
-            aggregated_output::HEADER_LEN,
-            pis.len()
-        );
-    }
-    Ok(SlotMetadata {
-        asset_id: pis[aggregated_output::ASSET_ID_OFFSET].to_canonical_u64(),
-        volume_fee_bps: pis[aggregated_output::VOLUME_FEE_BPS_OFFSET].to_canonical_u64(),
-        block_hash: core::array::from_fn(|i| {
-            pis[aggregated_output::BLOCK_HASH_OFFSET + i].to_canonical_u64()
-        }),
-    })
-}
-
-/// Check that a new proof's batch metadata is compatible with every queued proof,
-/// mirroring the aggregation circuits' cross-slot constraints:
-///
-/// - block hash and volume_fee_bps must match between non-dummy slots
-///   (dummies are exempt in both circuits),
-/// - asset_id must match unconditionally when `asset_dummy_exempt` is false
-///   (the private-batch circuit enforces asset equality across ALL slots,
-///   dummies included), or only between non-dummies when true (the public-batch
-///   circuit exempts dummy inners).
-///
-/// NOTE: this must be kept in lockstep with the circuits' cross-slot
-/// constraints. If they drift (a new circuit constraint without a matching
-/// admission check), a stuck queue can be recovered via
-/// `AggregationBackend::drain_buffer`.
-fn ensure_batch_metadata_compatible(
-    new: &SlotMetadata,
-    queued: &[SlotMetadata],
-    asset_dummy_exempt: bool,
-    label: &str,
-) -> Result<()> {
-    for existing in queued {
-        let either_dummy = new.is_dummy() || existing.is_dummy();
-
-        if !(asset_dummy_exempt && either_dummy) && new.asset_id != existing.asset_id {
-            bail!(
-                "refusing to queue batch-incompatible {}: asset_id {} does not match \
-                 queued asset_id {} (the batch circuit enforces asset consistency)",
-                label,
-                new.asset_id,
-                existing.asset_id
-            );
-        }
-
-        if !either_dummy {
-            if new.block_hash != existing.block_hash {
-                bail!(
-                    "refusing to queue batch-incompatible {}: block_hash {:?} does not match \
-                     queued block_hash {:?} (the batch circuit enforces block consistency)",
-                    label,
-                    new.block_hash,
-                    existing.block_hash
-                );
-            }
-            if new.volume_fee_bps != existing.volume_fee_bps {
-                bail!(
-                    "refusing to queue batch-incompatible {}: volume_fee_bps {} does not match \
-                     queued volume_fee_bps {} (the batch circuit enforces fee consistency)",
-                    label,
-                    new.volume_fee_bps,
-                    existing.volume_fee_bps
-                );
-            }
-        }
-    }
-    Ok(())
-}
-
-/// Validate a proof and queue it. Since the backends only drain their queue on
-/// successful aggregation (#97067), anything admitted here that would make the
-/// batch fail proving deterministically (an invalid proof, or a valid proof
-/// whose metadata the circuit's cross-slot constraints reject) would wedge the
-/// aggregator: every aggregate() retry would fail on the same poisoned batch.
-///
-/// Checks run cheapest-first: capacity, PI length, batch-metadata
-/// compatibility, then cryptographic verification.
-fn verify_and_push(
-    verifier: &VerifierCircuitData<F, C, D>,
-    buf: &mut ProofBuffer,
-    proof: Proof,
-    label: &str,
-    extract_metadata: fn(&Proof) -> Result<SlotMetadata>,
-    asset_dummy_exempt: bool,
-) -> Result<()> {
-    if buf.is_full() {
-        bail!("proof buffer is full (capacity = {})", buf.cap());
-    }
-    ensure_proof_public_input_len(&proof, verifier.common.num_public_inputs, label)?;
-
-    let new_metadata = extract_metadata(&proof)?;
-    let queued_metadata: Vec<SlotMetadata> = buf
-        .iter()
-        .map(extract_metadata)
-        .collect::<Result<Vec<_>>>()?;
-    ensure_batch_metadata_compatible(&new_metadata, &queued_metadata, asset_dummy_exempt, label)?;
-
-    verifier.verify(proof.clone()).map_err(|e| {
-        anyhow!(
-            "refusing to queue invalid {}: verification failed: {}",
-            label,
-            e
-        )
-    })?;
-    buf.push(proof)
-}
-
-/// A small bounded buffer helper so the backends don't duplicate capacity checks / draining logic.
-#[derive(Debug)]
-struct ProofBuffer {
-    cap: usize,
-    buf: Vec<Proof>,
-}
-
-impl ProofBuffer {
-    fn new(cap: usize) -> Self {
-        Self {
-            cap,
-            buf: Vec::with_capacity(cap),
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.buf.len()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.buf.is_empty()
-    }
-
-    fn cap(&self) -> usize {
-        self.cap
-    }
-
-    fn is_full(&self) -> bool {
-        self.buf.len() >= self.cap
-    }
-
-    fn iter(&self) -> impl Iterator<Item = &Proof> {
-        self.buf.iter()
-    }
-
-    fn push(&mut self, proof: Proof) -> Result<()> {
-        if self.buf.len() >= self.cap {
-            bail!("proof buffer is full (capacity = {})", self.cap);
-        }
-        self.buf.push(proof);
-        Ok(())
-    }
-
-    /// Take all currently buffered proofs (clears buffer).
-    fn take_all(&mut self) -> Vec<Proof> {
-        std::mem::take(&mut self.buf)
-    }
-
-    /// Clone all currently buffered proofs without clearing the buffer.
-    ///
-    /// Used by the aggregation backends to attempt commit/prove over a copy so
-    /// that a failed aggregation leaves the queued proofs intact (#97067).
-    fn clone_all(&self) -> Vec<Proof> {
-        self.buf.clone()
-    }
-}
-
 // ============================================================================
-// Layer 1 backend (delegated aggregation)
+// Public-batch aggregation service
 // ============================================================================
 
 pub struct PublicBatchAggregator {
     bins_dir: PathBuf,
     aggregator_address: BytesDigest,
-    buf: ProofBuffer,
-    /// Canonical-pinned private-batch verifier data (inner proofs), loaded once at construction.
-    private_batch_verifier: VerifierCircuitData<F, C, D>,
+    pool: ProofPool,
     /// Canonical-pinned public-batch verifier data, loaded once at construction.
     verifier: VerifierCircuitData<F, C, D>,
+    /// Canonical-pinned private-batch (inner) common data, kept for proof
+    /// deserialization by callers.
+    private_batch_common: CommonCircuitData<F, D>,
 }
 
 impl PublicBatchAggregator {
     pub fn new<P: AsRef<Path>>(bins_dir: P, aggregator_address: BytesDigest) -> Result<Self> {
+        Self::with_limits(bins_dir, aggregator_address, PoolLimits::default())
+    }
+
+    pub fn with_limits<P: AsRef<Path>>(
+        bins_dir: P,
+        aggregator_address: BytesDigest,
+        limits: PoolLimits,
+    ) -> Result<Self> {
         let bins_dir = bins_dir.as_ref().to_path_buf();
 
-        // Load config
         let config = CircuitBinsConfig::load(&bins_dir)?;
-
         let num_private_batch_proofs = config
             .num_private_batch_proofs
             .ok_or_else(|| anyhow!("config is missing num_private_batch_proofs. Please regenerate the binaries and set \"num_private_batch_proofs\""))?;
         let num_leaf_proofs = config.num_leaf_proofs;
 
-        let leaf = canonical_leaf_verifier_data();
-        let private_batch =
-            load_private_batch_verifier_from_bins(&bins_dir, &leaf, num_leaf_proofs)?;
+        let private_batch = load_private_batch_verifier_from_bins(&bins_dir, num_leaf_proofs)?;
         let verifier = load_public_batch_verifier_from_bins(
             &bins_dir,
             &private_batch,
@@ -367,47 +122,46 @@ impl PublicBatchAggregator {
             num_private_batch_proofs,
         )?;
 
+        let private_batch_common = private_batch.common.clone();
+        let pool = ProofPool::new(
+            private_batch,
+            num_leaf_proofs,
+            num_private_batch_proofs,
+            limits,
+        )?;
+
         Ok(Self {
             bins_dir,
             aggregator_address,
-            buf: ProofBuffer::new(num_private_batch_proofs),
-            private_batch_verifier: private_batch,
+            pool,
             verifier,
+            private_batch_common,
         })
     }
-}
 
-impl AggregationBackend for PublicBatchAggregator {
-    fn push_proof(&mut self, proof: Proof) -> Result<()> {
-        verify_and_push(
-            &self.private_batch_verifier,
-            &mut self.buf,
-            proof,
-            "private-batch aggregated proof",
-            private_batch_slot_metadata,
-            // The public-batch circuit exempts dummy inners from asset checks.
-            true,
-        )
+    /// Validate a private-batch proof and admit it into the pool, returning the
+    /// bucket key it landed in. See [`ProofPool::push`].
+    pub fn push_proof(&mut self, proof: Proof) -> Result<BatchKey> {
+        self.pool.push(proof)
     }
 
-    fn buffer_len(&self) -> usize {
-        self.buf.len()
-    }
+    /// Aggregate one bucket into a public-batch proof bound to this
+    /// aggregator's address. Partial buckets are padded with the dummy
+    /// private-batch template.
+    ///
+    /// The bucket is drained only on success; a failed attempt (e.g. an
+    /// operational error loading the prover) leaves it intact for retry.
+    pub fn aggregate(&mut self, key: &BatchKey) -> Result<Proof> {
+        let Some(batch) = self.pool.bucket_proofs(key) else {
+            bail!(
+                "no pooled proofs for block {:?} (asset {}, fee {})",
+                key.block_hash,
+                key.asset_id,
+                key.volume_fee_bps
+            );
+        };
 
-    fn batch_size(&self) -> usize {
-        self.buf.cap()
-    }
-
-    fn aggregate(&mut self) -> Result<Proof> {
-        if self.buf.is_empty() {
-            bail!("there are no private-batch proofs to aggregate");
-        }
-
-        // Aggregate over a clone of the queue so a failed commit/prove leaves the
-        // queued proofs intact for retry instead of dropping them (#97067).
-        let batch = self.buf.clone_all();
-
-        // Load the public-batch prover (failures here don't touch the queue).
+        // Load the public-batch prover (failures here don't touch the pool).
         let prover = PublicBatchProver::new_from_binaries_dir(&self.bins_dir)
             .context("failed to load prebuilt public-batch prover")?;
 
@@ -423,17 +177,44 @@ impl AggregationBackend for PublicBatchAggregator {
             .and_then(|committed| committed.prove().context("public-batch proving failed"));
 
         if result.is_ok() {
-            // Only drain the queue once aggregation fully succeeds.
-            let _ = self.buf.take_all();
+            // Only drain the bucket once aggregation fully succeeds (#97067).
+            let _ = self.pool.remove_bucket(key);
         }
         result
     }
 
-    fn drain_buffer(&mut self) -> Vec<Proof> {
-        self.buf.take_all()
+    /// Per-bucket statistics for the operator's "when to aggregate what" policy.
+    pub fn bucket_stats(&self) -> Vec<BucketStats> {
+        self.pool.bucket_stats()
     }
 
-    fn verify(&self, proof: Proof) -> Result<()> {
+    /// Total number of pooled proofs.
+    pub fn pool_len(&self) -> usize {
+        self.pool.len()
+    }
+
+    /// Proofs per public batch (bucket capacity).
+    pub fn batch_size(&self) -> usize {
+        self.pool.batch_size()
+    }
+
+    /// Evict every pooled proof with a nullifier in `settled`, returning the
+    /// number evicted. Call on every imported block so proofs settled by other
+    /// miners (directly or via a competing public batch) stop occupying batch
+    /// slots. See [`ProofPool::evict_settled`].
+    pub fn evict_settled(&mut self, settled: &HashSet<BytesDigest>) -> usize {
+        self.pool.evict_settled(settled)
+    }
+
+    /// Remove one bucket entirely, returning its proofs (operator recovery /
+    /// expiry path).
+    pub fn remove_bucket(&mut self, key: &BatchKey) -> Vec<Proof> {
+        self.pool.remove_bucket(key)
+    }
+
+    /// Verify an aggregated public-batch proof produced under this aggregator's
+    /// address.
+    pub fn verify(&self, proof: Proof) -> Result<()> {
         // Bind the proof's exposed aggregator address to the configured one before
         // accepting it: the public-batch circuit exposes the address as a public
         // input, so without this check a valid proof produced under a different
@@ -458,234 +239,14 @@ impl AggregationBackend for PublicBatchAggregator {
             .map_err(|e| anyhow!("public-batch aggregated proof verification failed: {}", e))
     }
 
-    fn load_common_data(&self, circuit_type: CircuitType) -> Result<CommonCircuitData<F, D>> {
-        match circuit_type {
-            CircuitType::Root => Ok(self.verifier.common.clone()),
-            CircuitType::Leaf => Ok(self.private_batch_verifier.common.clone()),
-        }
-    }
-}
-
-// ============================================================================
-// Layer 0 backend (client-side aggregation)
-// ============================================================================
-
-pub struct PrivateBatchAggregator {
-    bins_dir: PathBuf,
-    buf: ProofBuffer,
-    /// Canonical-pinned leaf verifier data, loaded once at construction.
-    leaf_verifier: VerifierCircuitData<F, C, D>,
-    /// Canonical-pinned private-batch verifier data, loaded once at construction.
-    verifier: VerifierCircuitData<F, C, D>,
-}
-
-impl PrivateBatchAggregator {
-    pub fn new<P: AsRef<Path>>(bins_dir: P) -> Result<Self> {
-        let bins_dir = bins_dir.as_ref().to_path_buf();
-
-        // Load config
-        let config = CircuitBinsConfig::load(&bins_dir)?;
-        let num_leaf_proofs = config.num_leaf_proofs;
-
-        let leaf = load_leaf_verifier_from_bins(&bins_dir)?;
-        let verifier = load_private_batch_verifier_from_bins(&bins_dir, &leaf, num_leaf_proofs)?;
-
-        Ok(Self {
-            bins_dir,
-            buf: ProofBuffer::new(num_leaf_proofs),
-            leaf_verifier: leaf,
-            verifier,
-        })
+    /// Common circuit data of the public-batch (output) circuit.
+    pub fn public_batch_common(&self) -> &CommonCircuitData<F, D> {
+        &self.verifier.common
     }
 
-    fn build_prover(&self) -> Result<PrivateBatchProver> {
-        PrivateBatchProver::new_from_binaries_dir(&self.bins_dir)
-            .context("failed to load prebuilt private-batch prover from binaries dir")
-    }
-}
-
-impl AggregationBackend for PrivateBatchAggregator {
-    fn push_proof(&mut self, proof: Proof) -> Result<()> {
-        verify_and_push(
-            &self.leaf_verifier,
-            &mut self.buf,
-            proof,
-            "leaf proof",
-            leaf_slot_metadata,
-            // The private-batch circuit enforces asset equality across ALL
-            // slots, dummies included.
-            false,
-        )
-    }
-
-    fn buffer_len(&self) -> usize {
-        self.buf.len()
-    }
-
-    fn batch_size(&self) -> usize {
-        self.buf.cap()
-    }
-
-    fn aggregate(&mut self) -> Result<Proof> {
-        if self.buf.is_empty() {
-            bail!("there are no leaf proofs to aggregate");
-        }
-
-        // Aggregate over a clone of the queue so a failed preflight/commit/prove
-        // leaves the queued proofs intact for retry instead of dropping them (#97067).
-        let proofs = self.buf.clone_all();
-
-        // Private-batch prover commit does padding/shuffling/dummy-nullifier-preimage handling,
-        // so we can pass any non-empty batch. The wrapper's same-block / same-asset invariants are
-        // intentional protocol rules and remain enforced in-circuit; this preflight only rejects
-        // malformed or dummy-padding-incompatible inputs earlier.
-        if proofs.len() < self.batch_size() {
-            for (idx, proof) in proofs.iter().enumerate() {
-                let asset_id = leaf_proof_asset_id(proof)?;
-                if asset_id != 0 {
-                    bail!(
-                        "proof {} has asset_id={}, but private-batch dummy padding requires all real proofs to use asset_id=0",
-                        idx,
-                        asset_id
-                    );
-                }
-            }
-        }
-
-        let prover = self.build_prover()?;
-        let result = prover
-            .commit(proofs)
-            .context("failed to commit leaf proofs to private-batch aggregation prover")
-            .and_then(|committed| committed.prove().context("private-batch proving failed"));
-
-        if result.is_ok() {
-            // Only drain the queue once aggregation fully succeeds.
-            let _ = self.buf.take_all();
-        }
-        result
-    }
-
-    fn drain_buffer(&mut self) -> Vec<Proof> {
-        self.buf.take_all()
-    }
-
-    fn verify(&self, proof: Proof) -> Result<()> {
-        self.verifier
-            .verify(proof)
-            .map_err(|e| anyhow!("private-batch aggregated proof verification failed: {}", e))
-    }
-
-    fn load_common_data(&self, circuit_type: CircuitType) -> Result<CommonCircuitData<F, D>> {
-        match circuit_type {
-            CircuitType::Root => Ok(self.verifier.common.clone()),
-            CircuitType::Leaf => Ok(self.leaf_verifier.common.clone()),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn real(asset_id: u64, volume_fee_bps: u64, block: u64) -> SlotMetadata {
-        SlotMetadata {
-            asset_id,
-            volume_fee_bps,
-            block_hash: [block, 0, 0, 0],
-        }
-    }
-
-    fn dummy(asset_id: u64, volume_fee_bps: u64) -> SlotMetadata {
-        SlotMetadata {
-            asset_id,
-            volume_fee_bps,
-            block_hash: [0; 4],
-        }
-    }
-
-    #[test]
-    fn compatible_real_proofs_are_accepted() {
-        let queued = [real(0, 10, 1), real(0, 10, 1)];
-        for asset_dummy_exempt in [false, true] {
-            ensure_batch_metadata_compatible(&real(0, 10, 1), &queued, asset_dummy_exempt, "test")
-                .expect("identical metadata must be compatible");
-        }
-    }
-
-    #[test]
-    fn empty_queue_accepts_anything() {
-        ensure_batch_metadata_compatible(&real(7, 99, 3), &[], false, "test")
-            .expect("first proof in an empty queue is always compatible");
-    }
-
-    #[test]
-    fn mismatched_block_hash_between_real_proofs_is_rejected() {
-        let err =
-            ensure_batch_metadata_compatible(&real(0, 10, 2), &[real(0, 10, 1)], false, "test")
-                .expect_err("real proofs over different blocks must be rejected");
-        assert!(
-            err.to_string().contains("block_hash"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn mismatched_fee_between_real_proofs_is_rejected() {
-        let err =
-            ensure_batch_metadata_compatible(&real(0, 20, 1), &[real(0, 10, 1)], false, "test")
-                .expect_err("real proofs with different fees must be rejected");
-        assert!(
-            err.to_string().contains("volume_fee_bps"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn dummy_is_exempt_from_block_and_fee_checks() {
-        for asset_dummy_exempt in [false, true] {
-            ensure_batch_metadata_compatible(
-                &dummy(0, 999),
-                &[real(0, 10, 1)],
-                asset_dummy_exempt,
-                "test",
-            )
-            .expect("dummies are exempt from block/fee consistency");
-        }
-    }
-
-    #[test]
-    fn leaf_mode_rejects_asset_mismatch_even_for_dummies() {
-        // The private-batch circuit enforces asset equality across ALL slots,
-        // dummies included, so leaf admission must be strict.
-        let err = ensure_batch_metadata_compatible(&dummy(5, 10), &[dummy(0, 10)], false, "test")
-            .expect_err("leaf-mode asset checks must include dummies");
-        assert!(
-            err.to_string().contains("asset_id"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn public_batch_mode_exempts_dummies_from_asset_checks() {
-        // The public-batch circuit exempts dummy inners from asset consistency.
-        ensure_batch_metadata_compatible(&dummy(5, 10), &[real(0, 10, 1)], true, "test")
-            .expect("public-batch mode exempts dummies from asset checks");
-    }
-
-    #[test]
-    fn mismatched_asset_between_real_proofs_is_rejected_in_both_modes() {
-        for asset_dummy_exempt in [false, true] {
-            let err = ensure_batch_metadata_compatible(
-                &real(5, 10, 1),
-                &[real(0, 10, 1)],
-                asset_dummy_exempt,
-                "test",
-            )
-            .expect_err("real proofs with different assets must be rejected");
-            assert!(
-                err.to_string().contains("asset_id"),
-                "unexpected error: {err}"
-            );
-        }
+    /// Common circuit data of the private-batch (inner) circuit, e.g. for
+    /// deserializing client proof submissions.
+    pub fn private_batch_common(&self) -> &CommonCircuitData<F, D> {
+        &self.private_batch_common
     }
 }

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -20,7 +20,7 @@
 //!
 //! ```text
 //! // admission thread, short lock:
-//! let taken = aggregator.lock().take_batch(&key);
+//! let taken = aggregator.lock().take_batch(&key)?;
 //!
 //! // proving worker, NO lock held (use its own prover instance):
 //! let prover = PublicBatchProver::new_from_binaries_dir(&bins_dir)?;
@@ -189,14 +189,7 @@ impl PublicBatchAggregator {
     /// holding the lock, then drop the batch on success or
     /// [`Self::reinsert_batch`] on failure.
     pub fn aggregate(&mut self, key: &BatchKey) -> Result<Proof> {
-        let Some(taken) = self.pool.take_batch(key) else {
-            bail!(
-                "no pooled proofs for block {:?} (asset {}, fee {})",
-                key.block_hash,
-                key.asset_id,
-                key.volume_fee_bps
-            );
-        };
+        let taken = self.take_batch(key)?;
 
         match self.prove_taken(&taken) {
             Ok(proof) => Ok(proof),
@@ -209,8 +202,25 @@ impl PublicBatchAggregator {
 
     /// Remove up to `batch_size` of the oldest proofs for `key` from the pool,
     /// for proving via [`Self::prove_taken`]. Cheap; see [`ProofPool::take_batch`].
-    pub fn take_batch(&mut self, key: &BatchKey) -> Option<TakenBatch> {
-        self.pool.take_batch(key)
+    ///
+    /// Refuses the dummy sentinel bucket: an all-dummy public batch is a valid
+    /// proof that settles nothing, so proving it only wastes minutes.
+    /// ([`ProofPool`] itself stays policy-free and admits that bucket.)
+    pub fn take_batch(&mut self, key: &BatchKey) -> Result<TakenBatch> {
+        if key.is_dummy() {
+            bail!(
+                "refusing to aggregate the dummy sentinel bucket (block_hash == 0): \
+                 an all-dummy public batch settles nothing"
+            );
+        }
+        self.pool.take_batch(key).ok_or_else(|| {
+            anyhow!(
+                "no pooled proofs for block {:?} (asset {}, fee {})",
+                key.block_hash,
+                key.asset_id,
+                key.volume_fee_bps
+            )
+        })
     }
 
     /// Restore a taken batch after a failed proving attempt (no cryptographic

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -10,6 +10,35 @@
 //! knows its own full leaf set up front, so it uses
 //! [`PrivateBatchProver::aggregate`](crate::private_batch::prover::PrivateBatchProver::aggregate)
 //! directly.
+//!
+//! # Concurrency
+//!
+//! Public-batch proving takes minutes. [`PublicBatchAggregator::aggregate`] is
+//! the simple blocking convenience; a service that must keep admitting proofs
+//! while proving should split the phases and only lock around the cheap pool
+//! operations:
+//!
+//! ```text
+//! // admission thread, short lock:
+//! let taken = aggregator.lock().take_batch(&key);
+//!
+//! // proving worker, NO lock held (use its own prover instance):
+//! let prover = PublicBatchProver::new_from_binaries_dir(&bins_dir)?;
+//! let result = prover
+//!     .commit(PublicBatchInputs { proofs: taken.proofs(), aggregator_address })?
+//!     .prove();
+//!
+//! // back under a short lock:
+//! match result {
+//!     Ok(proof) => drop(taken), // proofs consumed; submit `proof`
+//!     Err(_) => { aggregator.lock().reinsert_batch(taken); }
+//! }
+//! ```
+//!
+//! Buckets queue deeper than one batch, so admissions for the same key keep
+//! landing while its previous batch is out being proved. Reinserted proofs are
+//! not re-verified, and proofs that settled on-chain while out are cleaned up
+//! by the regular [`PublicBatchAggregator::evict_settled`] cadence.
 
 use anyhow::{anyhow, bail, Context, Result};
 use plonky2::plonk::{
@@ -26,7 +55,7 @@ use zk_circuits_common::{
     utils::try_4_felts_to_bytes,
 };
 
-use crate::pool::{BatchKey, BucketStats, PoolLimits, ProofPool};
+use crate::pool::{BatchKey, BucketStats, PoolLimits, ProofPool, TakenBatch};
 use crate::public_batch::prover::{PublicBatchInputs, PublicBatchProver};
 use crate::{
     common::utils::{
@@ -145,14 +174,22 @@ impl PublicBatchAggregator {
         self.pool.push(proof)
     }
 
-    /// Aggregate one bucket into a public-batch proof bound to this
-    /// aggregator's address. Partial buckets are padded with the dummy
-    /// private-batch template.
+    /// Aggregate the oldest batch of one bucket into a public-batch proof
+    /// bound to this aggregator's address. Partial batches are padded with the
+    /// dummy private-batch template.
     ///
-    /// The bucket is drained only on success; a failed attempt (e.g. an
-    /// operational error loading the prover) leaves it intact for retry.
+    /// Only the proofs actually proved are drained, and only on success; a
+    /// failed attempt reinserts them for retry without re-verification
+    /// (#97067). Proofs beyond `batch_size` stay queued for the next call.
+    ///
+    /// This convenience method holds `&mut self` for the entire (minutes-long)
+    /// proving run, so a lock-wrapped aggregator admits nothing meanwhile. A
+    /// concurrent service should use the split API instead: [`Self::take_batch`]
+    /// under a short lock, [`Self::prove_taken`] on a proving worker WITHOUT
+    /// holding the lock, then drop the batch on success or
+    /// [`Self::reinsert_batch`] on failure.
     pub fn aggregate(&mut self, key: &BatchKey) -> Result<Proof> {
-        let Some(batch) = self.pool.bucket_proofs(key) else {
+        let Some(taken) = self.pool.take_batch(key) else {
             bail!(
                 "no pooled proofs for block {:?} (asset {}, fee {})",
                 key.block_hash,
@@ -161,26 +198,49 @@ impl PublicBatchAggregator {
             );
         };
 
-        // Load the public-batch prover (failures here don't touch the pool).
+        match self.prove_taken(&taken) {
+            Ok(proof) => Ok(proof),
+            Err(e) => {
+                self.pool.reinsert(taken);
+                Err(e)
+            }
+        }
+    }
+
+    /// Remove up to `batch_size` of the oldest proofs for `key` from the pool,
+    /// for proving via [`Self::prove_taken`]. Cheap; see [`ProofPool::take_batch`].
+    pub fn take_batch(&mut self, key: &BatchKey) -> Option<TakenBatch> {
+        self.pool.take_batch(key)
+    }
+
+    /// Restore a taken batch after a failed proving attempt (no cryptographic
+    /// re-verification). Returns the number of proofs restored; see
+    /// [`ProofPool::reinsert`].
+    pub fn reinsert_batch(&mut self, batch: TakenBatch) -> usize {
+        self.pool.reinsert(batch)
+    }
+
+    /// Prove a taken batch into a public-batch proof bound to this
+    /// aggregator's address. Does not touch the pool.
+    ///
+    /// Takes minutes. In a concurrent service, run this on a dedicated proving
+    /// worker without holding whatever lock guards the aggregator — either via
+    /// a separately constructed [`PublicBatchProver`] fed `batch.proofs()`, or
+    /// by cheaply cloning the `TakenBatch`-relevant state out of the lock.
+    pub fn prove_taken(&self, batch: &TakenBatch) -> Result<Proof> {
         let prover = PublicBatchProver::new_from_binaries_dir(&self.bins_dir)
             .context("failed to load prebuilt public-batch prover")?;
 
         // Partial batches are fine: PublicBatchProver::commit pads with the dummy
         // private-batch proof template (no shuffle - forwarding stays order-preserving
         // so the chain can attribute each segment to its inner proof).
-        let result = prover
+        prover
             .commit(PublicBatchInputs {
-                proofs: batch,
+                proofs: batch.proofs(),
                 aggregator_address: self.aggregator_address,
             })
             .context("failed to commit private-batch proofs to public-batch prover")
-            .and_then(|committed| committed.prove().context("public-batch proving failed"));
-
-        if result.is_ok() {
-            // Only drain the bucket once aggregation fully succeeds (#97067).
-            let _ = self.pool.remove_bucket(key);
-        }
-        result
+            .and_then(|committed| committed.prove().context("public-batch proving failed"))
     }
 
     /// Per-bucket statistics for the operator's "when to aggregate what" policy.
@@ -193,7 +253,7 @@ impl PublicBatchAggregator {
         self.pool.len()
     }
 
-    /// Proofs per public batch (bucket capacity).
+    /// Proofs per public batch (how many one `take_batch`/`aggregate` proves).
     pub fn batch_size(&self) -> usize {
         self.pool.batch_size()
     }

--- a/wormhole/aggregator/src/lib.rs
+++ b/wormhole/aggregator/src/lib.rs
@@ -2,6 +2,7 @@ pub mod aggregator;
 pub mod common;
 pub mod config;
 pub mod dummy_proof;
+pub mod pool;
 pub mod private_batch;
 pub mod public_batch;
 

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -382,7 +382,10 @@ impl ProofPool {
                 self.nullifier_index.remove(nullifier);
             }
         }
-        Some(TakenBatch { key: *key, proofs: taken })
+        Some(TakenBatch {
+            key: *key,
+            proofs: taken,
+        })
     }
 
     /// Restore a taken batch after a failed proving attempt, WITHOUT repeating
@@ -608,8 +611,7 @@ mod tests {
 
         // batch_size is 1, but a hot key keeps admitting past it.
         for n in [11, 12, 13] {
-            pool.push(prove_fake(&data, &targets, &fake(1, n)))
-                .unwrap();
+            pool.push(prove_fake(&data, &targets, &fake(1, n))).unwrap();
         }
         assert_eq!(pool.len(), 3);
 

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -7,6 +7,12 @@
 //! construction: the "when to aggregate which bucket" decision is left to the
 //! operator's policy, fed by [`BucketStats`].
 //!
+//! Buckets queue arbitrarily deep (bounded only by [`PoolLimits`]), so a hot
+//! (block, asset, fee) stream keeps admitting while earlier batches are being
+//! proved. [`ProofPool::take_batch`] removes the oldest `batch_size` proofs as
+//! an opaque [`TakenBatch`]; prove it without holding any pool lock, then drop
+//! it on success or [`ProofPool::reinsert`] it on failure (no re-verification).
+//!
 //! Staleness: a queued proof becomes worthless once any of its nullifiers is
 //! settled on-chain (e.g. another miner included the same private batch, or a
 //! public batch containing it). Operators should call
@@ -74,10 +80,12 @@ impl Default for PoolLimits {
 #[derive(Debug, Clone)]
 pub struct BucketStats {
     pub key: BatchKey,
-    /// Number of proofs currently queued in this bucket.
+    /// Number of proofs currently queued in this bucket. Buckets queue
+    /// arbitrarily deep (bounded only by [`PoolLimits`]), so this can exceed
+    /// `batch_size`.
     pub num_proofs: usize,
-    /// Bucket capacity (= public-batch size); at `num_proofs == batch_size`
-    /// the bucket aggregates without dummy padding.
+    /// Public-batch size: how many proofs one `take_batch` removes, and the
+    /// count at which a batch aggregates without dummy padding.
     pub batch_size: usize,
     /// Time since the oldest queued proof in this bucket was admitted.
     pub oldest_age: Duration,
@@ -86,6 +94,7 @@ pub struct BucketStats {
 }
 
 impl BucketStats {
+    /// Whether the bucket holds at least one full (padding-free) batch.
     pub fn is_full(&self) -> bool {
         self.num_proofs >= self.batch_size
     }
@@ -97,6 +106,37 @@ struct PooledProof {
     nullifiers: Vec<BytesDigest>,
     volume: u64,
     admitted_at: Instant,
+}
+
+/// A batch of admission-verified proofs removed from the pool for proving.
+///
+/// Opaque by design: it can only be produced by [`ProofPool::take_batch`], so
+/// [`ProofPool::reinsert`] can restore it on proving failure without repeating
+/// cryptographic verification. Callers must either prove-and-drop it (success)
+/// or reinsert it (failure); dropping it silently discards the proofs.
+#[derive(Debug)]
+pub struct TakenBatch {
+    key: BatchKey,
+    proofs: Vec<PooledProof>,
+}
+
+impl TakenBatch {
+    pub fn key(&self) -> &BatchKey {
+        &self.key
+    }
+
+    pub fn len(&self) -> usize {
+        self.proofs.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.proofs.is_empty()
+    }
+
+    /// Clone the contained proofs (e.g. to feed a prover's `commit`).
+    pub fn proofs(&self) -> Vec<Proof> {
+        self.proofs.iter().map(|q| q.proof.clone()).collect()
+    }
 }
 
 /// A bounded pool of admission-verified private-batch proofs, bucketed by
@@ -175,6 +215,10 @@ impl ProofPool {
     /// admitted here is individually valid and, by bucketing, batch-compatible
     /// with every other proof in its bucket, so aggregation over a bucket
     /// cannot fail deterministically on admitted inputs (#97067).
+    ///
+    /// Buckets are NOT capped at one batch: a hot key keeps admitting (up to
+    /// the global limits) while earlier batches for it are out being proved;
+    /// [`Self::take_batch`] takes the oldest `batch_size` proofs at a time.
     pub fn push(&mut self, proof: Proof) -> Result<BatchKey> {
         if self.len() >= self.limits.max_proofs {
             bail!(
@@ -189,15 +233,6 @@ impl ProofPool {
 
         match self.buckets.get(&key) {
             Some(bucket) => {
-                if bucket.len() >= self.batch_size {
-                    bail!(
-                        "bucket for block {:?} (asset {}, fee {}) is full ({} proofs)",
-                        key.block_hash,
-                        key.asset_id,
-                        key.volume_fee_bps,
-                        self.batch_size
-                    );
-                }
                 // A duplicate nullifier within one bucket means the same leaf
                 // spend would occupy two batch slots; the second copy can never
                 // settle. Reject it (this also deduplicates client re-submissions).
@@ -288,6 +323,56 @@ impl ProofPool {
         self.buckets
             .get(key)
             .map(|bucket| bucket.iter().map(|q| q.proof.clone()).collect())
+    }
+
+    /// Remove up to `batch_size` of the oldest proofs for `key`, for proving.
+    ///
+    /// This is the non-blocking aggregation primitive: taking is cheap, so a
+    /// service can take under a short lock, prove for minutes WITHOUT holding
+    /// any pool lock (admissions for the same key keep landing in the bucket
+    /// remainder), then drop the batch on success or [`Self::reinsert`] it on
+    /// failure. Returns `None` if the bucket doesn't exist.
+    pub fn take_batch(&mut self, key: &BatchKey) -> Option<TakenBatch> {
+        let bucket = self.buckets.get_mut(key)?;
+        let n = bucket.len().min(self.batch_size);
+        let taken: Vec<PooledProof> = bucket.drain(..n).collect();
+        if bucket.is_empty() {
+            self.buckets.remove(key);
+        }
+        Some(TakenBatch { key: *key, proofs: taken })
+    }
+
+    /// Restore a taken batch after a failed proving attempt, WITHOUT repeating
+    /// cryptographic verification (the batch is only constructable from this
+    /// pool's own admission path).
+    ///
+    /// Proofs are restored at the front of their bucket, preserving age order.
+    /// A proof whose nullifier was re-admitted by a client while the batch was
+    /// out is dropped as a duplicate (the copies are interchangeable spends).
+    /// Returns the number of proofs actually restored.
+    ///
+    /// NOTE: proofs may have gone stale while out (settled by another miner);
+    /// they are subject to the next [`Self::evict_settled`] like any other.
+    pub fn reinsert(&mut self, batch: TakenBatch) -> usize {
+        let bucket = self.buckets.entry(batch.key).or_default();
+        let queued_nullifiers: HashSet<BytesDigest> = bucket
+            .iter()
+            .flat_map(|q| q.nullifiers.iter().copied())
+            .collect();
+
+        let mut restored: Vec<PooledProof> = batch
+            .proofs
+            .into_iter()
+            .filter(|q| !q.nullifiers.iter().any(|n| queued_nullifiers.contains(n)))
+            .collect();
+        let count = restored.len();
+
+        restored.append(bucket);
+        *bucket = restored;
+        if bucket.is_empty() {
+            self.buckets.remove(&batch.key);
+        }
+        count
     }
 
     /// Remove one bucket entirely, returning its proofs (empty if absent).
@@ -453,21 +538,98 @@ mod tests {
         assert!(!b.is_full());
     }
 
+    /// First public-input felt of a proof's nullifier (test proofs use
+    /// single-felt nullifiers), to assert take/reinsert ordering.
+    fn nullifier_felt(proof: &Proof) -> u64 {
+        proof.public_inputs[aggregated_output::nullifiers_start(NUM_LEAVES)].to_canonical_u64()
+    }
+
     #[test]
-    fn full_bucket_rejects_without_touching_other_buckets() {
+    fn buckets_queue_deeper_than_one_batch() {
         let (mut pool, data, targets) = make_pool(1, PoolLimits::default());
 
+        // batch_size is 1, but a hot key keeps admitting past it.
+        for n in [11, 12, 13] {
+            pool.push(prove_fake(&data, &targets, &fake(1, n)))
+                .unwrap();
+        }
+        assert_eq!(pool.len(), 3);
+
+        let stats = pool.bucket_stats();
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats[0].num_proofs, 3);
+        assert!(stats[0].is_full());
+    }
+
+    #[test]
+    fn take_batch_takes_oldest_and_leaves_remainder() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        pool.push(prove_fake(&data, &targets, &fake(1, 12)))
+            .unwrap();
+        pool.push(prove_fake(&data, &targets, &fake(1, 13)))
+            .unwrap();
+
+        let taken = pool.take_batch(&key).unwrap();
+        assert_eq!(taken.key(), &key);
+        let taken_nullifiers: Vec<u64> = taken.proofs().iter().map(nullifier_felt).collect();
+        assert_eq!(taken_nullifiers, vec![11, 12]);
+        assert_eq!(pool.len(), 1);
+
+        // The remainder is the next batch (partial), and admissions continue.
+        pool.push(prove_fake(&data, &targets, &fake(1, 14)))
+            .unwrap();
+        let next = pool.take_batch(&key).unwrap();
+        let next_nullifiers: Vec<u64> = next.proofs().iter().map(nullifier_felt).collect();
+        assert_eq!(next_nullifiers, vec![13, 14]);
+        assert!(pool.is_empty());
+        assert!(pool.take_batch(&key).is_none());
+    }
+
+    #[test]
+    fn reinsert_restores_age_order_without_reverification() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        pool.push(prove_fake(&data, &targets, &fake(1, 12)))
+            .unwrap();
+
+        let taken = pool.take_batch(&key).unwrap();
+        // A newer proof lands while the batch is out being proved.
+        pool.push(prove_fake(&data, &targets, &fake(1, 13)))
+            .unwrap();
+
+        assert_eq!(pool.reinsert(taken), 2);
+        assert_eq!(pool.len(), 3);
+
+        // The reinserted (older) proofs come out first on the next take.
+        let retaken = pool.take_batch(&key).unwrap();
+        let nullifiers: Vec<u64> = retaken.proofs().iter().map(nullifier_felt).collect();
+        assert_eq!(nullifiers, vec![11, 12]);
+    }
+
+    #[test]
+    fn reinsert_drops_nullifiers_readmitted_while_out() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        let taken = pool.take_batch(&key).unwrap();
+
+        // The client re-submits the same spend while its proof is out; the
+        // bucket is empty so the duplicate is admitted.
         pool.push(prove_fake(&data, &targets, &fake(1, 11)))
             .unwrap();
-        let err = pool
-            .push(prove_fake(&data, &targets, &fake(1, 12)))
-            .unwrap_err();
-        assert!(err.to_string().contains("is full"), "got: {err}");
 
-        // Other keys still admit.
-        pool.push(prove_fake(&data, &targets, &fake(2, 13)))
-            .unwrap();
-        assert_eq!(pool.len(), 2);
+        // Reinserting must not create an in-bucket duplicate nullifier.
+        assert_eq!(pool.reinsert(taken), 0);
+        assert_eq!(pool.len(), 1);
     }
 
     #[test]

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -22,8 +22,9 @@
 //!
 //! Note on dummies: an all-dummy private-batch proof (all-zero block hash) is
 //! admissible — it is a valid proof and lands in its own bucket — but it
-//! settles nothing, so a production policy should never select that bucket for
-//! aggregation.
+//! settles nothing, so it must never be selected for aggregation
+//! ([`BucketStats::is_dummy`] flags it, and the `PublicBatchAggregator` façade
+//! refuses to take it; the pool itself stays policy-free).
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::{Duration, Instant};
@@ -97,6 +98,13 @@ impl BucketStats {
     /// Whether the bucket holds at least one full (padding-free) batch.
     pub fn is_full(&self) -> bool {
         self.num_proofs >= self.batch_size
+    }
+
+    /// Whether this is the dummy sentinel bucket (`block_hash == 0`).
+    /// Aggregating it proves a public batch that settles nothing; policy code
+    /// must skip it (`PublicBatchAggregator` refuses it outright).
+    pub fn is_dummy(&self) -> bool {
+        self.key.is_dummy()
     }
 }
 

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -25,7 +25,7 @@
 //! settles nothing, so a production policy should never select that bucket for
 //! aggregation.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, ensure, Result};
@@ -151,6 +151,15 @@ pub struct ProofPool {
     batch_size: usize,
     limits: PoolLimits,
     buckets: BTreeMap<BatchKey, Vec<PooledProof>>,
+    /// Global index of every pooled nullifier to the bucket holding its proof.
+    ///
+    /// Duplicates are rejected pool-wide, not just per bucket: the merkle tree
+    /// is cumulative, so the SAME spend can be validly proven against two
+    /// different recent blocks, landing in different buckets — only one copy
+    /// can ever settle. The index also makes [`Self::evict_settled`] a lookup
+    /// instead of a full pool scan. Invariant: contains exactly the nullifiers
+    /// of proofs currently in `buckets` (taken batches are not indexed).
+    nullifier_index: HashMap<BytesDigest, BatchKey>,
 }
 
 impl ProofPool {
@@ -188,6 +197,7 @@ impl ProofPool {
             batch_size,
             limits,
             buckets: BTreeMap::new(),
+            nullifier_index: HashMap::new(),
         })
     }
 
@@ -231,31 +241,31 @@ impl ProofPool {
         let metadata = self.parse_metadata(&proof)?;
         let key = metadata.0;
 
-        match self.buckets.get(&key) {
-            Some(bucket) => {
-                // A duplicate nullifier within one bucket means the same leaf
-                // spend would occupy two batch slots; the second copy can never
-                // settle. Reject it (this also deduplicates client re-submissions).
-                for queued in bucket {
-                    if let Some(dup) = metadata.1.iter().find(|n| queued.nullifiers.contains(n)) {
-                        bail!(
-                            "refusing to queue private-batch proof: nullifier {:?} is already \
-                             queued in the same bucket",
-                            dup
-                        );
-                    }
-                }
-            }
-            None => {
-                if self.buckets.len() >= self.limits.max_buckets {
-                    bail!(
-                        "proof pool bucket limit reached ({} buckets); \
-                         proof for block {:?} rejected",
-                        self.limits.max_buckets,
-                        key.block_hash
-                    );
-                }
-            }
+        // A duplicate nullifier anywhere in the pool means the same leaf spend
+        // is already staged; only one copy can ever settle. This is checked
+        // pool-wide (not per bucket): the cumulative merkle tree lets the same
+        // spend be proven against different recent blocks, i.e. into different
+        // buckets. It also deduplicates client re-submissions.
+        if let Some(dup) = metadata
+            .1
+            .iter()
+            .find(|n| self.nullifier_index.contains_key(n))
+        {
+            bail!(
+                "refusing to queue private-batch proof: nullifier {:?} is already \
+                 pooled (in bucket for block {:?})",
+                dup,
+                self.nullifier_index[dup].block_hash
+            );
+        }
+
+        if !self.buckets.contains_key(&key) && self.buckets.len() >= self.limits.max_buckets {
+            bail!(
+                "proof pool bucket limit reached ({} buckets); \
+                 proof for block {:?} rejected",
+                self.limits.max_buckets,
+                key.block_hash
+            );
         }
 
         self.verifier.verify(proof.clone()).map_err(|e| {
@@ -266,6 +276,9 @@ impl ProofPool {
         })?;
 
         let (key, nullifiers, volume) = metadata;
+        for nullifier in &nullifiers {
+            self.nullifier_index.insert(*nullifier, key);
+        }
         self.buckets.entry(key).or_default().push(PooledProof {
             proof,
             nullifiers,
@@ -282,17 +295,32 @@ impl ProofPool {
     /// aggregating (avoid proving dead weight) and before submitting a finished
     /// public batch (detect batches that went stale mid-proving).
     pub fn evict_settled(&mut self, settled: &HashSet<BytesDigest>) -> usize {
+        // The nullifier index turns this into a lookup over `settled` instead
+        // of a scan of every pooled proof.
+        let affected_keys: HashSet<BatchKey> = settled
+            .iter()
+            .filter_map(|n| self.nullifier_index.get(n).copied())
+            .collect();
+
         let mut evicted = 0;
-        self.buckets.retain(|_, bucket| {
+        for key in affected_keys {
+            let Some(bucket) = self.buckets.get_mut(&key) else {
+                continue;
+            };
             bucket.retain(|queued| {
                 let stale = queued.nullifiers.iter().any(|n| settled.contains(n));
                 if stale {
                     evicted += 1;
+                    for n in &queued.nullifiers {
+                        self.nullifier_index.remove(n);
+                    }
                 }
                 !stale
             });
-            !bucket.is_empty()
-        });
+            if bucket.is_empty() {
+                self.buckets.remove(&key);
+            }
+        }
         evicted
     }
 
@@ -339,6 +367,13 @@ impl ProofPool {
         if bucket.is_empty() {
             self.buckets.remove(key);
         }
+        // Taken proofs leave the pool, so their nullifiers leave the index;
+        // `reinsert` re-checks for duplicates admitted while the batch was out.
+        for queued in &taken {
+            for nullifier in &queued.nullifiers {
+                self.nullifier_index.remove(nullifier);
+            }
+        }
         Some(TakenBatch { key: *key, proofs: taken })
     }
 
@@ -347,28 +382,33 @@ impl ProofPool {
     /// pool's own admission path).
     ///
     /// Proofs are restored at the front of their bucket, preserving age order.
-    /// A proof whose nullifier was re-admitted by a client while the batch was
-    /// out is dropped as a duplicate (the copies are interchangeable spends).
-    /// Returns the number of proofs actually restored.
+    /// A proof whose nullifier was re-admitted (to any bucket) while the batch
+    /// was out is dropped as a duplicate (the copies are interchangeable
+    /// spends). Returns the number of proofs actually restored.
     ///
     /// NOTE: proofs may have gone stale while out (settled by another miner);
     /// they are subject to the next [`Self::evict_settled`] like any other.
     pub fn reinsert(&mut self, batch: TakenBatch) -> usize {
-        let bucket = self.buckets.entry(batch.key).or_default();
-        let queued_nullifiers: HashSet<BytesDigest> = bucket
-            .iter()
-            .flat_map(|q| q.nullifiers.iter().copied())
-            .collect();
-
-        let mut restored: Vec<PooledProof> = batch
+        let restored: Vec<PooledProof> = batch
             .proofs
             .into_iter()
-            .filter(|q| !q.nullifiers.iter().any(|n| queued_nullifiers.contains(n)))
+            .filter(|q| {
+                !q.nullifiers
+                    .iter()
+                    .any(|n| self.nullifier_index.contains_key(n))
+            })
             .collect();
         let count = restored.len();
+        for queued in &restored {
+            for nullifier in &queued.nullifiers {
+                self.nullifier_index.insert(*nullifier, batch.key);
+            }
+        }
 
-        restored.append(bucket);
-        *bucket = restored;
+        let bucket = self.buckets.entry(batch.key).or_default();
+        let mut merged = restored;
+        merged.append(bucket);
+        *bucket = merged;
         if bucket.is_empty() {
             self.buckets.remove(&batch.key);
         }
@@ -382,7 +422,17 @@ impl ProofPool {
     pub fn remove_bucket(&mut self, key: &BatchKey) -> Vec<Proof> {
         self.buckets
             .remove(key)
-            .map(|bucket| bucket.into_iter().map(|q| q.proof).collect())
+            .map(|bucket| {
+                bucket
+                    .into_iter()
+                    .map(|q| {
+                        for nullifier in &q.nullifiers {
+                            self.nullifier_index.remove(nullifier);
+                        }
+                        q.proof
+                    })
+                    .collect()
+            })
             .unwrap_or_default()
     }
 
@@ -622,14 +672,43 @@ mod tests {
             .unwrap();
         let taken = pool.take_batch(&key).unwrap();
 
-        // The client re-submits the same spend while its proof is out; the
-        // bucket is empty so the duplicate is admitted.
+        // The client re-submits the same spend while its proof is out — this
+        // time proven against a DIFFERENT block, so it lands in another
+        // bucket. Admission succeeds because taken proofs are out of the pool.
+        pool.push(prove_fake(&data, &targets, &fake(2, 11)))
+            .unwrap();
+
+        // Reinserting must not duplicate the nullifier anywhere in the pool.
+        assert_eq!(pool.reinsert(taken), 0);
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.num_buckets(), 1);
+    }
+
+    #[test]
+    fn nullifier_index_stays_consistent_through_pool_mutations() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        // remove_bucket must unindex its nullifiers so they can be re-pooled.
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        pool.remove_bucket(&key);
         pool.push(prove_fake(&data, &targets, &fake(1, 11)))
             .unwrap();
 
-        // Reinserting must not create an in-bucket duplicate nullifier.
-        assert_eq!(pool.reinsert(taken), 0);
-        assert_eq!(pool.len(), 1);
+        // take + reinsert round-trips the index: re-pushing the nullifier
+        // afterwards is still rejected as a duplicate.
+        let taken = pool.take_batch(&key).unwrap();
+        assert_eq!(pool.reinsert(taken), 1);
+        let err = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap_err();
+        assert!(err.to_string().contains("already pooled"), "got: {err}");
+
+        // ...and eviction through the index still finds the reinserted proof.
+        let settled: HashSet<BytesDigest> = [nullifier_digest(11)].into_iter().collect();
+        assert_eq!(pool.evict_settled(&settled), 1);
+        assert!(pool.is_empty());
     }
 
     #[test]
@@ -641,7 +720,32 @@ mod tests {
         let err = pool
             .push(prove_fake(&data, &targets, &fake(1, 11)))
             .unwrap_err();
-        assert!(err.to_string().contains("already queued"), "got: {err}");
+        assert!(err.to_string().contains("already pooled"), "got: {err}");
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn duplicate_nullifier_is_rejected_across_buckets() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        // The cumulative merkle tree lets the SAME spend be proven against two
+        // different recent blocks: individually valid proofs, same nullifier,
+        // different BatchKeys. Only one copy can settle, so the second must be
+        // rejected pool-wide, not just within its own bucket.
+        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        let err = pool
+            .push(prove_fake(&data, &targets, &fake(2, 11)))
+            .unwrap_err();
+        assert!(err.to_string().contains("already pooled"), "got: {err}");
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.num_buckets(), 1);
+
+        // Once the original is evicted (settled), the nullifier frees up.
+        let settled: HashSet<BytesDigest> = [nullifier_digest(11)].into_iter().collect();
+        assert_eq!(pool.evict_settled(&settled), 1);
+        pool.push(prove_fake(&data, &targets, &fake(2, 11)))
+            .unwrap();
         assert_eq!(pool.len(), 1);
     }
 

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -1,0 +1,603 @@
+//! Proof pool for delegated (public-batch) aggregation.
+//!
+//! A miner-facing, in-memory pool of private-batch proofs received from
+//! untrusted clients. Proofs are cryptographically verified on admission and
+//! bucketed by the metadata the public-batch circuit constrains across a batch
+//! (block hash, asset id, volume fee), so every bucket is aggregatable by
+//! construction: the "when to aggregate which bucket" decision is left to the
+//! operator's policy, fed by [`BucketStats`].
+//!
+//! Staleness: a queued proof becomes worthless once any of its nullifiers is
+//! settled on-chain (e.g. another miner included the same private batch, or a
+//! public batch containing it). Operators should call
+//! [`ProofPool::evict_settled`] with newly settled nullifiers on every imported
+//! block — both before proving (don't aggregate dead weight) and before
+//! submitting a finished public batch (don't submit stale segments).
+//!
+//! Note on dummies: an all-dummy private-batch proof (all-zero block hash) is
+//! admissible — it is a valid proof and lands in its own bucket — but it
+//! settles nothing, so a production policy should never select that bucket for
+//! aggregation.
+
+use std::collections::{BTreeMap, HashSet};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, ensure, Result};
+use plonky2::field::types::PrimeField64;
+use plonky2::plonk::{circuit_data::VerifierCircuitData, proof::ProofWithPublicInputs};
+use qp_wormhole_inputs::BytesDigest;
+use zk_circuits_common::{
+    circuit::{C, D, F},
+    utils::try_4_felts_to_bytes,
+};
+
+use crate::private_batch::circuit::constants::aggregated_output;
+
+type Proof = ProofWithPublicInputs<F, C, D>;
+
+/// The metadata the public-batch circuit requires all non-dummy inner proofs in
+/// one batch to share. Proofs with equal keys are aggregatable together by
+/// construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BatchKey {
+    pub block_hash: BytesDigest,
+    pub asset_id: u64,
+    pub volume_fee_bps: u64,
+}
+
+impl BatchKey {
+    /// All-dummy sentinel: the proof references no real block and settles nothing.
+    pub fn is_dummy(&self) -> bool {
+        self.block_hash == BytesDigest::default()
+    }
+}
+
+/// Global size limits protecting a pool that fronts untrusted traffic.
+#[derive(Debug, Clone, Copy)]
+pub struct PoolLimits {
+    /// Maximum number of proofs across all buckets.
+    pub max_proofs: usize,
+    /// Maximum number of distinct buckets (keys).
+    pub max_buckets: usize,
+}
+
+impl Default for PoolLimits {
+    fn default() -> Self {
+        Self {
+            max_proofs: 1024,
+            max_buckets: 256,
+        }
+    }
+}
+
+/// Point-in-time view of one bucket, for the operator's aggregation policy.
+#[derive(Debug, Clone)]
+pub struct BucketStats {
+    pub key: BatchKey,
+    /// Number of proofs currently queued in this bucket.
+    pub num_proofs: usize,
+    /// Bucket capacity (= public-batch size); at `num_proofs == batch_size`
+    /// the bucket aggregates without dummy padding.
+    pub batch_size: usize,
+    /// Time since the oldest queued proof in this bucket was admitted.
+    pub oldest_age: Duration,
+    /// Sum of all exit-slot amounts across queued proofs (settled volume proxy).
+    pub total_volume: u64,
+}
+
+impl BucketStats {
+    pub fn is_full(&self) -> bool {
+        self.num_proofs >= self.batch_size
+    }
+}
+
+#[derive(Debug)]
+struct PooledProof {
+    proof: Proof,
+    nullifiers: Vec<BytesDigest>,
+    volume: u64,
+    admitted_at: Instant,
+}
+
+/// A bounded pool of admission-verified private-batch proofs, bucketed by
+/// [`BatchKey`].
+#[derive(Debug)]
+pub struct ProofPool {
+    /// Canonical-pinned private-batch verifier data used for admission.
+    verifier: VerifierCircuitData<F, C, D>,
+    /// Leaves per inner private-batch proof (fixes the PI layout).
+    inner_num_leaves: usize,
+    /// Proofs per bucket (= public-batch size).
+    batch_size: usize,
+    limits: PoolLimits,
+    buckets: BTreeMap<BatchKey, Vec<PooledProof>>,
+}
+
+impl ProofPool {
+    /// Create a pool admitting proofs valid under `verifier`.
+    ///
+    /// `inner_num_leaves` is the number of leaves aggregated per private-batch
+    /// proof and `batch_size` the number of private-batch proofs per public
+    /// batch; both must match the circuit shapes pinned into `verifier` and the
+    /// public-batch prover this pool feeds.
+    pub fn new(
+        verifier: VerifierCircuitData<F, C, D>,
+        inner_num_leaves: usize,
+        batch_size: usize,
+        limits: PoolLimits,
+    ) -> Result<Self> {
+        ensure!(batch_size > 0, "batch_size must be positive");
+        ensure!(
+            limits.max_proofs >= batch_size,
+            "max_proofs ({}) must allow at least one full batch ({})",
+            limits.max_proofs,
+            batch_size
+        );
+        ensure!(limits.max_buckets > 0, "max_buckets must be positive");
+        let expected_pi_len = aggregated_output::pi_len(inner_num_leaves);
+        ensure!(
+            verifier.common.num_public_inputs == expected_pi_len,
+            "verifier public-input length {} does not match private-batch layout for {} leaves ({})",
+            verifier.common.num_public_inputs,
+            inner_num_leaves,
+            expected_pi_len
+        );
+        Ok(Self {
+            verifier,
+            inner_num_leaves,
+            batch_size,
+            limits,
+            buckets: BTreeMap::new(),
+        })
+    }
+
+    /// Total number of proofs across all buckets.
+    pub fn len(&self) -> usize {
+        self.buckets.values().map(Vec::len).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buckets.is_empty()
+    }
+
+    pub fn num_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    /// Validate and admit a proof, returning the bucket key it landed in.
+    ///
+    /// Checks run cheapest-first: capacity limits, public-input shape,
+    /// duplicate-nullifier rejection, then cryptographic verification. A proof
+    /// admitted here is individually valid and, by bucketing, batch-compatible
+    /// with every other proof in its bucket, so aggregation over a bucket
+    /// cannot fail deterministically on admitted inputs (#97067).
+    pub fn push(&mut self, proof: Proof) -> Result<BatchKey> {
+        if self.len() >= self.limits.max_proofs {
+            bail!(
+                "proof pool is full ({} proofs, limit {})",
+                self.len(),
+                self.limits.max_proofs
+            );
+        }
+
+        let metadata = self.parse_metadata(&proof)?;
+        let key = metadata.0;
+
+        match self.buckets.get(&key) {
+            Some(bucket) => {
+                if bucket.len() >= self.batch_size {
+                    bail!(
+                        "bucket for block {:?} (asset {}, fee {}) is full ({} proofs)",
+                        key.block_hash,
+                        key.asset_id,
+                        key.volume_fee_bps,
+                        self.batch_size
+                    );
+                }
+                // A duplicate nullifier within one bucket means the same leaf
+                // spend would occupy two batch slots; the second copy can never
+                // settle. Reject it (this also deduplicates client re-submissions).
+                for queued in bucket {
+                    if let Some(dup) = metadata.1.iter().find(|n| queued.nullifiers.contains(n)) {
+                        bail!(
+                            "refusing to queue private-batch proof: nullifier {:?} is already \
+                             queued in the same bucket",
+                            dup
+                        );
+                    }
+                }
+            }
+            None => {
+                if self.buckets.len() >= self.limits.max_buckets {
+                    bail!(
+                        "proof pool bucket limit reached ({} buckets); \
+                         proof for block {:?} rejected",
+                        self.limits.max_buckets,
+                        key.block_hash
+                    );
+                }
+            }
+        }
+
+        self.verifier.verify(proof.clone()).map_err(|e| {
+            anyhow!(
+                "refusing to queue invalid private-batch proof: verification failed: {}",
+                e
+            )
+        })?;
+
+        let (key, nullifiers, volume) = metadata;
+        self.buckets.entry(key).or_default().push(PooledProof {
+            proof,
+            nullifiers,
+            volume,
+            admitted_at: Instant::now(),
+        });
+        Ok(key)
+    }
+
+    /// Remove every queued proof that has at least one nullifier in `settled`,
+    /// dropping buckets that become empty. Returns the number of evicted proofs.
+    ///
+    /// Call with the nullifiers settled by each imported block, both before
+    /// aggregating (avoid proving dead weight) and before submitting a finished
+    /// public batch (detect batches that went stale mid-proving).
+    pub fn evict_settled(&mut self, settled: &HashSet<BytesDigest>) -> usize {
+        let mut evicted = 0;
+        self.buckets.retain(|_, bucket| {
+            bucket.retain(|queued| {
+                let stale = queued.nullifiers.iter().any(|n| settled.contains(n));
+                if stale {
+                    evicted += 1;
+                }
+                !stale
+            });
+            !bucket.is_empty()
+        });
+        evicted
+    }
+
+    /// Per-bucket statistics for the operator's aggregation policy.
+    pub fn bucket_stats(&self) -> Vec<BucketStats> {
+        let now = Instant::now();
+        self.buckets
+            .iter()
+            .map(|(key, bucket)| BucketStats {
+                key: *key,
+                num_proofs: bucket.len(),
+                batch_size: self.batch_size,
+                oldest_age: bucket
+                    .iter()
+                    .map(|q| now.saturating_duration_since(q.admitted_at))
+                    .max()
+                    .unwrap_or_default(),
+                total_volume: bucket
+                    .iter()
+                    .fold(0u64, |acc, q| acc.saturating_add(q.volume)),
+            })
+            .collect()
+    }
+
+    /// Clone the proofs of one bucket (for aggregation attempts that must not
+    /// disturb the pool on failure).
+    pub fn bucket_proofs(&self, key: &BatchKey) -> Option<Vec<Proof>> {
+        self.buckets
+            .get(key)
+            .map(|bucket| bucket.iter().map(|q| q.proof.clone()).collect())
+    }
+
+    /// Remove one bucket entirely, returning its proofs (empty if absent).
+    ///
+    /// Used both to drain a bucket after successful aggregation and as an
+    /// operator recovery/expiry path for buckets that will never be aggregated.
+    pub fn remove_bucket(&mut self, key: &BatchKey) -> Vec<Proof> {
+        self.buckets
+            .remove(key)
+            .map(|bucket| bucket.into_iter().map(|q| q.proof).collect())
+            .unwrap_or_default()
+    }
+
+    /// Parse (key, nullifiers, volume) from a private-batch proof's public inputs.
+    fn parse_metadata(&self, proof: &Proof) -> Result<(BatchKey, Vec<BytesDigest>, u64)> {
+        let pis = &proof.public_inputs;
+        let expected = self.verifier.common.num_public_inputs;
+        if pis.len() != expected {
+            bail!(
+                "private-batch proof public input length mismatch: expected {}, got {}",
+                expected,
+                pis.len()
+            );
+        }
+
+        let block_hash = try_4_felts_to_bytes(
+            &pis[aggregated_output::BLOCK_HASH_OFFSET..aggregated_output::BLOCK_HASH_OFFSET + 4],
+        )
+        .map_err(|e| anyhow!("failed to parse private-batch proof block hash: {}", e))?;
+        let key = BatchKey {
+            block_hash,
+            asset_id: pis[aggregated_output::ASSET_ID_OFFSET].to_canonical_u64(),
+            volume_fee_bps: pis[aggregated_output::VOLUME_FEE_BPS_OFFSET].to_canonical_u64(),
+        };
+
+        let nullifiers_start = aggregated_output::nullifiers_start(self.inner_num_leaves);
+        let nullifiers = (0..aggregated_output::nullifiers_count(self.inner_num_leaves))
+            .map(|i| {
+                let start = nullifiers_start + i * 4;
+                try_4_felts_to_bytes(&pis[start..start + 4]).map_err(|e| {
+                    anyhow!("failed to parse private-batch proof nullifier {}: {}", i, e)
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let exit_slots_start = aggregated_output::exit_slots_start();
+        let volume = (0..aggregated_output::exit_slots_count(self.inner_num_leaves))
+            .map(|i| {
+                pis[exit_slots_start + i * aggregated_output::EXIT_SLOT_LEN].to_canonical_u64()
+            })
+            .fold(0u64, |acc, sum| acc.saturating_add(sum));
+
+        Ok((key, nullifiers, volume))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use plonky2::field::types::Field;
+    use plonky2::iop::target::Target;
+    use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+    use plonky2::plonk::{
+        circuit_builder::CircuitBuilder,
+        circuit_data::{CircuitConfig, CircuitData},
+    };
+
+    const NUM_LEAVES: usize = 1;
+
+    fn pi_len() -> usize {
+        aggregated_output::pi_len(NUM_LEAVES)
+    }
+
+    /// A minimal circuit whose public inputs mimic the private-batch layout,
+    /// so pool admission logic can be exercised without real aggregation proofs.
+    fn build_fake_private_batch_circuit() -> (CircuitData<F, C, D>, Vec<Target>) {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut builder = CircuitBuilder::<F, D>::new(config);
+        let pis = builder.add_virtual_targets(pi_len());
+        builder.range_check(pis[0], 32);
+        builder.register_public_inputs(&pis);
+        (builder.build::<C>(), pis)
+    }
+
+    struct FakePis {
+        asset_id: u64,
+        volume_fee_bps: u64,
+        block: u64,
+        exit_sums: [u64; 2],
+        nullifier: u64,
+    }
+
+    fn prove_fake(data: &CircuitData<F, C, D>, targets: &[Target], p: &FakePis) -> Proof {
+        let mut values = vec![F::ZERO; pi_len()];
+        values[aggregated_output::NUM_EXIT_SLOTS_OFFSET] = F::from_canonical_u64(2);
+        values[aggregated_output::ASSET_ID_OFFSET] = F::from_canonical_u64(p.asset_id);
+        values[aggregated_output::VOLUME_FEE_BPS_OFFSET] = F::from_canonical_u64(p.volume_fee_bps);
+        values[aggregated_output::BLOCK_HASH_OFFSET] = F::from_canonical_u64(p.block);
+        for i in 0..2 {
+            values[aggregated_output::exit_slots_start() + i * aggregated_output::EXIT_SLOT_LEN] =
+                F::from_canonical_u64(p.exit_sums[i]);
+        }
+        values[aggregated_output::nullifiers_start(NUM_LEAVES)] =
+            F::from_canonical_u64(p.nullifier);
+
+        let mut pw = PartialWitness::new();
+        for (t, v) in targets.iter().zip(values.iter()) {
+            pw.set_target(*t, *v).unwrap();
+        }
+        data.prove(pw).unwrap()
+    }
+
+    fn nullifier_digest(n: u64) -> BytesDigest {
+        let felts = [F::from_canonical_u64(n), F::ZERO, F::ZERO, F::ZERO];
+        try_4_felts_to_bytes(&felts).unwrap()
+    }
+
+    fn make_pool(
+        batch_size: usize,
+        limits: PoolLimits,
+    ) -> (ProofPool, CircuitData<F, C, D>, Vec<Target>) {
+        let (data, targets) = build_fake_private_batch_circuit();
+        let pool = ProofPool::new(data.verifier_data(), NUM_LEAVES, batch_size, limits).unwrap();
+        (pool, data, targets)
+    }
+
+    fn fake(block: u64, nullifier: u64) -> FakePis {
+        FakePis {
+            asset_id: 0,
+            volume_fee_bps: 10,
+            block,
+            exit_sums: [100, 50],
+            nullifier,
+        }
+    }
+
+    #[test]
+    fn proofs_bucket_by_key() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        let key_a = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        let key_a2 = pool
+            .push(prove_fake(&data, &targets, &fake(1, 12)))
+            .unwrap();
+        let key_b = pool
+            .push(prove_fake(&data, &targets, &fake(2, 13)))
+            .unwrap();
+
+        assert_eq!(key_a, key_a2);
+        assert_ne!(key_a, key_b);
+        assert_eq!(pool.len(), 3);
+        assert_eq!(pool.num_buckets(), 2);
+
+        let stats = pool.bucket_stats();
+        let a = stats.iter().find(|s| s.key == key_a).unwrap();
+        assert_eq!(a.num_proofs, 2);
+        assert!(a.is_full());
+        assert_eq!(a.total_volume, 300);
+        let b = stats.iter().find(|s| s.key == key_b).unwrap();
+        assert_eq!(b.num_proofs, 1);
+        assert!(!b.is_full());
+    }
+
+    #[test]
+    fn full_bucket_rejects_without_touching_other_buckets() {
+        let (mut pool, data, targets) = make_pool(1, PoolLimits::default());
+
+        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        let err = pool
+            .push(prove_fake(&data, &targets, &fake(1, 12)))
+            .unwrap_err();
+        assert!(err.to_string().contains("is full"), "got: {err}");
+
+        // Other keys still admit.
+        pool.push(prove_fake(&data, &targets, &fake(2, 13)))
+            .unwrap();
+        assert_eq!(pool.len(), 2);
+    }
+
+    #[test]
+    fn duplicate_nullifier_in_bucket_is_rejected() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        let err = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap_err();
+        assert!(err.to_string().contains("already queued"), "got: {err}");
+        assert_eq!(pool.len(), 1);
+    }
+
+    #[test]
+    fn tampered_proof_is_rejected() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        let mut proof = prove_fake(&data, &targets, &fake(1, 11));
+        proof.public_inputs[aggregated_output::ASSET_ID_OFFSET] = F::from_canonical_u64(9);
+        let err = pool.push(proof).unwrap_err();
+        assert!(
+            err.to_string().contains("verification failed"),
+            "got: {err}"
+        );
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn wrong_pi_length_is_rejected() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        let mut proof = prove_fake(&data, &targets, &fake(1, 11));
+        proof.public_inputs.pop();
+        let err = pool.push(proof).unwrap_err();
+        assert!(
+            err.to_string().contains("public input length mismatch"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn global_proof_cap_is_enforced() {
+        let (mut pool, data, targets) = make_pool(
+            1,
+            PoolLimits {
+                max_proofs: 1,
+                max_buckets: 8,
+            },
+        );
+
+        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        let err = pool
+            .push(prove_fake(&data, &targets, &fake(2, 12)))
+            .unwrap_err();
+        assert!(err.to_string().contains("pool is full"), "got: {err}");
+    }
+
+    #[test]
+    fn bucket_cap_is_enforced() {
+        let (mut pool, data, targets) = make_pool(
+            1,
+            PoolLimits {
+                max_proofs: 16,
+                max_buckets: 1,
+            },
+        );
+
+        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        let err = pool
+            .push(prove_fake(&data, &targets, &fake(2, 12)))
+            .unwrap_err();
+        assert!(err.to_string().contains("bucket limit"), "got: {err}");
+    }
+
+    #[test]
+    fn evict_settled_removes_proofs_and_empty_buckets() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        let key_a = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        pool.push(prove_fake(&data, &targets, &fake(1, 12)))
+            .unwrap();
+        let key_b = pool
+            .push(prove_fake(&data, &targets, &fake(2, 13)))
+            .unwrap();
+
+        let settled: HashSet<BytesDigest> = [nullifier_digest(11), nullifier_digest(13)]
+            .into_iter()
+            .collect();
+        let evicted = pool.evict_settled(&settled);
+
+        assert_eq!(evicted, 2);
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.num_buckets(), 1);
+        assert!(pool.bucket_proofs(&key_a).is_some());
+        assert!(pool.bucket_proofs(&key_b).is_none());
+    }
+
+    #[test]
+    fn remove_bucket_returns_proofs() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        pool.push(prove_fake(&data, &targets, &fake(1, 12)))
+            .unwrap();
+
+        let drained = pool.remove_bucket(&key);
+        assert_eq!(drained.len(), 2);
+        assert!(pool.is_empty());
+        assert!(pool.remove_bucket(&key).is_empty());
+    }
+
+    #[test]
+    fn dummy_key_is_detected() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(0, 11)))
+            .unwrap();
+        assert!(key.is_dummy());
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(3, 12)))
+            .unwrap();
+        assert!(!key.is_dummy());
+    }
+}

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -252,6 +252,13 @@ impl PrivateBatchProver {
             bail!("private-batch aggregation prover has already committed to inputs");
         };
 
+        // An empty batch would be padded into an all-dummy proof that settles
+        // nothing; a client asking for that is a caller bug. (The intentional
+        // all-dummy padding template is built on the circuit-build path, which
+        // fills the witness with explicit dummy leaves and never calls here.)
+        if proofs.is_empty() {
+            bail!("no leaf proofs to aggregate");
+        }
         if proofs.len() > self.num_leaf_proofs {
             bail!(
                 "too many proofs: got {}, expected at most {}",

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -244,6 +244,9 @@ impl PrivateBatchProver {
     /// Commit leaf proofs to the aggregation circuit witness.
     ///
     /// Performs padding with dummy proofs, shuffling, and witness filling.
+    /// Rejects batches the private-batch circuit's cross-slot constraints would
+    /// fail (mixed block hashes, asset ids, or fee rates) up front, so callers
+    /// get a precise error in milliseconds instead of a proving failure.
     pub fn commit(mut self, mut proofs: Vec<ProofWithPublicInputs<F, C, D>>) -> Result<Self> {
         let Some(targets) = self.targets.take() else {
             bail!("private-batch aggregation prover has already committed to inputs");
@@ -281,6 +284,8 @@ impl PrivateBatchProver {
             }
         }
 
+        ensure_leaf_batch_compatible(&proofs)?;
+
         // Pad with dummy proofs
         for _ in 0..num_dummies_needed {
             proofs.push(self.dummy_proof_template.clone());
@@ -314,11 +319,102 @@ impl PrivateBatchProver {
             .prove(self.partial_witness)
             .map_err(|e| anyhow!("Failed to prove private-batch aggregation circuit: {}", e))
     }
+
+    /// One-shot client aggregation: commit the full leaf-proof set and prove.
+    ///
+    /// This is the intended client (CLI / mobile) entry point: a client knows
+    /// its complete leaf set up front, so there is no queue — pass everything
+    /// at once. Cross-proof compatibility is checked fail-fast in `commit`.
+    pub fn aggregate(
+        self,
+        proofs: Vec<ProofWithPublicInputs<F, C, D>>,
+    ) -> Result<ProofWithPublicInputs<F, C, D>> {
+        self.commit(proofs)?.prove()
+    }
 }
 
 // -----------------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------------
+
+/// Check that a set of leaf proofs is mutually compatible under the
+/// private-batch circuit's cross-slot constraints, so an incompatible batch is
+/// rejected at commit time instead of failing after minutes of proving:
+///
+/// - `asset_id` must match across ALL proofs (dummies included),
+/// - `block_hash` and `volume_fee_bps` must match between non-dummy proofs
+///   (`block_hash == 0` slots are exempt).
+///
+/// NOTE: keep in lockstep with the circuit's cross-slot constraints
+/// (`private_batch::circuit::circuit_logic`). The circuit remains the enforcer;
+/// this only improves failure latency and error quality.
+fn ensure_leaf_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) -> Result<()> {
+    use crate::private_batch::circuit::constants::{
+        ASSET_ID_START, BLOCK_HASH_START, VOLUME_FEE_BPS_START,
+    };
+
+    struct LeafMeta {
+        asset_id: u64,
+        volume_fee_bps: u64,
+        block_hash: [u64; 4],
+    }
+    // PI lengths were validated by the caller.
+    let metas: Vec<LeafMeta> = proofs
+        .iter()
+        .map(|proof| LeafMeta {
+            asset_id: proof.public_inputs[ASSET_ID_START].to_canonical_u64(),
+            volume_fee_bps: proof.public_inputs[VOLUME_FEE_BPS_START].to_canonical_u64(),
+            block_hash: core::array::from_fn(|i| {
+                proof.public_inputs[BLOCK_HASH_START + i].to_canonical_u64()
+            }),
+        })
+        .collect();
+
+    if let Some(first) = metas.first() {
+        for (idx, meta) in metas.iter().enumerate().skip(1) {
+            if meta.asset_id != first.asset_id {
+                bail!(
+                    "leaf proof {} has asset_id={}, but proof 0 has asset_id={}; \
+                     the private-batch circuit enforces asset consistency across all slots",
+                    idx,
+                    meta.asset_id,
+                    first.asset_id
+                );
+            }
+        }
+    }
+
+    let mut reference: Option<(usize, &LeafMeta)> = None;
+    for (idx, meta) in metas.iter().enumerate() {
+        if meta.block_hash == [0u64; 4] {
+            continue; // dummy sentinel: exempt from block/fee consistency
+        }
+        match reference {
+            None => reference = Some((idx, meta)),
+            Some((ref_idx, reference)) => {
+                if meta.block_hash != reference.block_hash {
+                    bail!(
+                        "leaf proof {} is for a different block than proof {}; \
+                         all non-dummy proofs in a private batch must share one block hash",
+                        idx,
+                        ref_idx
+                    );
+                }
+                if meta.volume_fee_bps != reference.volume_fee_bps {
+                    bail!(
+                        "leaf proof {} has volume_fee_bps={}, but proof {} has volume_fee_bps={}; \
+                         all non-dummy proofs in a private batch must share one fee rate",
+                        idx,
+                        meta.volume_fee_bps,
+                        ref_idx,
+                        reference.volume_fee_bps
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
 
 /// Verify that the dummy leaf proof template is a valid leaf proof carrying the
 /// strong dummy sentinel: `block_hash == 0` AND both output amounts zero.
@@ -378,6 +474,9 @@ fn generate_dummy_nullifier_pre_images_for_slots(n_slots: usize) -> Vec<[F; 4]> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::private_batch::circuit::constants::{
+        ASSET_ID_START, BLOCK_HASH_START, VOLUME_FEE_BPS_START,
+    };
     use plonky2::field::types::Field;
     use qp_wormhole_inputs::{
         BLOCK_HASH_START_INDEX, NULLIFIER_START_INDEX, OUTPUT_AMOUNT_1_INDEX,
@@ -431,5 +530,64 @@ mod tests {
             err.to_string().contains("failed verification"),
             "got: {err}"
         );
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-proof batch-compatibility preflight
+    // -------------------------------------------------------------------------
+
+    fn leaf_pis(asset_id: u64, volume_fee_bps: u64, block: u64) -> [F; PUBLIC_INPUTS_FELTS_LEN] {
+        let mut pis = [F::ZERO; PUBLIC_INPUTS_FELTS_LEN];
+        pis[ASSET_ID_START] = F::from_canonical_u64(asset_id);
+        pis[VOLUME_FEE_BPS_START] = F::from_canonical_u64(volume_fee_bps);
+        pis[BLOCK_HASH_START] = F::from_canonical_u64(block);
+        pis
+    }
+
+    #[test]
+    fn compatible_leaf_batch_is_accepted() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let proofs = vec![
+            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 1)),
+            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 1)),
+            // Dummy slot: exempt from block/fee consistency.
+            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 99, 0)),
+        ];
+        ensure_leaf_batch_compatible(&proofs).expect("compatible batch must be accepted");
+    }
+
+    #[test]
+    fn mixed_block_leaf_batch_is_rejected() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let proofs = vec![
+            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 1)),
+            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 2)),
+        ];
+        let err = ensure_leaf_batch_compatible(&proofs).unwrap_err();
+        assert!(err.to_string().contains("different block"), "got: {err}");
+    }
+
+    #[test]
+    fn mixed_fee_leaf_batch_is_rejected() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let proofs = vec![
+            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 1)),
+            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 20, 1)),
+        ];
+        let err = ensure_leaf_batch_compatible(&proofs).unwrap_err();
+        assert!(err.to_string().contains("volume_fee_bps"), "got: {err}");
+    }
+
+    #[test]
+    fn mixed_asset_leaf_batch_is_rejected_even_for_dummies() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        // Second proof is a dummy (block 0) with a different asset: the circuit
+        // enforces asset equality across ALL slots, dummies included.
+        let proofs = vec![
+            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 1)),
+            prove_fake_leaf(&leaf, &targets, leaf_pis(5, 10, 0)),
+        ];
+        let err = ensure_leaf_batch_compatible(&proofs).unwrap_err();
+        assert!(err.to_string().contains("asset"), "got: {err}");
     }
 }

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -9,10 +9,10 @@ use std::path::{Path, PathBuf};
 use std::sync::{Once, OnceLock};
 use test_helpers::{compute_zk_leaf_hash, TestInputs};
 use wormhole_aggregator::aggregator::PublicBatchAggregator;
-use wormhole_aggregator::pool::BatchKey;
 use wormhole_aggregator::common::utils::{
     load_canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
 };
+use wormhole_aggregator::pool::BatchKey;
 use wormhole_aggregator::private_batch::prover::PrivateBatchProver;
 use wormhole_circuit::inputs::{CircuitInputs, ParsePublicInputs};
 use wormhole_prover::WormholeProver;

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Once, OnceLock};
 use test_helpers::{compute_zk_leaf_hash, TestInputs};
 use wormhole_aggregator::aggregator::PublicBatchAggregator;
+use wormhole_aggregator::pool::BatchKey;
 use wormhole_aggregator::common::utils::{
     load_canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
 };
@@ -113,6 +114,20 @@ fn private_batch_verifier() -> VerifierCircuitData<F, C, D> {
         PRIVATE_NUM_LEAVES,
     )
     .expect("Failed to load private-batch verifier data")
+}
+
+/// Valid leaf inputs like `test_inputs_0` but with a REAL block hash computed
+/// from the header fields, so the proof is non-dummy (`test_inputs_0` uses the
+/// dummy sentinel `block_hash == 0`, which pools into the dummy bucket that
+/// `PublicBatchAggregator` refuses to aggregate).
+fn test_inputs_with_real_block() -> CircuitInputs {
+    use wormhole_circuit::block_header::header::HeaderInputs;
+
+    let mut inputs = CircuitInputs::test_inputs_0();
+    inputs.public.block_hash = HeaderInputs::try_from(&inputs)
+        .expect("header inputs from test inputs")
+        .block_hash();
+    inputs
 }
 
 /// Valid leaf inputs like `test_inputs_0` but for a non-native asset. The asset
@@ -349,7 +364,8 @@ fn make_private_batch_proof_in_public_dir() -> ProofWithPublicInputs<F, C, D> {
         .get_or_init(|| {
             setup_public_test_binaries();
             let dir = public_bins_dir();
-            let leaf = make_leaf_proof_in(&dir, &CircuitInputs::test_inputs_0());
+            // Non-dummy inputs: the aggregator refuses the dummy bucket.
+            let leaf = make_leaf_proof_in(&dir, &test_inputs_with_real_block());
             PrivateBatchProver::new_from_binaries_dir(&dir)
                 .expect("load private-batch prover from public test binaries")
                 .aggregate(vec![leaf])
@@ -407,6 +423,15 @@ fn pool_rejects_invalid_proofs_and_aggregates_by_bucket() {
     // Aggregating a missing bucket is an error, and the pool stays usable.
     let err = aggregator.aggregate(&key).unwrap_err();
     assert!(err.to_string().contains("no pooled proofs"), "got: {err}");
+
+    // The dummy sentinel bucket (block_hash == 0) is refused outright: an
+    // all-dummy public batch settles nothing, so proving it wastes minutes.
+    let dummy_key = BatchKey {
+        block_hash: BytesDigest::default(),
+        ..key
+    };
+    let err = aggregator.aggregate(&dummy_key).unwrap_err();
+    assert!(err.to_string().contains("dummy"), "got: {err}");
 }
 
 #[test]

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -2,13 +2,15 @@
 
 use circuit_builder::generate_all_circuit_binaries;
 use plonky2::field::types::Field;
+use plonky2::plonk::circuit_data::VerifierCircuitData;
 use plonky2::plonk::proof::ProofWithPublicInputs;
 use qp_wormhole_inputs::{BytesDigest, PublicCircuitInputs};
-use std::path::Path;
-use std::sync::Once;
+use std::path::{Path, PathBuf};
+use std::sync::{Once, OnceLock};
 use test_helpers::{compute_zk_leaf_hash, TestInputs};
-use wormhole_aggregator::aggregator::{
-    AggregationBackend, PrivateBatchAggregator, PublicBatchAggregator,
+use wormhole_aggregator::aggregator::PublicBatchAggregator;
+use wormhole_aggregator::common::utils::{
+    load_canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
 };
 use wormhole_aggregator::private_batch::prover::PrivateBatchProver;
 use wormhole_circuit::inputs::{CircuitInputs, ParsePublicInputs};
@@ -17,122 +19,135 @@ use zk_circuits_common::circuit::{C, D, F};
 
 use crate::aggregator::circuit_config;
 
-const TEST_OUTPUT_DIR: &str = "tmp-test-bins";
-const PUBLIC_TEST_OUTPUT_DIR: &str = "tmp-test-public-bins";
+/// Leaves per private batch in the client-side test artifacts.
+const PRIVATE_NUM_LEAVES: usize = 2;
 
 static TEST_INIT: Once = Once::new();
 static PUBLIC_TEST_INIT: Once = Once::new();
 
-extern "C" fn cleanup_test_output_dir() {
-    // Best-effort cleanup (don’t panic during shutdown)
-    let _ = std::fs::remove_dir_all(TEST_OUTPUT_DIR);
+/// Absolute per-process root for generated circuit artifacts.
+///
+/// Tests previously used cwd-relative directories, which made every test in
+/// the binary sensitive to the working directory and to sibling tests'
+/// cleanup. Absolute paths keyed by pid keep parallel test binaries and
+/// reruns isolated from each other.
+fn test_bins_root() -> &'static PathBuf {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        std::env::temp_dir().join(format!(
+            "qp-wormhole-aggregator-tests-{}",
+            std::process::id()
+        ))
+    })
+}
+
+fn private_bins_dir() -> PathBuf {
+    test_bins_root().join("private")
+}
+
+fn public_bins_dir() -> PathBuf {
+    test_bins_root().join("public")
+}
+
+extern "C" fn cleanup_test_bins_root() {
+    // Best-effort cleanup (don't panic during shutdown).
+    let _ = std::fs::remove_dir_all(test_bins_root());
 }
 
 fn setup_test_binaries() {
     TEST_INIT.call_once(|| {
-        generate_all_circuit_binaries(TEST_OUTPUT_DIR, true, 2, None)
+        generate_all_circuit_binaries(private_bins_dir(), true, PRIVATE_NUM_LEAVES, None)
             .expect("Failed to generate test circuit binaries");
 
         // Register a process-exit cleanup so the directory is removed once all tests finish.
         unsafe {
             // Ignore return value; if registration fails we simply won't auto-clean.
-            let _ = libc::atexit(cleanup_test_output_dir);
+            let _ = libc::atexit(cleanup_test_bins_root);
         }
     });
-}
-
-fn make_leaf_proof(inputs: &CircuitInputs) -> ProofWithPublicInputs<F, C, D> {
-    setup_test_binaries();
-
-    let prover_path = format!("{}/prover.bin", TEST_OUTPUT_DIR);
-    let common_path = format!("{}/common.bin", TEST_OUTPUT_DIR);
-    let prover = WormholeProver::new_from_files(Path::new(&prover_path), Path::new(&common_path))
-        .expect("Failed to create prover from binaries");
-    prover.commit(inputs).unwrap().prove().unwrap()
-}
-fn make_aggregator() -> PrivateBatchAggregator {
-    setup_test_binaries();
-    PrivateBatchAggregator::new(TEST_OUTPUT_DIR).unwrap()
-}
-
-fn make_private_batch_prover() -> PrivateBatchProver {
-    setup_test_binaries();
-    PrivateBatchProver::new_from_binaries_dir(Path::new(TEST_OUTPUT_DIR))
-        .expect("Failed to load private-batch prover from generated binaries")
 }
 
 fn setup_public_test_binaries() {
     PUBLIC_TEST_INIT.call_once(|| {
         // Smallest public-batch circuit (1 inner private-batch of 1 leaf) to keep
         // artifact generation fast.
-        generate_all_circuit_binaries(PUBLIC_TEST_OUTPUT_DIR, true, 1, Some(1))
+        generate_all_circuit_binaries(public_bins_dir(), true, 1, Some(1))
             .expect("Failed to generate public-batch test circuit binaries");
+
+        unsafe {
+            let _ = libc::atexit(cleanup_test_bins_root);
+        }
     });
 }
 
-#[test]
-fn push_proof_to_buffer() {
-    setup_test_binaries();
-    let proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
-
-    let mut aggregator = make_aggregator();
-
-    aggregator.push_proof(proof).unwrap();
-
-    assert_eq!(aggregator.buffer_len(), 1);
+fn make_leaf_proof_in(dir: &Path, inputs: &CircuitInputs) -> ProofWithPublicInputs<F, C, D> {
+    let prover = WormholeProver::new_from_files(&dir.join("prover.bin"), &dir.join("common.bin"))
+        .expect("Failed to create prover from binaries");
+    prover.commit(inputs).unwrap().prove().unwrap()
 }
 
-#[test]
-fn push_proof_to_full_buffer() {
+fn make_leaf_proof(inputs: &CircuitInputs) -> ProofWithPublicInputs<F, C, D> {
     setup_test_binaries();
-    let proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
+    make_leaf_proof_in(&private_bins_dir(), inputs)
+}
 
-    let mut aggregator = make_aggregator();
+fn make_private_batch_prover() -> PrivateBatchProver {
+    setup_test_binaries();
+    PrivateBatchProver::new_from_binaries_dir(&private_bins_dir())
+        .expect("Failed to load private-batch prover from generated binaries")
+}
 
-    // Fill the buffer
-    for _ in 0..aggregator.batch_size() {
-        aggregator.push_proof(proof.clone()).unwrap();
-    }
+/// Canonical-pinned verifier for the client-side private-batch artifacts.
+fn private_batch_verifier() -> VerifierCircuitData<F, C, D> {
+    setup_test_binaries();
+    let dir = private_bins_dir();
+    let leaf = load_canonical_leaf_verifier_data(
+        &std::fs::read(dir.join("common.bin")).unwrap(),
+        &std::fs::read(dir.join("verifier.bin")).unwrap(),
+    )
+    .expect("Failed to load leaf verifier data");
+    load_canonical_private_batch_verifier_data(
+        &std::fs::read(dir.join("private_batch_common.bin")).unwrap(),
+        &std::fs::read(dir.join("private_batch_verifier.bin")).unwrap(),
+        &leaf,
+        PRIVATE_NUM_LEAVES,
+    )
+    .expect("Failed to load private-batch verifier data")
+}
 
-    // One more push should fail
-    let result = aggregator.push_proof(proof);
-    assert!(
-        result.is_err(),
-        "expected error when pushing to full buffer"
+/// Valid leaf inputs like `test_inputs_0` but for a non-native asset. The asset
+/// id is part of the ZK leaf hash, so the tree root must be recomputed.
+fn test_inputs_with_asset(asset_id: u32) -> CircuitInputs {
+    let mut inputs = CircuitInputs::test_inputs_0();
+    inputs.public.asset_id = asset_id;
+    inputs.private.zk_tree_root = compute_zk_leaf_hash(
+        &inputs.private.unspendable_account,
+        inputs.private.transfer_count,
+        asset_id,
+        inputs.private.input_amount,
     );
+    inputs
 }
 
-#[test]
-fn push_proof_rejects_malformed_public_input_length() {
-    setup_test_binaries();
-    let mut proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
-    proof.public_inputs.pop();
-
-    let mut aggregator = make_aggregator();
-    let err = aggregator.push_proof(proof).unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("leaf proof public input length mismatch"));
-}
+// ============================================================================
+// Client-side (private batch): one-shot aggregation, no queue
+// ============================================================================
 
 #[test]
 fn aggregate_single_proof() {
-    setup_test_binaries();
     let proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
 
-    let mut aggregator = make_aggregator();
-
-    aggregator.push_proof(proof).unwrap();
-
-    let aggregated = aggregator.aggregate().unwrap();
-    aggregator
+    // A single proof in a 2-slot batch exercises dummy padding.
+    let aggregated = make_private_batch_prover()
+        .aggregate(vec![proof])
+        .expect("aggregation must succeed");
+    private_batch_verifier()
         .verify(aggregated)
         .expect("Aggregated proof should verify");
 }
 
 #[test]
 fn aggregate_proofs_into_tree() {
-    setup_test_binaries();
     // All proofs must be from the SAME BLOCK for fixed-structure aggregation.
     let inputs = CircuitInputs::test_inputs_0();
 
@@ -145,40 +160,19 @@ fn aggregate_proofs_into_tree() {
     println!("proof_0 public inputs = {:?}", pi0);
     println!("proof_1 public inputs = {:?}", pi1);
 
-    let mut aggregator = make_aggregator();
-
-    aggregator.push_proof(proof_0).unwrap();
-    aggregator.push_proof(proof_1).unwrap();
-
-    let aggregated = aggregator.aggregate().unwrap();
-    aggregator
-        .verify(aggregated)
-        .expect("Aggregated proof should verify");
-}
-
-#[test]
-fn aggregate_half_full_proof_array_into_tree() {
-    setup_test_binaries();
-    // Intentionally only push one proof into a 2-proof aggregator to exercise padding.
-    let proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
-
-    let mut aggregator = make_aggregator();
-
-    aggregator.push_proof(proof).unwrap();
-
-    let aggregated = aggregator.aggregate().unwrap();
-    aggregator
+    let aggregated = make_private_batch_prover()
+        .aggregate(vec![proof_0, proof_1])
+        .expect("aggregation must succeed");
+    private_batch_verifier()
         .verify(aggregated)
         .expect("Aggregated proof should verify");
 }
 
 #[test]
 fn commit_rejects_nonzero_asset_id_when_dummy_padding_is_needed() {
-    setup_test_binaries();
-    // Tampering with asset_id invalidates the proof cryptographically, so the
-    // aggregator now rejects it at push time (see below). The asset-id padding
-    // preflight is still reachable through the prover's commit API, which does
-    // not verify proofs itself.
+    // Tampering with asset_id invalidates the proof cryptographically, but the
+    // prover's commit API does not verify proofs; the asset-id padding
+    // preflight must still reject it before witness filling.
     let mut proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
     proof.public_inputs[0] = F::from_canonical_u64(1);
 
@@ -188,150 +182,45 @@ fn commit_rejects_nonzero_asset_id_when_dummy_padding_is_needed() {
 }
 
 #[test]
-fn push_proof_rejects_invalid_proof_and_queue_stays_usable() {
-    setup_test_binaries();
-    // An invalid proof (correct PI length, tampered contents) must be rejected at
-    // push time. Since aggregate() only drains the queue on success (#97067), a
-    // poisoned proof accepted into the queue would make every retry fail on the
-    // same batch, wedging the aggregator permanently.
-    let mut tampered = make_leaf_proof(&CircuitInputs::test_inputs_0());
-    tampered.public_inputs[0] = F::from_canonical_u64(1);
+fn commit_rejects_batch_incompatible_proofs() {
+    // Two individually valid proofs whose metadata the private-batch circuit's
+    // cross-slot constraints reject (different asset ids) must fail fast at
+    // commit time, not minutes later inside proving.
+    let proof_asset_0 = make_leaf_proof(&CircuitInputs::test_inputs_0());
+    let proof_asset_5 = make_leaf_proof(&test_inputs_with_asset(5));
 
-    let mut aggregator = make_aggregator();
-    let err = aggregator.push_proof(tampered).unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("refusing to queue invalid leaf proof"),
-        "got: {err}"
-    );
-    assert_eq!(
-        aggregator.buffer_len(),
-        0,
-        "rejected proof must not be queued"
-    );
-
-    // The aggregator remains fully usable: a valid proof pushes and aggregates.
-    let valid = make_leaf_proof(&CircuitInputs::test_inputs_0());
-    aggregator.push_proof(valid).unwrap();
-    let aggregated = aggregator.aggregate().expect("aggregation must succeed");
-    aggregator
-        .verify(aggregated)
-        .expect("aggregated proof should verify");
+    let prover = make_private_batch_prover();
+    let err = prover
+        .commit(vec![proof_asset_0, proof_asset_5])
+        .unwrap_err();
+    assert!(err.to_string().contains("asset"), "got: {err}");
 }
 
 #[test]
-fn push_proof_rejects_batch_incompatible_proof_and_buffer_is_recoverable() {
-    setup_test_binaries();
-    // Two individually valid proofs whose metadata the private-batch circuit's
-    // cross-slot constraints reject (different asset_ids) must not both be
-    // admitted: aggregate() would fail deterministically and, since the queue
-    // only drains on success (#97067), every retry would fail on the same
-    // batch, wedging the aggregator permanently.
-    let proof_asset_0 = make_leaf_proof(&CircuitInputs::test_inputs_0());
+fn full_batch_of_same_nonzero_asset_aggregates() {
+    // Sanity check for the fail-fast path: a FULL batch of same-asset proofs
+    // needs no dummy padding, so a non-native asset is fine and the
+    // compatibility preflight lets it through to real proving.
+    let inputs = test_inputs_with_asset(5);
+    let proof_0 = make_leaf_proof(&inputs);
+    let proof_1 = make_leaf_proof(&inputs);
 
-    // A cryptographically valid proof for asset_id=5: same fixture, but the
-    // asset is part of the ZK leaf hash, so the tree root must be recomputed.
-    let proof_asset_5 = {
-        let mut inputs = CircuitInputs::test_inputs_0();
-        inputs.public.asset_id = 5;
-        inputs.private.zk_tree_root = compute_zk_leaf_hash(
-            &inputs.private.unspendable_account,
-            inputs.private.transfer_count,
-            5,
-            inputs.private.input_amount,
-        );
-        make_leaf_proof(&inputs)
-    };
-
-    let mut aggregator = make_aggregator();
-    aggregator.push_proof(proof_asset_0).unwrap();
-
-    // Sanity: the incompatible proof is valid on its own; only the combination
-    // with the queued asset-0 proof is rejected.
-    let err = aggregator.push_proof(proof_asset_5.clone()).unwrap_err();
-    assert!(
-        err.to_string().contains("batch-incompatible") && err.to_string().contains("asset_id"),
-        "got: {err}"
-    );
-    assert_eq!(
-        aggregator.buffer_len(),
-        1,
-        "rejected proof must not be queued; queued proof must be retained"
-    );
-
-    // Recovery path: drain the queue and requeue as the operator sees fit.
-    // The incompatible proof is admitted once the conflicting one is gone.
-    let drained = aggregator.drain_buffer();
-    assert_eq!(drained.len(), 1);
-    assert_eq!(aggregator.buffer_len(), 0);
-    aggregator.push_proof(proof_asset_5).unwrap();
-
-    // The backend stays fully usable: requeue the drained proof set and
-    // aggregate it successfully.
-    let recovered = aggregator.drain_buffer();
-    assert_eq!(recovered.len(), 1);
-    for proof in drained {
-        aggregator.push_proof(proof).unwrap();
-    }
-    let aggregated = aggregator.aggregate().expect("aggregation must succeed");
-    aggregator
+    let aggregated = make_private_batch_prover()
+        .aggregate(vec![proof_0, proof_1])
+        .expect("full same-asset batch must aggregate");
+    private_batch_verifier()
         .verify(aggregated)
-        .expect("aggregated proof should verify");
+        .expect("Aggregated proof should verify");
 }
 
 /// This simulates a CLI-ish flow without prebuilt binaries:
 /// 1. Generate proofs from separate prover instances
-/// 2. Serialize proof bytes
+/// 2. Serialize proof bytes (hex like the CLI handoff format)
 /// 3. Deserialize using a fresh common_data
-/// 4. Aggregate them
-#[test]
-fn aggregate_proofs_from_separate_prover_instances_serialized() {
-    setup_test_binaries();
-    println!("=== Testing local CLI-like flow with separate prover instances ===");
-
-    // Proof 1 from prover A
-    let prover_a = WormholeProver::new(circuit_config());
-    let inputs_1 = CircuitInputs::test_inputs_0();
-    let proof_1 = prover_a.commit(&inputs_1).unwrap().prove().unwrap();
-    let proof_1_bytes = proof_1.to_bytes();
-
-    // Proof 2 from prover B (same block)
-    let prover_b = WormholeProver::new(circuit_config());
-    let inputs_2 = CircuitInputs::test_inputs_0();
-    let proof_2 = prover_b.commit(&inputs_2).unwrap().prove().unwrap();
-    let proof_2_bytes = proof_2.to_bytes();
-
-    // Create aggregator (local/in-memory path)
-    let mut aggregator = make_aggregator();
-
-    // Use fresh common_data to deserialize like CLI would
-    let deser_common_data = WormholeProver::new(circuit_config()).circuit_data.common;
-
-    let proof_1_deserialized: ProofWithPublicInputs<F, C, D> =
-        ProofWithPublicInputs::from_bytes(proof_1_bytes, &deser_common_data)
-            .expect("Failed to deserialize proof 1");
-
-    let proof_2_deserialized: ProofWithPublicInputs<F, C, D> =
-        ProofWithPublicInputs::from_bytes(proof_2_bytes, &deser_common_data)
-            .expect("Failed to deserialize proof 2");
-
-    aggregator.push_proof(proof_1_deserialized).unwrap();
-    aggregator.push_proof(proof_2_deserialized).unwrap();
-
-    let aggregated = aggregator.aggregate().expect("Aggregation failed");
-
-    aggregator
-        .verify(aggregated)
-        .expect("Aggregated proof verification failed");
-
-    println!("=== Test passed ===");
-}
-
-/// Same as above but includes hex encoding/decoding to match CLI proof handoff format.
+/// 4. Aggregate them one-shot
 #[test]
 fn aggregate_proofs_from_separate_prover_instances_hex_serialized() {
     setup_test_binaries();
-    println!("=== Testing local CLI-like flow with hex encoding ===");
 
     // Proof 1 from prover A
     let prover_a = WormholeProver::new(circuit_config());
@@ -345,8 +234,7 @@ fn aggregate_proofs_from_separate_prover_instances_hex_serialized() {
     let proof_2 = prover_b.commit(&inputs_2).unwrap().prove().unwrap();
     let proof_2_hex = hex::encode(proof_2.to_bytes());
 
-    let mut aggregator = make_aggregator();
-
+    // Use fresh common_data to deserialize like CLI would
     let deser_common_data = WormholeProver::new(circuit_config()).circuit_data.common;
 
     let proof_1_bytes = hex::decode(&proof_1_hex).expect("Failed to decode proof 1 hex");
@@ -360,21 +248,17 @@ fn aggregate_proofs_from_separate_prover_instances_hex_serialized() {
         ProofWithPublicInputs::from_bytes(proof_2_bytes, &deser_common_data)
             .expect("Failed to deserialize proof 2");
 
-    aggregator.push_proof(proof_1_deserialized).unwrap();
-    aggregator.push_proof(proof_2_deserialized).unwrap();
+    let aggregated = make_private_batch_prover()
+        .aggregate(vec![proof_1_deserialized, proof_2_deserialized])
+        .expect("Aggregation failed");
 
-    let aggregated = aggregator.aggregate().expect("Aggregation failed");
-
-    aggregator
+    private_batch_verifier()
         .verify(aggregated)
         .expect("Aggregated proof verification failed");
-
-    println!("=== Test passed ===");
 }
 
 #[test]
 fn private_batch_commit_rejects_malformed_full_batch_at_api_boundary() {
-    setup_test_binaries();
     // A full 2-proof batch where one proof has the wrong public-input length must
     // be rejected at the API boundary instead of panicking in witness assignment.
     // Previously the length check ran only when dummy padding was needed (#97073).
@@ -398,10 +282,10 @@ fn private_batch_prover_rejects_poisoned_dummy_template() {
     // binaries. Otherwise the poisoned template would be padded into every
     // partial batch, replaying its payout once per empty slot via the circuit's
     // exit-dedup sum (leaf-level analogue of #97026).
-    let poisoned_dir = Path::new("tmp-test-bins-poisoned-dummy");
-    let _ = std::fs::remove_dir_all(poisoned_dir);
-    std::fs::create_dir_all(poisoned_dir).unwrap();
-    for entry in std::fs::read_dir(TEST_OUTPUT_DIR).unwrap() {
+    let poisoned_dir = test_bins_root().join("private-poisoned-dummy");
+    let _ = std::fs::remove_dir_all(&poisoned_dir);
+    std::fs::create_dir_all(&poisoned_dir).unwrap();
+    for entry in std::fs::read_dir(private_bins_dir()).unwrap() {
         let entry = entry.unwrap();
         std::fs::copy(entry.path(), poisoned_dir.join(entry.file_name())).unwrap();
     }
@@ -412,7 +296,7 @@ fn private_batch_prover_rejects_poisoned_dummy_template() {
     poisoned.public_inputs[4] = F::from_canonical_u64(0xdead_beef); // nullifier felt
     std::fs::write(poisoned_dir.join("dummy_proof.bin"), poisoned.to_bytes()).unwrap();
 
-    let err = PrivateBatchProver::new_from_binaries_dir(poisoned_dir)
+    let err = PrivateBatchProver::new_from_binaries_dir(&poisoned_dir)
         .expect_err("poisoned dummy template must be rejected at load time");
     assert!(
         err.to_string()
@@ -429,7 +313,7 @@ fn private_batch_prover_rejects_poisoned_dummy_template() {
     )
     .unwrap();
 
-    let err = PrivateBatchProver::new_from_binaries_dir(poisoned_dir)
+    let err = PrivateBatchProver::new_from_binaries_dir(&poisoned_dir)
         .expect_err("non-zero-payout dummy template must be rejected at load time");
     assert!(
         err.to_string().contains("non-zero output amounts"),
@@ -437,33 +321,90 @@ fn private_batch_prover_rejects_poisoned_dummy_template() {
     );
 
     // The pristine directory still loads fine (sanity check).
-    PrivateBatchProver::new_from_binaries_dir(Path::new(TEST_OUTPUT_DIR))
+    PrivateBatchProver::new_from_binaries_dir(&private_bins_dir())
         .expect("pristine binaries must still load");
 
-    let _ = std::fs::remove_dir_all(poisoned_dir);
+    let _ = std::fs::remove_dir_all(&poisoned_dir);
+}
+
+// ============================================================================
+// Miner-side (public batch): pooled aggregation
+// ============================================================================
+
+/// Build (once) a real private-batch proof compatible with the public-batch
+/// test artifacts. Cached because private aggregation costs minutes.
+fn make_private_batch_proof_in_public_dir() -> ProofWithPublicInputs<F, C, D> {
+    static PROOF: OnceLock<ProofWithPublicInputs<F, C, D>> = OnceLock::new();
+    PROOF
+        .get_or_init(|| {
+            setup_public_test_binaries();
+            let dir = public_bins_dir();
+            let leaf = make_leaf_proof_in(&dir, &CircuitInputs::test_inputs_0());
+            PrivateBatchProver::new_from_binaries_dir(&dir)
+                .expect("load private-batch prover from public test binaries")
+                .aggregate(vec![leaf])
+                .expect("private aggregate")
+        })
+        .clone()
+}
+
+#[test]
+fn pool_rejects_invalid_proofs_and_aggregates_by_bucket() {
+    setup_public_test_binaries();
+    let dir = public_bins_dir();
+    let address = BytesDigest::try_from([1u8; 32]).expect("valid address");
+
+    let private_batch_proof = make_private_batch_proof_in_public_dir();
+    let mut aggregator = PublicBatchAggregator::new(&dir, address).expect("public aggregator");
+
+    // Shape rejection: a leaf proof is not a private-batch proof.
+    let leaf = make_leaf_proof_in(&dir, &CircuitInputs::test_inputs_0());
+    let err = aggregator.push_proof(leaf).unwrap_err();
+    assert!(
+        err.to_string().contains("public input length mismatch"),
+        "got: {err}"
+    );
+
+    // Cryptographic rejection: valid shape, tampered contents. A proof admitted
+    // into the pool despite being invalid would wedge its bucket forever, since
+    // buckets only drain on successful aggregation (#97067).
+    let mut tampered = private_batch_proof.clone();
+    tampered.public_inputs[1] = F::from_canonical_u64(9); // asset_id felt
+    let err = aggregator.push_proof(tampered).unwrap_err();
+    assert!(
+        err.to_string().contains("verification failed"),
+        "got: {err}"
+    );
+    assert_eq!(aggregator.pool_len(), 0, "rejected proofs must not pool");
+
+    // A valid proof is admitted, keyed by its (block, asset, fee) metadata.
+    let key = aggregator
+        .push_proof(private_batch_proof)
+        .expect("valid private-batch proof must be admitted");
+    assert_eq!(aggregator.pool_len(), 1);
+    let stats = aggregator.bucket_stats();
+    assert_eq!(stats.len(), 1);
+    assert_eq!(stats[0].key, key);
+    assert!(stats[0].is_full(), "batch_size=1 bucket must be full");
+
+    // Aggregating the bucket produces a verifiable public batch and drains it.
+    let aggregated = aggregator.aggregate(&key).expect("public aggregate");
+    aggregator
+        .verify(aggregated)
+        .expect("public-batch proof must verify");
+    assert_eq!(aggregator.pool_len(), 0, "bucket must drain on success");
+
+    // Aggregating a missing bucket is an error, and the pool stays usable.
+    let err = aggregator.aggregate(&key).unwrap_err();
+    assert!(err.to_string().contains("no pooled proofs"), "got: {err}");
 }
 
 #[test]
 fn public_batch_verify_rejects_proof_bound_to_a_different_aggregator_address() {
     setup_public_test_binaries();
-    let dir = Path::new(PUBLIC_TEST_OUTPUT_DIR);
+    let dir = public_bins_dir();
 
-    // Build a real private-batch proof to feed the public-batch aggregator.
-    let leaf = {
-        let prover =
-            WormholeProver::new_from_files(&dir.join("prover.bin"), &dir.join("common.bin"))
-                .expect("load leaf prover");
-        prover
-            .commit(&CircuitInputs::test_inputs_0())
-            .unwrap()
-            .prove()
-            .unwrap()
-    };
-    let private_batch_proof = {
-        let mut agg = PrivateBatchAggregator::new(dir).expect("private aggregator");
-        agg.push_proof(leaf).unwrap();
-        agg.aggregate().expect("private aggregate")
-    };
+    let private_batch_proof = make_private_batch_proof_in_public_dir();
 
     let address_a = BytesDigest::try_from([1u8; 32]).expect("valid address a");
     let address_b = BytesDigest::try_from([2u8; 32]).expect("valid address b");
@@ -472,19 +413,19 @@ fn public_batch_verify_rejects_proof_bound_to_a_different_aggregator_address() {
     // Produce a public-batch proof bound to address_a (this also exercises the
     // dummy-template verification + count/shape validation in new_from_bytes).
     let public_batch_proof = {
-        let mut agg = PublicBatchAggregator::new(dir, address_a).expect("public aggregator a");
-        agg.push_proof(private_batch_proof.clone()).unwrap();
-        agg.aggregate().expect("public aggregate")
+        let mut agg = PublicBatchAggregator::new(&dir, address_a).expect("public aggregator a");
+        let key = agg.push_proof(private_batch_proof.clone()).unwrap();
+        agg.aggregate(&key).expect("public aggregate")
     };
 
     // The producing backend accepts its own proof.
-    PublicBatchAggregator::new(dir, address_a)
+    PublicBatchAggregator::new(&dir, address_a)
         .expect("public aggregator a")
         .verify(public_batch_proof.clone())
         .expect("same-address proof must verify");
 
     // A backend configured for a different aggregator address must reject it (#96981).
-    let err = PublicBatchAggregator::new(dir, address_b)
+    let err = PublicBatchAggregator::new(&dir, address_b)
         .expect("public aggregator b")
         .verify(public_batch_proof)
         .unwrap_err();
@@ -493,6 +434,4 @@ fn public_batch_verify_rejects_proof_bound_to_a_different_aggregator_address() {
             .contains("does not match configured aggregator address"),
         "got: {err}"
     );
-
-    let _ = std::fs::remove_dir_all(dir);
 }

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -182,6 +182,16 @@ fn commit_rejects_nonzero_asset_id_when_dummy_padding_is_needed() {
 }
 
 #[test]
+fn aggregate_rejects_empty_batch() {
+    // Without leaf proofs, commit would pad the entire batch with the dummy
+    // template and prove an all-dummy private batch that settles nothing.
+    // The client entry point must reject that instead (the intentional
+    // all-dummy template is built on the circuit-build path, not here).
+    let err = make_private_batch_prover().aggregate(vec![]).unwrap_err();
+    assert!(err.to_string().contains("no leaf proofs"), "got: {err}");
+}
+
+#[test]
 fn commit_rejects_batch_incompatible_proofs() {
     // Two individually valid proofs whose metadata the private-batch circuit's
     // cross-slot constraints reject (different asset ids) must fail fast at


### PR DESCRIPTION
## Summary

Restructures the aggregation layer around its actual trust boundary. The client-side (private-batch) queue is removed entirely; the miner-facing (public-batch) queue is replaced with a `ProofPool` that buckets proofs by batch compatibility, so heterogeneous traffic from many clients can no longer wedge or starve aggregation.

## Motivation

The previous design gave both layers the same push/aggregate queue (`AggregationBackend`), which solved the wrong problem on each side:

- **Clients don't need a queue.** A client knows its complete leaf set before aggregating, so buffering adds only latency, redundant self-verification, and retained-state failure modes.
- **Miners need more than a queue.** A public batch requires all non-dummy inner proofs to share block hash, asset id, and volume fee (circuit cross-slot constraints). For a miner accepting proofs from many clients, *metadata incompatibility is the normal case, not the attack case* — different clients prove against different recent blocks. A single FIFO must either reject legitimate traffic based on arrival order or admit incompatible proofs and deterministically fail proving, retrying the same poisoned batch forever (#97067).

## Design

### Client side: one-shot aggregation

- `PrivateBatchProver::aggregate(proofs)` is the client (CLI / mobile) entry point: commit + prove in one call.
- `commit` now runs a fail-fast cross-proof compatibility preflight mirroring the private-batch circuit's constraints (asset equality across **all** slots including dummies; block hash and fee equality between non-dummy slots), so an incompatible batch errors in milliseconds instead of minutes into proving. The circuit remains the enforcer; the preflight only improves failure latency and error quality.
- `PrivateBatchAggregator`, `AggregationBackend`, and `CircuitType` are removed (breaking; no non-test consumers in this repo).

### Miner side: `pool::ProofPool` + reworked `PublicBatchAggregator`

New `pool` module (exported for use by CLI, mobile FFI, and the miner service):

- **Admission** (cheapest-first): global caps → PI shape → duplicate-nullifier rejection within the bucket → full cryptographic verification. No client's submission can poison another client's batch.
- **Bucketing** by `BatchKey { block_hash, asset_id, volume_fee_bps }`, parsed from the proof's public inputs. Every bucket is aggregatable by construction. (On-chain, asset and fee are currently constants, so the effective key is the block hash. Clients proving against any recent block works because the ZK tree is cumulative.)
- **Nullifier-indexed eviction**: `evict_settled(nullifiers)` drops proofs whose spends were settled by competing miners (directly or via a rival public batch). Operators call it on each imported block and before submitting a finished proof, so stale proofs neither occupy batch slots nor get re-proved.
- **Policy signals, not policy**: `bucket_stats()` exposes per-bucket count, capacity, oldest age, and total settled volume. When to aggregate which bucket (bucket full, aged partial flush with dummy padding, direct-inclusion economics) is the operator's decision.
- **Bounded**: `PoolLimits` caps total proofs and bucket count against spam across fabricated keys.
- **Recovery**: `remove_bucket` drains a bucket explicitly (expiry / operator recovery).

`PublicBatchAggregator` becomes a thin composition: pool + prover loading + per-bucket `aggregate(&key)` (partial buckets dummy-padded; bucket drained only on success) + address-bound `verify` (#96981 check retained).

## Testing

- 10 new `pool` unit tests (bucketing, caps, duplicate nullifiers, tampered/short proofs, eviction, drain) using a fake private-batch circuit for fast real verification.
- 4 new prover-preflight unit tests (compatible batch, mixed block / fee / asset incl. dummy-asset strictness).
- Integration tests rewritten for the new APIs, including: one-shot aggregation with padding, fail-fast incompatible commit, full same-asset non-native batch (no over-rejection), pool shape/crypto rejection + bucket aggregate/verify/drain lifecycle, and the retained dummy-template poisoning and cross-address verification regressions.
- Test isolation fix: generated circuit artifacts now live in absolute per-process temp dirs instead of cwd-relative paths, which made results depend on working directory and sibling-test cleanup.
- `cargo test -p qp-wormhole-aggregator --lib`: 44 passed. Integration aggregator suite: passed serially.

## Breaking changes

- Removed: `aggregator::{AggregationBackend, PrivateBatchAggregator, CircuitType}`.
- `PublicBatchAggregator::push_proof` returns `Result<BatchKey>`; `aggregate` takes `&BatchKey`; `buffer_len`/`batch_size`/`drain_buffer`/`load_common_data` replaced by `pool_len`/`batch_size`/`remove_bucket`/`{public,private}_batch_common`.

## Follow-ups (out of scope, other repos)

- Miner aggregator service (client submission endpoint, block-import eviction loop, aggregation policy, extrinsic submission) — planned as a new crate in `quantus-miner`.
- Wire the public-batch verifier into the wormhole pallet.
- Update CLI / mobile call sites to `PrivateBatchProver::aggregate`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API and miner aggregation semantics (bucket selection, eviction) affect proof admission and settlement correctness; circuit enforcement is unchanged but admission logic must stay aligned with cross-slot constraints.
> 
> **Overview**
> Restructures aggregation around **client one-shot proving** vs **miner keyed pooling**, removing the shared `AggregationBackend` / `PrivateBatchAggregator` queue model.
> 
> **Client (private batch):** Callers use `PrivateBatchProver::aggregate(proofs)` instead of push/aggregate on a buffer. `commit` adds fail-fast `ensure_leaf_batch_compatible` (asset across all slots; block hash and fee for non-dummies) so bad batches error before proving.
> 
> **Miner (public batch):** New `pool` module with `ProofPool` — admission (caps, PI shape, per-bucket duplicate nullifiers, verify), bucketing by `BatchKey { block_hash, asset_id, volume_fee_bps }`, `evict_settled`, `bucket_stats`, and `remove_bucket`. `PublicBatchAggregator` wraps the pool: `push_proof` → `BatchKey`, `aggregate(&key)` drains only on success; adds `with_limits`, `evict_settled`, and `{public,private}_batch_common` accessors.
> 
> **Tests/benches:** Integration tests target prover + pool APIs; circuit artifacts use per-process temp dirs. Benchmarks use `PrivateBatchProver` / direct provers where the pool would reject duplicate nullifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bfc7f5d60aa1763bf4d6564f5d55e5daa3b6050. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->