### PR TITLE
ci: rewrite exact path-dep version pins during workspace bumps

### DIFF
--- a/.github/workflows/create-release-proposal.yml
+++ b/.github/workflows/create-release-proposal.yml
@@ -142,8 +142,12 @@ jobs:
           git checkout "$SOURCE_BRANCH"
           git checkout -b "$branch_name"
 
+          # Rewrite path-dep version pins before cargo set-version. Match both
+          # "X.Y.Z" and "=X.Y.Z" (exact pins); the audit tooling pinned internals
+          # as "=…", which the previous regex missed and left as =3.0.0 while
+          # packages moved to 3.1.0, breaking cargo metadata resolution.
           echo "Updating version fields in internal path dependencies"
-          find . -name "Cargo.toml" -exec sed -i -E "s/(version = \")[0-9]+\\.[0-9]+\\.[0-9]+(\", path = )/\\1$new_cargo_version\\2/g" {} \;
+          find . -name "Cargo.toml" -exec sed -i -E "s/(version = \"=?)[0-9]+\\.[0-9]+\\.[0-9]+(\", path = )/\\1$new_cargo_version\\2/g" {} \;
 
           echo "Updating [workspace.package] version in Cargo.toml to: $new_cargo_version"
           sed -i -E 's/^version[[:space:]]*=[[:space:]]*"[^"]*"/version = "'$new_cargo_version'"/' Cargo.toml


### PR DESCRIPTION
The release workflow sed only matched version = "X.Y.Z", path = …, but internal path deps are now pinned as "=X.Y.Z". That left requirements at =3.0.0 after cargo set-version moved packages to 3.1.0, so cargo metadata failed. Allow an optional = inside the quoted version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only regex change in the release automation; no runtime or application code paths.
> 
> **Overview**
> Fixes the **Create Workspace Release Proposal** workflow so internal path dependency versions stay in sync when the workspace is bumped.
> 
> The `find`/`sed` step that rewrites `version = "…", path = …` now accepts an optional **`=`** prefix in the quoted semver (e.g. `=3.0.0` from audit tooling). Previously only plain `X.Y.Z` was updated, leaving exact pins stale after `cargo set-version` and breaking **`cargo metadata`** resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30655ed03e9e69511810823e6aac3996c5a2a269. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->