### PR TITLE
ci: Automate workspace version bump to v3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ checksum = "55e32db7b3a5d70086f82f198ecfc021f17cb7ec70a416512dba3488f4a116c1"
 
 [[package]]
 name = "qp-voting-circuit"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "qp-plonky2",
@@ -1086,7 +1086,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-aggregator"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1106,7 +1106,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-circuit"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-circuit-builder"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1130,14 +1130,14 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-inputs"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "qp-wormhole-prover"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1149,7 +1149,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-verifier"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "qp-zk-circuits-common"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "qp-plonky2",
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "test-helpers"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "hex",
  "qp-plonky2",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "wormhole-memprof"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ edition = "2021"
 keywords = ["circuits", "plonky2", "quantus-network", "wormhole", "zk"]
 license = "MIT"
 repository = "https://github.com/Quantus-Network/qp-zk-circuits"
-version = "3.0.0"
+version = "3.1.0"
 
 [workspace.lints.clippy]
 uninlined_format_args = "allow"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = { workspace = true, default-features = false }
 qp-plonky2 = { workspace = true, default-features = false }
 qp-poseidon-constants = { version = "=1.1.0", default-features = false }
 qp-poseidon-core = { workspace = true, default-features = false }
-qp-wormhole-inputs = { version = "=3.0.0", path = "../wormhole/inputs", default-features = false }
+qp-wormhole-inputs = { version = "=3.1.0", path = "../wormhole/inputs", default-features = false }
 rand = { version = "=0.8.6", default-features = false, features = ["alloc"], optional = true }
 serde = { workspace = true }
 

--- a/voting/Cargo.toml
+++ b/voting/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.0.0", path = "../common" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../common" }
 
 [features]
 default = ["std"]

--- a/wormhole/aggregator/Cargo.toml
+++ b/wormhole/aggregator/Cargo.toml
@@ -11,14 +11,14 @@ version.workspace = true
 anyhow = { workspace = true }
 hex = "=0.4.3"
 qp-plonky2 = { workspace = true }
-qp-wormhole-inputs = { version = "=3.0.0", path = "../inputs" }
+qp-wormhole-inputs = { version = "=3.1.0", path = "../inputs" }
 rand = "=0.8.6"
 rayon = { version = "=1.12.0", optional = true }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.150"
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.0.0", path = "../circuit", default-features = false }
-wormhole-prover = { package = "qp-wormhole-prover", version = "=3.0.0", path = "../prover", default-features = false }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.0.0", path = "../../common" }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path = "../circuit", default-features = false }
+wormhole-prover = { package = "qp-wormhole-prover", version = "=3.1.0", path = "../prover", default-features = false }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/wormhole/circuit-builder/Cargo.toml
+++ b/wormhole/circuit-builder/Cargo.toml
@@ -10,18 +10,18 @@ version.workspace = true
 
 [build-dependencies]
 qp-plonky2 = { workspace = true, features = ["default"] }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.0.0", path = "../aggregator", default-features = false, features = ["std"] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.0.0", path = "../circuit", default-features = false, features = ["std"] }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.0.0", path = "../../common" }
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.1.0", path = "../aggregator", default-features = false, features = ["std"] }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path = "../circuit", default-features = false, features = ["std"] }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common" }
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 clap = { version = "=4.6.1", features = ["derive"] }
 qp-plonky2 = { workspace = true, features = ["default"] }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.0.0", path = "../aggregator", default-features = false, features = [
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.1.0", path = "../aggregator", default-features = false, features = [
 	"std",
 ] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.0.0", path = "../circuit", default-features = false, features = [
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path = "../circuit", default-features = false, features = [
 	"std",
 ] }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.0.0", path = "../../common" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common" }

--- a/wormhole/circuit/Cargo.toml
+++ b/wormhole/circuit/Cargo.toml
@@ -11,8 +11,8 @@ version.workspace = true
 anyhow = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 qp-plonky2 = { workspace = true }
-qp-wormhole-inputs = { version = "=3.0.0", path = "../inputs", default-features = false }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.0.0", path = "../../common", default-features = false }
+qp-wormhole-inputs = { version = "=3.1.0", path = "../inputs", default-features = false }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common", default-features = false }
 
 [features]
 default = ["std"]

--- a/wormhole/memprof/Cargo.toml
+++ b/wormhole/memprof/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { workspace = true, features = ["std"] }
 clap = { version = "=4.6.1", features = ["derive"] }
 qp-plonky2 = { workspace = true, features = ["default"] }
 rayon = "=1.12.0"
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.0.0", path = "../aggregator", default-features = false, features = [
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.1.0", path = "../aggregator", default-features = false, features = [
 	"std",
 ] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.0.0", path = "../circuit", default-features = false, features = [
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path = "../circuit", default-features = false, features = [
 	"std",
 ] }
-wormhole-prover = { package = "qp-wormhole-prover", version = "=3.0.0", path = "../prover", default-features = false, features = [
+wormhole-prover = { package = "qp-wormhole-prover", version = "=3.1.0", path = "../prover", default-features = false, features = [
 	"std",
 ] }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.0.0", path = "../../common" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common" }
 
 [lints]
 workspace = true

--- a/wormhole/prover/Cargo.toml
+++ b/wormhole/prover/Cargo.toml
@@ -10,12 +10,12 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.0.0", path = "../circuit" }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.0.0", path = "../../common" }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path = "../circuit" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common" }
 
 [dev-dependencies]
 criterion = { workspace = true }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.0.0", path = "../aggregator" }
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.1.0", path = "../aggregator" }
 
 [features]
 default = ["std"]

--- a/wormhole/tests/Cargo.toml
+++ b/wormhole/tests/Cargo.toml
@@ -12,20 +12,20 @@ bench = []
 
 [dependencies]
 anyhow = { workspace = true }
-circuit-builder = { package = "qp-wormhole-circuit-builder", version = "=3.0.0", path = "../circuit-builder" }
+circuit-builder = { package = "qp-wormhole-circuit-builder", version = "=3.1.0", path = "../circuit-builder" }
 hex = { workspace = true }
 libc = "=0.2.186"
 qp-plonky2 = { workspace = true, default-features = true }
-qp-wormhole-inputs = { version = "=3.0.0", path = "../inputs" }
+qp-wormhole-inputs = { version = "=3.1.0", path = "../inputs" }
 rand = { version = "=0.9.4", default-features = false, features = [
 	"thread_rng",
 ] }
 test-helpers = { path = "./test-helpers" }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.0.0", path = "../aggregator", features = ["no_zk"] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.0.0", path = "../circuit", default-features = true }
-wormhole-prover = { package = "qp-wormhole-prover", version = "=3.0.0", path = "../prover", default-features = true }
-wormhole-verifier = { package = "qp-wormhole-verifier", version = "=3.0.0", path = "../verifier", default-features = true }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.0.0", path = "../../common" }
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.1.0", path = "../aggregator", features = ["no_zk"] }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path = "../circuit", default-features = true }
+wormhole-prover = { package = "qp-wormhole-prover", version = "=3.1.0", path = "../prover", default-features = true }
+wormhole-verifier = { package = "qp-wormhole-verifier", version = "=3.1.0", path = "../verifier", default-features = true }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common" }
 
 [dev-dependencies]
 proptest = "=1.11.0"

--- a/wormhole/tests/test-helpers/Cargo.toml
+++ b/wormhole/tests/test-helpers/Cargo.toml
@@ -10,6 +10,6 @@ version.workspace = true
 [dependencies]
 hex = { workspace = true }
 qp-plonky2 = { workspace = true, default-features = true }
-qp-wormhole-inputs = { version = "=3.0.0", path = "../../inputs" }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.0.0", path = "../../circuit" }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.0.0", path = "../../../common" }
+qp-wormhole-inputs = { version = "=3.1.0", path = "../../inputs" }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path = "../../circuit" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../../common" }

--- a/wormhole/verifier/Cargo.toml
+++ b/wormhole/verifier/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2-verifier = { version = "=1.5.4", default-features = false }
-qp-wormhole-inputs = { version = "=3.0.0", path = "../inputs", default-features = false }
+qp-wormhole-inputs = { version = "=3.1.0", path = "../inputs", default-features = false }
 tiny-keccak = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Automated workspace version bump for release v3.1.0.

https://github.com/Quantus-Network/qp-zk-circuits/actions/runs/29714594901

Triggered by workflow run: minor

Type: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only changes with no Rust source modifications; main risk is consumers needing to align on 3.1.0 if they pin exact internal crate versions.
> 
> **Overview**
> Automated **minor release** prep: the workspace package version moves from **3.0.0** to **3.1.0** in the root `Cargo.toml`, and every internal path dependency that pins `qp-*` crates is updated to **`=3.1.0`** across `common`, `voting`, and the wormhole crates (aggregator, circuit, prover, verifier, circuit-builder, tests, memprof, test-helpers).
> 
> `Cargo.lock` is refreshed so all listed workspace members (`qp-zk-circuits-common`, wormhole stack, `qp-voting-circuit`, `tests`, `test-helpers`, `wormhole-memprof`, etc.) resolve at **3.1.0**. No application or circuit logic changes appear in this diff—only versioning and lockfile alignment for release **v3.1.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 143e6c8edf6dba881aedf8f2afff2dd35c8b779c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->