### PR TITLE
security: harden artifact publishing and operator-facing CLI boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,6 +1126,7 @@ dependencies = [
  "qp-wormhole-aggregator",
  "qp-wormhole-circuit",
  "qp-zk-circuits-common",
+ "rand 0.8.6",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,9 +15,7 @@ qp-poseidon-core = { workspace = true, default-features = false }
 qp-wormhole-inputs = { version = "=3.1.0", path = "../wormhole/inputs", default-features = false }
 rand = { version = "=0.8.6", default-features = false, features = ["alloc"], optional = true }
 serde = { workspace = true }
-
-[dev-dependencies]
-serde_json = "=1.0.150"
+serde_json = { version = "=1.0.150", default-features = false, features = ["alloc"] }
 
 [features]
 default = ["std"]
@@ -30,4 +28,5 @@ std = [
 	"rand/std",
 	"rand/std_rng",
 	"serde/std",
+	"serde_json/std",
 ]

--- a/common/src/circuit.rs
+++ b/common/src/circuit.rs
@@ -27,6 +27,16 @@ pub const MAX_STORAGE_PROOF_HEX_BYTES: usize = 1 << 20;
 pub const MAX_MERKLE_INDICES: usize = 1024;
 /// Maximum byte length of the hex `state_root` string in [`TransferProofJson`].
 pub const MAX_STATE_ROOT_HEX_LEN: usize = 64;
+/// Maximum raw byte length of a serialized [`TransferProofJson`] document.
+///
+/// The per-field caps above bound what a parsed document may contain, but they
+/// are enforced from inside Serde visitor callbacks — by the time a visitor
+/// sees a string's length, the deserializer has already decoded any escaped
+/// content into scratch storage. Only a cap on the raw, undecoded input can
+/// bound that allocation. 8 MiB is ~8x the largest in-bounds document
+/// (storage_proof dominates at 1 MiB of hex), leaving room for maximally
+/// escape-inflated (6 bytes per decoded byte) but otherwise legal payloads.
+pub const MAX_TRANSFER_PROOF_JSON_BYTES: usize = 8 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 pub struct TransferProofJson {
@@ -40,10 +50,32 @@ pub struct TransferProofJson {
 }
 
 impl TransferProofJson {
+    /// Parse untrusted transfer-proof JSON, bounding allocation up front.
+    ///
+    /// This is the entry point services should use for attacker-supplied
+    /// payloads. The raw document length is checked against
+    /// [`MAX_TRANSFER_PROOF_JSON_BYTES`] BEFORE any parsing: the per-field
+    /// Serde bounds only observe string lengths after the deserializer has
+    /// decoded escaped content into scratch storage, so on their own they
+    /// cannot stop a single escape-inflated field from allocating and
+    /// scanning arbitrarily far past its cap before being rejected.
+    pub fn from_json_str(json: &str) -> Result<Self, String> {
+        if json.len() > MAX_TRANSFER_PROOF_JSON_BYTES {
+            return Err(format!(
+                "transfer proof JSON exceeds {} bytes ({} bytes); refusing to parse it",
+                MAX_TRANSFER_PROOF_JSON_BYTES,
+                json.len()
+            ));
+        }
+        serde_json::from_str(json).map_err(|e| format!("failed to parse transfer proof JSON: {e}"))
+    }
+
     /// Validate the decoded transfer proof bounds.
     ///
-    /// `#[serde(deserialize_with)]` already caps each field at deserialization time;
-    /// this is a convenience check for callers that construct the struct directly.
+    /// `#[serde(deserialize_with)]` enforces the same caps on parsed documents
+    /// (though only after the deserializer has decoded each string — see
+    /// [`Self::from_json_str`] for the raw-input bound); this is a convenience
+    /// check for callers that construct the struct directly.
     pub fn validate(&self) -> Result<(), String> {
         if self.state_root.len() > MAX_STATE_ROOT_HEX_LEN {
             return Err(format!(
@@ -84,6 +116,11 @@ impl TransferProofJson {
 
 /// Deserialize a hex `state_root` string, rejecting inputs longer than
 /// [`MAX_STATE_ROOT_HEX_LEN`] before allocating the owned `String`.
+///
+/// NOTE: for escaped or streamed input the deserializer must decode the string
+/// into its own scratch storage before this visitor can observe the length, so
+/// this bound alone does not cap allocation. [`TransferProofJson::from_json_str`]
+/// bounds the raw document first; use it for untrusted payloads.
 fn deserialize_bounded_state_root<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
@@ -347,6 +384,51 @@ mod transfer_proof_json_tests {
         );
         let err = serde_json::from_str::<TransferProofJson>(&json).unwrap_err();
         assert!(err.to_string().contains("storage_proof node exceeds"));
+    }
+
+    /// A single field written as JSON escape sequences forces serde_json to
+    /// decode the whole thing into scratch storage BEFORE the visitor's field
+    /// bound can observe its length. The raw payload cap must therefore reject
+    /// oversized documents up front, without ever handing them to serde.
+    #[test]
+    fn oversized_escaped_payload_is_rejected_by_the_raw_size_cap() {
+        // An escaped state_root that decodes to megabytes: each `\u0061` is one
+        // decoded byte, so the field bound (64 bytes) only fires after the
+        // deserializer has already buffered the full decoded string.
+        let escaped = "\\u0061".repeat(MAX_TRANSFER_PROOF_JSON_BYTES / 6 + 1);
+        let json = format!(
+            r#"{{"transfer_count":1,"state_root":"{}","storage_proof":[],"indices":[]}}"#,
+            escaped
+        );
+        let err = TransferProofJson::from_json_str(&json).unwrap_err();
+        assert!(
+            err.contains("transfer proof JSON exceeds"),
+            "oversized payload must be rejected by the raw size cap before parsing, got: {err}"
+        );
+    }
+
+    /// Escapes are legal JSON: a payload whose fields are within bounds must
+    /// still parse even when its strings are escape-encoded.
+    #[test]
+    fn escaped_but_in_bounds_payload_still_parses() {
+        let escaped_root = "\\u0061".repeat(8); // decodes to "aaaaaaaa"
+        let json = format!(
+            r#"{{"transfer_count":1,"state_root":"{}","storage_proof":["00"],"indices":[0]}}"#,
+            escaped_root
+        );
+        let proof = TransferProofJson::from_json_str(&json).unwrap();
+        assert_eq!(proof.state_root, "a".repeat(8));
+    }
+
+    /// Payloads under the raw cap must still hit the per-field bounds.
+    #[test]
+    fn in_cap_payload_with_oversized_state_root_is_rejected_by_field_bound() {
+        let json = format!(
+            r#"{{"transfer_count":1,"state_root":"{}","storage_proof":[],"indices":[]}}"#,
+            "a".repeat(MAX_STATE_ROOT_HEX_LEN + 1)
+        );
+        let err = TransferProofJson::from_json_str(&json).unwrap_err();
+        assert!(err.contains("state_root exceeds"), "got: {err}");
     }
 
     #[test]

--- a/common/src/serialization.rs
+++ b/common/src/serialization.rs
@@ -190,14 +190,23 @@ pub fn bytes_to_felts_compact(input: &[u8]) -> Result<Vec<F>, &'static str> {
 /// always hash (matching pallet-zk-tree). Prefer this over calling
 /// `qp_poseidon_core::serialization::bytes_to_felts_compact`, which is fallible
 /// in poseidon-core ≥ 3.0.
-pub fn hash_bytes_compact(input: &[u8]) -> [u8; 32] {
+///
+/// Returns an error if `input.len()` exceeds [`MAX_SERIALIZED_BYTES`], matching
+/// the sibling byte-consuming helpers in this module: the intermediate felt
+/// buffer and the hashing work both scale with the input, so an unbounded
+/// public path here would let untrusted caller-supplied data force
+/// size-proportional allocation (audit #97066).
+pub fn hash_bytes_compact(input: &[u8]) -> Result<[u8; 32], &'static str> {
     use qp_poseidon_core::Goldilocks;
 
+    if input.len() > MAX_SERIALIZED_BYTES {
+        return Err("hash_bytes_compact: input exceeds maximum serialized length");
+    }
     let felts: Vec<Goldilocks> = qp_poseidon_core::serialization::bytes_to_u64s_compact(input)
         .into_iter()
         .map(Goldilocks::from_u64)
         .collect();
-    qp_poseidon_core::hash_to_bytes(&felts)
+    Ok(qp_poseidon_core::hash_to_bytes(&felts))
 }
 
 // ============================================================================
@@ -293,6 +302,26 @@ mod tests {
             let reconstructed = felts_to_bytes(&felts).unwrap();
             assert_eq!(original, reconstructed);
         }
+    }
+
+    /// `hash_bytes_compact` must enforce the same MAX_SERIALIZED_BYTES bound as
+    /// every sibling public byte-consuming helper in this module, so untrusted
+    /// input cannot force size-proportional allocation and hashing (audit
+    /// follow-up to #97066, which added the bound to the other helpers).
+    #[test]
+    fn hash_bytes_compact_rejects_oversized_input() {
+        let oversized = vec![0u8; MAX_SERIALIZED_BYTES + 1];
+        let err = hash_bytes_compact(&oversized).unwrap_err();
+        assert!(err.contains("maximum serialized length"), "got: {err}");
+    }
+
+    /// In-bounds inputs (including the exact maximum and the fixed 128-byte
+    /// merkle-node payload) must still hash.
+    #[test]
+    fn hash_bytes_compact_accepts_in_bounds_input() {
+        hash_bytes_compact(&[0x5au8; 128]).expect("merkle-node payload must hash");
+        hash_bytes_compact(&vec![0x5au8; MAX_SERIALIZED_BYTES])
+            .expect("input at the exact bound must hash");
     }
 
     #[test]

--- a/common/src/zk_merkle.rs
+++ b/common/src/zk_merkle.rs
@@ -33,6 +33,30 @@ use crate::serialization;
 /// Type alias for 32-byte hash.
 pub type Hash256 = [u8; 32];
 
+/// Goldilocks field modulus `p = 2^64 - 2^32 + 1`.
+///
+/// A 32-byte hash is decoded into four little-endian `u64` limbs before
+/// hashing; each limb must be `< p` for the 8-bytes-per-felt decode to be
+/// injective (see [`is_canonical_hash`]).
+const GOLDILOCKS_MODULUS: u64 = 0xFFFF_FFFF_0000_0001;
+
+/// Returns `true` if every 8-byte little-endian limb of `hash` is a canonical
+/// Goldilocks field element (strictly `< p`).
+///
+/// Internal-node hashing packs each limb into a field element via a mod-`p`
+/// reduction, so two distinct byte strings whose limbs differ by a multiple of
+/// `p` hash identically. Byte-level Merkle verification must therefore reject
+/// noncanonical hashes up front; otherwise a proof for a noncanonical byte
+/// alias of a genuine child would verify against the same root, and the API
+/// would validate membership of a field-equivalence class rather than of the
+/// exact 32-byte hash it presents.
+pub fn is_canonical_hash(hash: &Hash256) -> bool {
+    hash.chunks_exact(8).all(|chunk| {
+        let limb = u64::from_le_bytes(chunk.try_into().expect("chunk is 8 bytes"));
+        limb < GOLDILOCKS_MODULUS
+    })
+}
+
 /// Arity of the Merkle tree (4-ary).
 pub const ARITY: usize = 4;
 
@@ -143,6 +167,18 @@ impl ZkMerkleProof {
             return false;
         }
         if self.siblings.len() != self.positions.len() {
+            return false;
+        }
+
+        // Reject noncanonical hash bytes before hashing. The compact node hash
+        // reduces each 8-byte limb mod p, so a noncanonical byte alias of a
+        // genuine child would derive the same parent; requiring canonical limbs
+        // makes this verifier prove membership of the exact 32-byte hashes it
+        // presents (see `is_canonical_hash`).
+        if !is_canonical_hash(&self.leaf_hash) {
+            return false;
+        }
+        if !self.siblings.iter().flatten().all(is_canonical_hash) {
             return false;
         }
 
@@ -492,6 +528,91 @@ mod tests {
         // Out-of-range hint is likewise an invalid proof, not a panic.
         proof.positions[0] = 7;
         assert!(!proof.verify());
+    }
+
+    /// Goldilocks field modulus `p = 2^64 - 2^32 + 1`.
+    const GOLDILOCKS: u64 = 0xFFFF_FFFF_0000_0001;
+
+    /// Build a 32-byte hash from four little-endian `u64` limbs.
+    fn hash_from_limbs(limbs: [u64; 4]) -> Hash256 {
+        let mut bytes = [0u8; 32];
+        for (i, limb) in limbs.iter().enumerate() {
+            bytes[i * 8..i * 8 + 8].copy_from_slice(&limb.to_le_bytes());
+        }
+        bytes
+    }
+
+    /// Read the four little-endian `u64` limbs of a 32-byte hash.
+    fn limbs_from_hash(hash: &Hash256) -> [u64; 4] {
+        let mut limbs = [0u64; 4];
+        for (i, limb) in limbs.iter_mut().enumerate() {
+            *limb = u64::from_le_bytes(hash[i * 8..i * 8 + 8].try_into().unwrap());
+        }
+        limbs
+    }
+
+    /// Return a distinct byte string that decodes to the same field digest as
+    /// `hash` by adding `p` to its first limb, or `None` if that limb is too
+    /// large for the `+p` alias to fit in a `u64`.
+    fn noncanonical_alias(hash: &Hash256) -> Option<Hash256> {
+        let mut limbs = limbs_from_hash(hash);
+        limbs[0] = limbs[0].checked_add(GOLDILOCKS)?;
+        let alias = hash_from_limbs(limbs);
+        (alias != *hash).then_some(alias)
+    }
+
+    /// Audit: the internal-node hash packs each 8-byte limb into a Goldilocks
+    /// felt via a mod-`p` reduction, so a caller can replace a canonical child
+    /// digest with a distinct noncanonical byte alias (limb `+ p`) and derive
+    /// the same parent/root. The byte-level verifier must reject noncanonical
+    /// leaf bytes so it proves membership of the exact 32-byte hash, not of a
+    /// field-equivalence class.
+    #[test]
+    fn verify_rejects_noncanonical_leaf_alias() {
+        let leaf0 = hash_from_limbs([0, 0, 0, 0]);
+        let leaf1 = hash_from_limbs([1, 0, 0, 0]);
+        let leaf2 = hash_from_limbs([2, 0, 0, 0]);
+        let leaf3 = hash_from_limbs([3, 0, 0, 0]);
+        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
+
+        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root);
+        assert!(proof.verify(), "sanity: canonical proof must verify");
+
+        // Alias of leaf0: limb 0 replaced by `p`, which reduces to 0 mod p.
+        let alias = noncanonical_alias(&leaf0).expect("leaf0 limb 0 admits a +p alias");
+        assert_ne!(alias, leaf0, "alias must be a distinct byte string");
+        proof.leaf_hash = alias;
+
+        assert!(
+            !proof.verify(),
+            "noncanonical leaf alias must be rejected, not accepted via field aliasing"
+        );
+        assert!(!proof.verify_with_positions());
+    }
+
+    /// Same aliasing attack, but on a sibling hash rather than the leaf.
+    #[test]
+    fn verify_rejects_noncanonical_sibling_alias() {
+        let leaf0 = hash_from_limbs([0, 0, 0, 0]);
+        let leaf1 = hash_from_limbs([1, 0, 0, 0]);
+        let leaf2 = hash_from_limbs([2, 0, 0, 0]);
+        let leaf3 = hash_from_limbs([3, 0, 0, 0]);
+        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
+
+        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root);
+        assert!(proof.verify(), "sanity: canonical proof must verify");
+
+        // Replace the first sibling with its noncanonical alias.
+        let original = proof.siblings[0][0];
+        let alias = noncanonical_alias(&original).expect("sibling limb 0 admits a +p alias");
+        assert_ne!(alias, original);
+        proof.siblings[0][0] = alias;
+
+        assert!(
+            !proof.verify(),
+            "noncanonical sibling alias must be rejected"
+        );
+        assert!(!proof.verify_with_positions());
     }
 
     #[test]

--- a/common/src/zk_merkle.rs
+++ b/common/src/zk_merkle.rs
@@ -312,7 +312,8 @@ pub fn hash_node_presorted(sorted_children: &[Hash256; ARITY]) -> Hash256 {
     }
 
     // Compact encoding (8 bytes/felt); lossy path for fixed-size hash payloads.
-    serialization::hash_bytes_compact(&data)
+    // 128 bytes is far below MAX_SERIALIZED_BYTES, so this cannot fail.
+    serialization::hash_bytes_compact(&data).expect("128-byte node payload is within bounds")
 }
 
 /// Hash 4 child hashes into a parent node hash.
@@ -332,7 +333,8 @@ pub fn hash_node(children: &[Hash256; ARITY]) -> Hash256 {
     }
 
     // Compact encoding (8 bytes/felt); 128 bytes -> 16 felts.
-    serialization::hash_bytes_compact(&data)
+    // 128 bytes is far below MAX_SERIALIZED_BYTES, so this cannot fail.
+    serialization::hash_bytes_compact(&data).expect("128-byte node payload is within bounds")
 }
 
 /// Empty hash value (all zeros).

--- a/wormhole/README.md
+++ b/wormhole/README.md
@@ -209,9 +209,9 @@ cargo run --release -p qp-wormhole-circuit-builder -- --num-leaf-proofs <N> [--n
 ```
 
 This creates `common.bin`, `verifier.bin`, `private_batch_common.bin`, `private_batch_verifier.bin`, `dummy_proof.bin`,
-and `config.json` inside `generated-bins/` (plus batch prover binaries unless `--skip-prover`).
+and `config.json` inside `generated-bins/` (plus the dummy private-batch padding proof unless `--skip-prover`).
 
-Note: no `prover.bin` is emitted for the leaf circuit. The leaf `WormholeProver` always builds
-its circuit from source (it is small and builds in milliseconds); loading serialized prover
-artifacts was removed because a poisoned artifact could exfiltrate private witness data
-through the proof's public-input list.
+Note: no `prover.bin` is emitted for any circuit. The provers (`WormholeProver`,
+`PrivateBatchProver`, `PublicBatchProver`) always rebuild their circuits from source;
+loading serialized prover artifacts was removed because a poisoned artifact could
+exfiltrate private witness data through the proof's public-input list.

--- a/wormhole/aggregator/benches/aggregator.rs
+++ b/wormhole/aggregator/benches/aggregator.rs
@@ -136,7 +136,7 @@ macro_rules! prove_public_batch_benchmark {
                 );
 
             let proof = generate_dummy_private_batch_proof();
-            generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs, true)
+            generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs)
                 .expect(
                     "Failed to generate public_batch circuit binaries for public_batch benchmark",
                 );
@@ -199,7 +199,7 @@ macro_rules! verify_public_batch_benchmark {
 
             let proof = generate_dummy_private_batch_proof();
 
-            generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs, true)
+            generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs)
                 .expect(
                     "Failed to generate public_batch circuit binaries for public_batch benchmark",
                 );

--- a/wormhole/aggregator/benches/aggregator.rs
+++ b/wormhole/aggregator/benches/aggregator.rs
@@ -136,10 +136,9 @@ macro_rules! prove_public_batch_benchmark {
                 );
 
             let proof = generate_dummy_private_batch_proof();
-            generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs)
-                .expect(
-                    "Failed to generate public_batch circuit binaries for public_batch benchmark",
-                );
+            generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs).expect(
+                "Failed to generate public_batch circuit binaries for public_batch benchmark",
+            );
 
             let config = CircuitBinsConfig::new(
                 PUBLIC_BATCH_INNER_NUM_LEAVES,
@@ -199,10 +198,9 @@ macro_rules! verify_public_batch_benchmark {
 
             let proof = generate_dummy_private_batch_proof();
 
-            generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs)
-                .expect(
-                    "Failed to generate public_batch circuit binaries for public_batch benchmark",
-                );
+            generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs).expect(
+                "Failed to generate public_batch circuit binaries for public_batch benchmark",
+            );
 
             let config = CircuitBinsConfig::new(
                 PUBLIC_BATCH_INNER_NUM_LEAVES,

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -52,7 +52,6 @@ use plonky2::plonk::{
 };
 use qp_wormhole_inputs::{public_batch_pi::AGGREGATOR_ADDRESS_LEN, BytesDigest};
 use std::collections::HashSet;
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use zk_circuits_common::{
@@ -78,7 +77,7 @@ type Proof = ProofWithPublicInputs<F, C, D>;
 // ============================================================================
 
 fn read_bin(bins_dir: &Path, file: &str) -> Result<Vec<u8>> {
-    fs::read(bins_dir.join(file))
+    crate::common::utils::read_artifact_file(&bins_dir.join(file))
         .with_context(|| format!("failed to read {}", bins_dir.join(file).display()))
 }
 

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -5,7 +5,7 @@ use plonky2::{
         circuit_data::{
             CircuitConfig, CommonCircuitData, VerifierCircuitData, VerifierOnlyCircuitData,
         },
-        proof::ProofWithPublicInputs,
+        proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
     util::serialization::DefaultGateSerializer,
 };
@@ -171,6 +171,249 @@ pub fn canonical_public_batch_verifier_data(
         num_leaf_proofs,
     )?
     .build_verifier())
+}
+
+fn ensure_len_matches(
+    actual: usize,
+    expected: usize,
+    label: &str,
+    slot: usize,
+    what: &str,
+) -> Result<()> {
+    if actual != expected {
+        bail!(
+            "{} at slot {} is malformed: {} has length {}, but the circuit expects {}",
+            label,
+            slot,
+            what,
+            actual,
+            expected
+        );
+    }
+    Ok(())
+}
+
+/// Preflight a caller-supplied proof's full internal shape against the
+/// circuit's proof targets, so a malformed proof is rejected at a Result
+/// boundary instead of reaching plonky2's witness writer.
+///
+/// `set_proof_with_pis_target` assigns the proof's internals through
+/// length-sensitive iterator paths: `zip_eq` (panics on mismatch, e.g. for the
+/// FRI query-round list), debug-only length asserts (silent partial assignment
+/// in release), and plain `zip` (silently leaves trailing targets unset, e.g.
+/// for Merkle caps). A proof with the expected public-input length but
+/// internally inconsistent vectors would otherwise crash the process or defer
+/// the failure to prove time. Plonky2's own shape validation is private to the
+/// crate and only runs inside `verify`, after witness filling.
+///
+/// `label` names the proof kind in error messages (e.g. "leaf proof").
+pub fn ensure_proof_shape_matches_targets(
+    proof_t: &ProofWithPublicInputsTarget<D>,
+    proof: &ProofWithPublicInputs<F, C, D>,
+    slot: usize,
+    label: &str,
+) -> Result<()> {
+    // With fewer public inputs than targets, set_proof_with_pis_target's
+    // internal zip_eq would panic instead of erroring.
+    ensure_len_matches(
+        proof.public_inputs.len(),
+        proof_t.public_inputs.len(),
+        label,
+        slot,
+        "public inputs",
+    )?;
+
+    let p = &proof.proof;
+    let t = &proof_t.proof;
+
+    ensure_len_matches(
+        p.wires_cap.0.len(),
+        t.wires_cap.0.len(),
+        label,
+        slot,
+        "wires_cap",
+    )?;
+    ensure_len_matches(
+        p.plonk_zs_partial_products_cap.0.len(),
+        t.plonk_zs_partial_products_cap.0.len(),
+        label,
+        slot,
+        "plonk_zs_partial_products_cap",
+    )?;
+    ensure_len_matches(
+        p.quotient_polys_cap.0.len(),
+        t.quotient_polys_cap.0.len(),
+        label,
+        slot,
+        "quotient_polys_cap",
+    )?;
+
+    let o = &p.openings;
+    let ot = &t.openings;
+    ensure_len_matches(
+        o.constants.len(),
+        ot.constants.len(),
+        label,
+        slot,
+        "openings.constants",
+    )?;
+    ensure_len_matches(
+        o.plonk_sigmas.len(),
+        ot.plonk_sigmas.len(),
+        label,
+        slot,
+        "openings.plonk_sigmas",
+    )?;
+    ensure_len_matches(o.wires.len(), ot.wires.len(), label, slot, "openings.wires")?;
+    ensure_len_matches(
+        o.plonk_zs.len(),
+        ot.plonk_zs.len(),
+        label,
+        slot,
+        "openings.plonk_zs",
+    )?;
+    ensure_len_matches(
+        o.plonk_zs_next.len(),
+        ot.plonk_zs_next.len(),
+        label,
+        slot,
+        "openings.plonk_zs_next",
+    )?;
+    ensure_len_matches(
+        o.partial_products.len(),
+        ot.partial_products.len(),
+        label,
+        slot,
+        "openings.partial_products",
+    )?;
+    ensure_len_matches(
+        o.quotient_polys.len(),
+        ot.quotient_polys.len(),
+        label,
+        slot,
+        "openings.quotient_polys",
+    )?;
+    ensure_len_matches(
+        o.lookup_zs.len(),
+        ot.lookup_zs.len(),
+        label,
+        slot,
+        "openings.lookup_zs",
+    )?;
+    ensure_len_matches(
+        o.lookup_zs_next.len(),
+        ot.next_lookup_zs.len(),
+        label,
+        slot,
+        "openings.lookup_zs_next",
+    )?;
+
+    let f = &p.opening_proof;
+    let ft = &t.opening_proof;
+
+    ensure_len_matches(
+        f.commit_phase_merkle_caps.len(),
+        ft.commit_phase_merkle_caps.len(),
+        label,
+        slot,
+        "opening_proof.commit_phase_merkle_caps",
+    )?;
+    for (i, (cap, cap_t)) in f
+        .commit_phase_merkle_caps
+        .iter()
+        .zip(ft.commit_phase_merkle_caps.iter())
+        .enumerate()
+    {
+        ensure_len_matches(
+            cap.0.len(),
+            cap_t.0.len(),
+            label,
+            slot,
+            &format!("opening_proof.commit_phase_merkle_caps[{i}]"),
+        )?;
+    }
+
+    ensure_len_matches(
+        f.query_round_proofs.len(),
+        ft.query_round_proofs.len(),
+        label,
+        slot,
+        "opening_proof.query_round_proofs",
+    )?;
+    for (i, (round, round_t)) in f
+        .query_round_proofs
+        .iter()
+        .zip(ft.query_round_proofs.iter())
+        .enumerate()
+    {
+        ensure_len_matches(
+            round.initial_trees_proof.evals_proofs.len(),
+            round_t.initial_trees_proof.evals_proofs.len(),
+            label,
+            slot,
+            &format!("opening_proof.query_round_proofs[{i}].initial_trees_proof.evals_proofs"),
+        )?;
+        for (j, ((evals, merkle), (evals_t, merkle_t))) in round
+            .initial_trees_proof
+            .evals_proofs
+            .iter()
+            .zip(round_t.initial_trees_proof.evals_proofs.iter())
+            .enumerate()
+        {
+            ensure_len_matches(
+                evals.len(),
+                evals_t.len(),
+                label,
+                slot,
+                &format!(
+                    "opening_proof.query_round_proofs[{i}].initial_trees_proof.evals_proofs[{j}].evals"
+                ),
+            )?;
+            ensure_len_matches(
+                merkle.siblings.len(),
+                merkle_t.siblings.len(),
+                label,
+                slot,
+                &format!(
+                    "opening_proof.query_round_proofs[{i}].initial_trees_proof.evals_proofs[{j}].siblings"
+                ),
+            )?;
+        }
+
+        ensure_len_matches(
+            round.steps.len(),
+            round_t.steps.len(),
+            label,
+            slot,
+            &format!("opening_proof.query_round_proofs[{i}].steps"),
+        )?;
+        for (j, (step, step_t)) in round.steps.iter().zip(round_t.steps.iter()).enumerate() {
+            ensure_len_matches(
+                step.evals.len(),
+                step_t.evals.len(),
+                label,
+                slot,
+                &format!("opening_proof.query_round_proofs[{i}].steps[{j}].evals"),
+            )?;
+            ensure_len_matches(
+                step.merkle_proof.siblings.len(),
+                step_t.merkle_proof.siblings.len(),
+                label,
+                slot,
+                &format!("opening_proof.query_round_proofs[{i}].steps[{j}].merkle_proof.siblings"),
+            )?;
+        }
+    }
+
+    ensure_len_matches(
+        f.final_poly.coeffs.len(),
+        ft.final_poly.0.len(),
+        label,
+        slot,
+        "opening_proof.final_poly",
+    )?;
+
+    Ok(())
 }
 
 pub fn ensure_proof_public_input_len(

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -1,4 +1,6 @@
 use anyhow::{anyhow, bail, Result};
+#[cfg(feature = "std")]
+use anyhow::Context;
 use plonky2::{
     field::types::PrimeField64,
     plonk::{
@@ -21,6 +23,58 @@ use crate::private_batch::circuit::{
     constants::{aggregated_output, ASSET_ID_START, LEAF_PI_LEN},
 };
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
+
+/// Maximum size accepted for any serialized circuit-artifact file.
+///
+/// The largest legitimate artifact is a serialized recursive proof (hundreds
+/// of KB); common/verifier data is smaller still. 64 MiB gives generous
+/// headroom for config variations while bounding the allocation an untrusted
+/// artifact directory can force: without a cap, a single oversized or sparse
+/// `*.bin` file is read fully into memory BEFORE canonical validation gets a
+/// chance to reject it, letting an attacker-chosen directory crash or memory-
+/// starve the loading process.
+pub const MAX_ARTIFACT_FILE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Read a circuit-artifact file, refusing anything larger than
+/// [`MAX_ARTIFACT_FILE_BYTES`] before allocating for its contents.
+///
+/// The size is checked via `fstat` on the already-opened handle (no
+/// stat-then-open race), and the read itself is additionally capped with
+/// `Read::take` in case the file grows after the check.
+#[cfg(feature = "std")]
+pub fn read_artifact_file(path: &std::path::Path) -> Result<Vec<u8>> {
+    use std::io::Read as _;
+
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open artifact file {}", path.display()))?;
+    let claimed_len = file
+        .metadata()
+        .with_context(|| format!("failed to stat artifact file {}", path.display()))?
+        .len();
+    if claimed_len > MAX_ARTIFACT_FILE_BYTES {
+        bail!(
+            "artifact file {} is {} bytes, which exceeds the {} byte limit for \
+             circuit artifacts; refusing to load it",
+            path.display(),
+            claimed_len,
+            MAX_ARTIFACT_FILE_BYTES
+        );
+    }
+
+    let mut bytes = Vec::with_capacity(claimed_len as usize);
+    file.take(MAX_ARTIFACT_FILE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("failed to read artifact file {}", path.display()))?;
+    if bytes.len() as u64 > MAX_ARTIFACT_FILE_BYTES {
+        bail!(
+            "artifact file {} grew past the {} byte limit for circuit artifacts \
+             while being read; refusing to load it",
+            path.display(),
+            MAX_ARTIFACT_FILE_BYTES
+        );
+    }
+    Ok(bytes)
+}
 
 /// Load verifier circuit data (common + verifier-only) from serialized bytes.
 pub fn load_verifier_data_from_bytes(
@@ -470,10 +524,40 @@ pub fn private_batch_num_leaves_from_padded_pi_len(pi_len: usize) -> Result<usiz
 #[cfg(test)]
 mod tests {
     use super::private_batch_num_leaves_from_padded_pi_len;
+    use super::{read_artifact_file, MAX_ARTIFACT_FILE_BYTES};
 
     #[test]
     fn private_batch_num_leaves_from_padded_pi_len_rejects_malformed_lengths() {
         let err = private_batch_num_leaves_from_padded_pi_len(9).unwrap_err();
         assert!(err.to_string().contains("malformed"));
+    }
+
+    #[test]
+    fn read_artifact_file_round_trips_normal_files_and_rejects_oversized_ones() {
+        let dir = std::env::temp_dir().join(format!(
+            "qp-artifact-read-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let normal = dir.join("normal.bin");
+        std::fs::write(&normal, b"artifact bytes").unwrap();
+        assert_eq!(read_artifact_file(&normal).unwrap(), b"artifact bytes");
+
+        // A sparse file costs no disk but still claims an oversized length,
+        // exactly like an attacker-planted artifact would.
+        let oversized = dir.join("oversized.bin");
+        std::fs::File::create(&oversized)
+            .unwrap()
+            .set_len(MAX_ARTIFACT_FILE_BYTES + 1)
+            .unwrap();
+        let err = read_artifact_file(&oversized).unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds the"),
+            "got: {err}"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -1,6 +1,6 @@
-use anyhow::{anyhow, bail, Result};
 #[cfg(feature = "std")]
 use anyhow::Context;
+use anyhow::{anyhow, bail, Result};
 use plonky2::{
     field::types::PrimeField64,
     plonk::{
@@ -534,10 +534,8 @@ mod tests {
 
     #[test]
     fn read_artifact_file_round_trips_normal_files_and_rejects_oversized_ones() {
-        let dir = std::env::temp_dir().join(format!(
-            "qp-artifact-read-test-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("qp-artifact-read-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
 
@@ -553,10 +551,7 @@ mod tests {
             .set_len(MAX_ARTIFACT_FILE_BYTES + 1)
             .unwrap();
         let err = read_artifact_file(&oversized).unwrap_err();
-        assert!(
-            err.to_string().contains("exceeds the"),
-            "got: {err}"
-        );
+        assert!(err.to_string().contains("exceeds the"), "got: {err}");
 
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -307,13 +307,16 @@ impl ProofPool {
 
     /// Validate and admit a proof, returning the bucket key it landed in.
     ///
-    /// Checks run cheapest-first: capacity limits, public-input shape,
-    /// duplicate-nullifier rejection, the verification budget
-    /// ([`PoolLimits::max_verifies_per_window`]), then cryptographic
-    /// verification. A proof admitted here is individually valid and, by
-    /// bucketing, batch-compatible with every other proof in its bucket, so
-    /// aggregation over a bucket cannot fail deterministically on admitted
-    /// inputs (#97067).
+    /// Checks run cheapest-first EXCEPT the duplicate-nullifier check:
+    /// capacity limits, public-input shape, dummy sentinel, bucket cap, the
+    /// verification budget ([`PoolLimits::max_verifies_per_window`]),
+    /// cryptographic verification, and only THEN duplicate-nullifier
+    /// rejection. The dedup check is deliberately gated behind verification so
+    /// its rejection cannot be used as a free, unlimited membership/status
+    /// oracle over the pool's not-yet-settled spends (see the check site). A
+    /// proof admitted here is individually valid and, by bucketing,
+    /// batch-compatible with every other proof in its bucket, so aggregation
+    /// over a bucket cannot fail deterministically on admitted inputs (#97067).
     ///
     /// Buckets are NOT capped at one batch: a hot key keeps admitting (up to
     /// the global limits) while earlier batches for it are out being proved;
@@ -338,30 +341,6 @@ impl ProofPool {
             bail!(
                 "refusing to pool an all-dummy private-batch proof (block_hash == 0): \
                  it settles nothing and can never be drained"
-            );
-        }
-
-        // A duplicate nullifier anywhere in the pool (including proofs out
-        // with a TakenBatch) means the same leaf spend is already staged; only
-        // one copy can ever settle. This is checked pool-wide (not per
-        // bucket): the cumulative merkle tree lets the same spend be proven
-        // against different recent blocks, i.e. into different buckets. It
-        // also deduplicates client re-submissions.
-        if let Some(dup) = metadata
-            .1
-            .iter()
-            .find(|n| self.nullifier_index.contains_key(n))
-        {
-            bail!(
-                "refusing to queue private-batch proof: nullifier {:?} is already \
-                 staged (bucket for block {:?}{})",
-                dup,
-                self.nullifier_index[dup].block_hash,
-                if self.taken_nullifiers.contains(dup) {
-                    ", currently out for proving"
-                } else {
-                    ""
-                }
             );
         }
 
@@ -400,6 +379,35 @@ impl ProofPool {
                 e
             )
         })?;
+
+        // A duplicate nullifier anywhere in the pool (including proofs out
+        // with a TakenBatch) means the same leaf spend is already staged; only
+        // one copy can ever settle. This is checked pool-wide (not per
+        // bucket): the cumulative merkle tree lets the same spend be proven
+        // against different recent blocks, i.e. into different buckets. It
+        // also deduplicates client re-submissions.
+        //
+        // Checked AFTER cryptographic verification and the verify budget, and
+        // with a generic message: otherwise this rejection is a free,
+        // unlimited membership/status oracle over the pool's not-yet-settled
+        // spends — an attacker submitting invalid proofs that reuse an
+        // observed nullifier could confirm the spend is pooled, learn which
+        // block it referenced, and detect when it goes out for proving, all
+        // without paying verification cost. Gating it behind verify means a
+        // probe now requires a cryptographically valid proof carrying the
+        // target nullifier (i.e. actually holding that spend), and the error
+        // reveals only that some nullifier collided, not which one, from which
+        // bucket, or its proving status.
+        if metadata
+            .1
+            .iter()
+            .any(|n| self.nullifier_index.contains_key(n))
+        {
+            bail!(
+                "refusing to queue private-batch proof: a nullifier in this proof \
+                 is already staged in the pool"
+            );
+        }
 
         let (key, nullifiers, volume) = metadata;
         for nullifier in &nullifiers {
@@ -867,12 +875,68 @@ mod tests {
         let err = pool
             .push(prove_fake(&data, &targets, &fake(2, 11)))
             .unwrap_err();
-        assert!(err.to_string().contains("out for proving"), "got: {err}");
+        assert!(err.to_string().contains("already staged"), "got: {err}");
 
         // The original comes back on proving failure, still deduplicated.
         assert_eq!(pool.reinsert(taken), 1);
         assert_eq!(pool.len(), 1);
         assert_eq!(pool.num_buckets(), 1);
+    }
+
+    /// The duplicate-nullifier rejection must not disclose internal pool state
+    /// to untrusted submitters: not the staged nullifier value, not the block
+    /// the staged copy referenced, and not whether it is out for proving.
+    #[test]
+    fn duplicate_rejection_does_not_leak_pool_state() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        // Staged against block 1, then taken out for proving (the case whose
+        // old message leaked the most: nullifier + block + proving status).
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        let taken = pool.take_batch(&key).unwrap();
+
+        let err = pool
+            .push(prove_fake(&data, &targets, &fake(2, 11)))
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(!msg.contains("out for proving"), "leaks proving status: {msg}");
+        assert!(
+            !msg.contains(&format!("{:?}", nullifier_digest(11))),
+            "leaks staged nullifier: {msg}"
+        );
+        // The staged copy referenced block 1 (its block hash is the same
+        // 4-felt encoding nullifier_digest uses). The submitter only supplied
+        // block 2, so block 1 must never appear in the error.
+        assert!(
+            !msg.contains(&format!("{:?}", nullifier_digest(1))),
+            "leaks staged bucket block hash: {msg}"
+        );
+
+        let _ = pool.reinsert(taken);
+    }
+
+    /// The duplicate check must run AFTER cryptographic verification and the
+    /// verify budget, so it can't be probed as a free membership oracle with
+    /// cryptographically invalid proofs. A well-formed but invalid proof that
+    /// reuses a staged nullifier must be rejected as invalid, never revealed as
+    /// a duplicate.
+    #[test]
+    fn duplicate_check_runs_after_verification() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+
+        // Same nullifier (11), tampered so verification fails.
+        let mut invalid = prove_fake(&data, &targets, &fake(2, 11));
+        invalid.public_inputs[aggregated_output::ASSET_ID_OFFSET] = F::from_canonical_u64(9);
+        let err = pool.push(invalid).unwrap_err();
+        assert!(
+            err.to_string().contains("verification failed"),
+            "duplicate check must not short-circuit ahead of verification, got: {err}"
+        );
     }
 
     /// The gap this closes: a proof settled on-chain while its batch was out

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -901,7 +901,10 @@ mod tests {
             .push(prove_fake(&data, &targets, &fake(2, 11)))
             .unwrap_err();
         let msg = err.to_string();
-        assert!(!msg.contains("out for proving"), "leaks proving status: {msg}");
+        assert!(
+            !msg.contains("out for proving"),
+            "leaks proving status: {msg}"
+        );
         assert!(
             !msg.contains(&format!("{:?}", nullifier_digest(11))),
             "leaks staged nullifier: {msg}"

--- a/wormhole/aggregator/src/private_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/build.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use zk_circuits_common::circuit::{wormhole_private_batch_circuit_config, C, D, F};
 
-use crate::common::utils::load_canonical_leaf_verifier_data;
+use crate::common::utils::{load_canonical_leaf_verifier_data, read_artifact_file};
 use crate::private_batch::circuit::circuit_logic::PrivateBatchCircuit;
 
 /// Generate prebuilt Private-batch aggregation circuit binaries.
@@ -42,9 +42,9 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     // their verifier key into the recursive circuit as constants. Without this, a
     // substituted or stale common.bin/verifier.bin would silently produce
     // private-batch artifacts with the wrong embedded inner verifier key.
-    let leaf_common_bytes = std::fs::read(output_path.join("common.bin"))
+    let leaf_common_bytes = read_artifact_file(&output_path.join("common.bin"))
         .with_context(|| format!("Failed to read {}/common.bin", output_path.display()))?;
-    let leaf_verifier_bytes = std::fs::read(output_path.join("verifier.bin"))
+    let leaf_verifier_bytes = read_artifact_file(&output_path.join("verifier.bin"))
         .with_context(|| format!("Failed to read {}/verifier.bin", output_path.display()))?;
     let leaf = load_canonical_leaf_verifier_data(&leaf_common_bytes, &leaf_verifier_bytes)?;
 
@@ -126,7 +126,7 @@ fn generate_dummy_private_batch_proof(
 
     println!("Generating dummy private-batch proof for public-batch padding...");
 
-    let dummy_leaf_bytes = std::fs::read(bins_dir.join("dummy_proof.bin"))
+    let dummy_leaf_bytes = read_artifact_file(&bins_dir.join("dummy_proof.bin"))
         .with_context(|| format!("Failed to read {}/dummy_proof.bin", bins_dir.display()))?;
     let dummy_leaf = crate::dummy_proof::load_dummy_proof(dummy_leaf_bytes, leaf_common)
         .map_err(|e| anyhow!("Failed to deserialize dummy leaf proof: {}", e))?;
@@ -148,4 +148,44 @@ fn generate_dummy_private_batch_proof(
         .prove(pw)
         .map_err(|e| anyhow!("Failed to prove dummy private batch: {}", e))?;
     Ok(proof.to_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::utils::MAX_ARTIFACT_FILE_BYTES;
+    use std::fs::File;
+    use std::path::PathBuf;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "qp-private-batch-build-{}-{}",
+            tag,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// An oversized (sparse) leaf artifact must be rejected by the size cap
+    /// before its contents are allocated into memory, not fed whole into
+    /// deserialization and canonical comparison.
+    #[test]
+    fn oversized_leaf_common_artifact_is_rejected_by_size_cap() {
+        let dir = temp_dir("oversized-common");
+        File::create(dir.join("common.bin"))
+            .unwrap()
+            .set_len(MAX_ARTIFACT_FILE_BYTES + 1)
+            .unwrap();
+        std::fs::write(dir.join("verifier.bin"), b"irrelevant").unwrap();
+
+        let err = generate_private_batch_circuit_binaries(&dir, 1, false).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("exceeds the"),
+            "oversized artifact must be rejected by the size cap, got: {err:#}"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 }

--- a/wormhole/aggregator/src/private_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/build.rs
@@ -1,14 +1,17 @@
 //! Prebuild / serialization helpers for the monolithic Private-batch aggregation circuit.
 //!
-//! Generates: `private_batch_common.bin`, `private_batch_verifier.bin`, `private_batch_prover.bin`
+//! Generates: `private_batch_common.bin`, `private_batch_verifier.bin`
+//!
+//! No `private_batch_prover.bin` is emitted: `PrivateBatchProver` always rebuilds
+//! the aggregation prover from source, because a poisoned prover artifact could
+//! exfiltrate witness data through the proof's public-input list. `include_prover`
+//! now only controls generation of the dummy private-batch proof used to pad
+//! partial public batches.
 //!
 //! Expects `common.bin` and `verifier.bin` to already exist in the output directory.
 
 use anyhow::{anyhow, Context, Result};
-use plonky2::{
-    plonk::circuit_data::CommonCircuitData,
-    util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer},
-};
+use plonky2::{plonk::circuit_data::CommonCircuitData, util::serialization::DefaultGateSerializer};
 use qp_wormhole_inputs::validate_proof_count;
 use std::{
     fs::{create_dir_all, write},
@@ -56,9 +59,6 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     let circuit_data = agg_circuit.build_circuit();
 
     let gate_serializer = DefaultGateSerializer;
-    let generator_serializer = DefaultGeneratorSerializer::<C, D> {
-        _phantom: Default::default(),
-    };
 
     // Generate the dummy private-batch proof template (an all-dummy batch) used to pad
     // partial public batches. Must happen BEFORE consuming circuit_data below
@@ -84,7 +84,6 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     }
 
     let verifier_data = circuit_data.verifier_data();
-    let prover_data = circuit_data.prover_data();
     let common_data = &verifier_data.common;
 
     let agg_common_bytes = common_data
@@ -106,19 +105,6 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     )?;
     println!("Saved {}/private_batch_verifier.bin", output_path.display());
 
-    if include_prover {
-        let agg_prover_only_bytes = prover_data
-            .prover_only
-            .to_bytes(&generator_serializer, common_data)
-            .map_err(|e| anyhow!("Failed to serialize aggregated prover data: {}", e))?;
-        write(
-            output_path.join("private_batch_prover.bin"),
-            agg_prover_only_bytes,
-        )?;
-        println!("Saved {}/private_batch_prover.bin", output_path.display());
-    } else {
-        println!("Skipping aggregated prover binary generation");
-    }
     Ok(())
 }
 

--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -1799,4 +1799,97 @@ mod tests {
         .expect_err("truncated proof public inputs must be rejected");
         assert!(err.to_string().contains("public inputs"), "got: {err}");
     }
+
+    // -------------------------------------------------------------------------
+    // Witness-fill proof-shape preflight
+    //
+    // A proof with the expected 21 public inputs can still carry internally
+    // inconsistent proof vectors. The pinned qp-plonky2 witness writer assigns
+    // those through zip_eq / debug-only length checks, so without a full shape
+    // preflight a malformed proof panics inside fill_private_batch_witness
+    // (or silently leaves targets unset) instead of returning Err.
+    // -------------------------------------------------------------------------
+
+    /// Prove one valid fake leaf and build matching 1-slot private-batch targets.
+    fn valid_leaf_proof_and_targets() -> (
+        ProofWithPublicInputs<F, C, D>,
+        super::PrivateBatchCircuitTargets,
+    ) {
+        let (leaf, leaf_targets) = build_fake_leaf_circuit();
+        let mut pw = PartialWitness::new();
+        for t in leaf_targets.iter() {
+            pw.set_target(*t, F::ZERO).unwrap();
+        }
+        let proof = leaf.prove(pw).unwrap();
+
+        let targets = PrivateBatchCircuit::new(
+            CircuitConfig::standard_recursion_config(),
+            &leaf.common,
+            &leaf.verifier_only,
+            1,
+        )
+        .unwrap()
+        .targets();
+
+        (proof, targets)
+    }
+
+    fn fill_witness_with_proof(
+        targets: &super::PrivateBatchCircuitTargets,
+        proof: ProofWithPublicInputs<F, C, D>,
+    ) -> Result<()> {
+        let mut pw = PartialWitness::new();
+        fill_private_batch_witness(
+            &mut pw,
+            targets,
+            &[proof],
+            &deterministic_dummy_nullifier_pre_images(1),
+        )
+    }
+
+    /// Control: an untampered proof must still pass the shape preflight.
+    #[test]
+    fn witness_fill_accepts_well_shaped_proof() {
+        let (proof, targets) = valid_leaf_proof_and_targets();
+        fill_witness_with_proof(&targets, proof)
+            .expect("a valid, well-shaped proof must fill the witness");
+    }
+
+    /// A shortened FRI query-round list panics in plonky2's zip_eq without a
+    /// shape preflight; it must instead be rejected with an error.
+    #[test]
+    fn witness_fill_rejects_truncated_fri_query_rounds() {
+        let (mut proof, targets) = valid_leaf_proof_and_targets();
+        proof.proof.opening_proof.query_round_proofs.pop();
+
+        let err = fill_witness_with_proof(&targets, proof)
+            .expect_err("proof with truncated FRI query rounds must be rejected");
+        assert!(err.to_string().contains("query_round_proofs"), "got: {err}");
+    }
+
+    /// A truncated opening set trips a debug-only length check in plonky2's
+    /// witness writer (silent partial assignment in release); it must instead
+    /// be rejected with an error.
+    #[test]
+    fn witness_fill_rejects_truncated_openings() {
+        let (mut proof, targets) = valid_leaf_proof_and_targets();
+        proof.proof.openings.wires.pop();
+
+        let err = fill_witness_with_proof(&targets, proof)
+            .expect_err("proof with truncated openings must be rejected");
+        assert!(err.to_string().contains("openings.wires"), "got: {err}");
+    }
+
+    /// A shortened wires Merkle cap is assigned through a plain zip, silently
+    /// leaving trailing cap targets unset and deferring failure to prove time;
+    /// it must instead be rejected with an error.
+    #[test]
+    fn witness_fill_rejects_truncated_wires_cap() {
+        let (mut proof, targets) = valid_leaf_proof_and_targets();
+        proof.proof.wires_cap.0.pop();
+
+        let err = fill_witness_with_proof(&targets, proof)
+            .expect_err("proof with truncated wires_cap must be rejected");
+        assert!(err.to_string().contains("wires_cap"), "got: {err}");
+    }
 }

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -59,7 +59,7 @@ impl PrivateBatchProver {
     /// In production, prefer `new_from_binaries_dir(...)` to load prebuilt circuits.
     /// Returns an error when `num_leaf_proofs` is outside the supported range,
     /// or when `dummy_proof_template` is not a valid leaf proof carrying the
-    /// strong dummy sentinel (zero block hash and zero outputs).
+    /// strong dummy sentinel (zero block hash, zero outputs, and zero asset_id).
     pub fn new(
         agg_circuit_config: CircuitConfig,
         leaf_common: CommonCircuitData<F, D>,
@@ -149,9 +149,10 @@ impl PrivateBatchProver {
                 .map_err(|e| anyhow!("failed to deserialize dummy proof: {}", e))?;
 
         // Verify the template is a valid leaf proof carrying the strong dummy
-        // sentinel (zero block hash AND zero outputs), so a poisoned padding
-        // template cannot inject a real payout into every partial batch. This
-        // mirrors the public-batch template check (#97026).
+        // sentinel (zero block hash, zero outputs, AND zero asset_id), so a
+        // poisoned padding template cannot inject a real payout into every
+        // partial batch or deny partial-batch padding with a nonzero asset.
+        // This mirrors the public-batch template check (#97026).
         verify_dummy_leaf_template(&dummy_proof_template, &leaf_verifier_data)?;
 
         Ok(Self {
@@ -404,13 +405,21 @@ fn ensure_leaf_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) -> Re
 }
 
 /// Verify that the dummy leaf proof template is a valid leaf proof carrying the
-/// strong dummy sentinel: `block_hash == 0` AND both output amounts zero.
+/// strong dummy sentinel: `block_hash == 0`, both output amounts zero, AND
+/// `asset_id == 0`.
 ///
 /// The private-batch circuit only treats `block_hash == 0` slots as dummies, and
 /// its exit-dedup gadget sums output amounts across matching exit accounts. If a
 /// poisoned `dummy_proof.bin` contained a *real* proof (non-zero block hash or
 /// outputs), every empty slot in a partial batch would replay that payout. This
 /// mirrors `verify_dummy_private_batch_template` at the public-batch layer (#97026).
+///
+/// `asset_id` must be zero because `commit` pads native-asset (`asset_id = 0`)
+/// batches with this template and the circuit enforces asset_id equality across
+/// ALL slots, dummies included. A nonzero-asset template would pass loading but
+/// make every padded batch unprovable: partial native-asset batches fail the
+/// in-circuit asset-equality constraint, and nonzero-asset batches are already
+/// rejected by the padding preflight — denying the partial-batch path entirely.
 fn verify_dummy_leaf_template(
     template: &ProofWithPublicInputs<F, C, D>,
     leaf_verifier: &VerifierCircuitData<F, C, D>,
@@ -438,6 +447,14 @@ fn verify_dummy_leaf_template(
              padding templates must contribute zero to every exit slot",
             pis.output_amount_1,
             pis.output_amount_2
+        );
+    }
+    if pis.asset_id != 0 {
+        bail!(
+            "dummy leaf proof template has non-zero asset_id {}; padding templates \
+             must use the native asset (asset_id = 0) because the circuit enforces \
+             asset_id equality across all slots, dummies included",
+            pis.asset_id
         );
     }
 
@@ -490,6 +507,16 @@ mod tests {
             err.to_string().contains("non-zero block_hash"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn dummy_template_with_nonzero_asset_id_is_rejected() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let mut pis = [F::ZERO; PUBLIC_INPUTS_FELTS_LEN];
+        pis[ASSET_ID_START] = F::from_canonical_u32(7);
+        let template = prove_fake_leaf(&leaf, &targets, pis);
+        let err = verify_dummy_leaf_template(&template, &leaf.verifier_data()).unwrap_err();
+        assert!(err.to_string().contains("non-zero asset_id"), "got: {err}");
     }
 
     #[test]

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -22,7 +22,7 @@ use plonky2::{
 use rand::seq::SliceRandom;
 
 #[cfg(feature = "std")]
-use std::{fs, path::Path};
+use std::path::Path;
 
 use qp_wormhole_inputs::{validate_proof_count, BytesDigest, PublicCircuitInputs};
 use zk_circuits_common::{
@@ -30,6 +30,8 @@ use zk_circuits_common::{
     utils::bytes_to_digest,
 };
 
+#[cfg(feature = "std")]
+use crate::common::utils::read_artifact_file;
 use crate::{
     common::utils::{
         ensure_proof_public_input_len, leaf_proof_asset_id, load_canonical_leaf_verifier_data,
@@ -172,12 +174,12 @@ impl PrivateBatchProver {
         dummy_proof_path: &Path,
         num_leaf_proofs: usize,
     ) -> Result<Self> {
-        let leaf_common_bytes = fs::read(leaf_common_path)
+        let leaf_common_bytes = read_artifact_file(leaf_common_path)
             .with_context(|| format!("Failed to read leaf common file {:?}", leaf_common_path))?;
-        let leaf_verifier_only_bytes = fs::read(leaf_verifier_path).with_context(|| {
+        let leaf_verifier_only_bytes = read_artifact_file(leaf_verifier_path).with_context(|| {
             format!("Failed to read leaf verifier file {:?}", leaf_verifier_path)
         })?;
-        let dummy_proof_bytes = fs::read(dummy_proof_path)
+        let dummy_proof_bytes = read_artifact_file(dummy_proof_path)
             .with_context(|| format!("Failed to read dummy proof file {:?}", dummy_proof_path))?;
 
         Self::new_from_bytes(

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -176,9 +176,10 @@ impl PrivateBatchProver {
     ) -> Result<Self> {
         let leaf_common_bytes = read_artifact_file(leaf_common_path)
             .with_context(|| format!("Failed to read leaf common file {:?}", leaf_common_path))?;
-        let leaf_verifier_only_bytes = read_artifact_file(leaf_verifier_path).with_context(|| {
-            format!("Failed to read leaf verifier file {:?}", leaf_verifier_path)
-        })?;
+        let leaf_verifier_only_bytes =
+            read_artifact_file(leaf_verifier_path).with_context(|| {
+                format!("Failed to read leaf verifier file {:?}", leaf_verifier_path)
+            })?;
         let dummy_proof_bytes = read_artifact_file(dummy_proof_path)
             .with_context(|| format!("Failed to read dummy proof file {:?}", dummy_proof_path))?;
 

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -13,12 +13,11 @@ use plonky2::{
     iop::witness::PartialWitness,
     plonk::{
         circuit_data::{
-            CircuitConfig, CommonCircuitData, ProverCircuitData, ProverOnlyCircuitData,
-            VerifierCircuitData, VerifierOnlyCircuitData,
+            CircuitConfig, CommonCircuitData, ProverCircuitData, VerifierCircuitData,
+            VerifierOnlyCircuitData,
         },
         proof::ProofWithPublicInputs,
     },
-    util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer},
 };
 use rand::seq::SliceRandom;
 
@@ -33,8 +32,7 @@ use zk_circuits_common::{
 
 use crate::{
     common::utils::{
-        ensure_common_matches_canonical, ensure_proof_public_input_len, leaf_proof_asset_id,
-        load_canonical_leaf_verifier_data,
+        ensure_proof_public_input_len, leaf_proof_asset_id, load_canonical_leaf_verifier_data,
     },
     dummy_proof::{generate_random_nullifier_preimage, load_dummy_proof},
     private_batch::{
@@ -101,26 +99,28 @@ impl PrivateBatchProver {
 
     /// Create a private-batch aggregation prover from serialized bytes.
     ///
+    /// The aggregation circuit's prover data is **rebuilt from source**, never
+    /// loaded from an artifact. `ProverOnlyCircuitData` carries the witness
+    /// generators and the `public_inputs` target list that decides which
+    /// witness values are exposed in the returned proof, so a poisoned
+    /// `private_batch_prover.bin` could otherwise make the prover emit chosen
+    /// witness targets (e.g. dummy-nullifier preimages that reveal padding
+    /// slots) in the serialized proof before any downstream verifier rejects
+    /// it. Rebuilding is free here because constructing the circuit is required
+    /// regardless, and it mirrors the leaf prover, which likewise never trusts a
+    /// serialized prover artifact.
+    ///
     /// Expected bytes:
-    /// - `aggregated_prover_only_bytes`: private-batch aggregated prover-only circuit data
-    /// - `aggregated_common_bytes`: private-batch aggregated common circuit data
     /// - `leaf_common_bytes`: leaf circuit common data (`common.bin`)
     /// - `leaf_verifier_only_bytes`: leaf verifier-only data (`verifier.bin`)
     /// - `dummy_proof_bytes`: serialized dummy leaf proof (`dummy_proof.bin`)
     /// - `num_leaf_proofs`: number of leaf proofs aggregated by this private-batch prover
     pub fn new_from_bytes(
-        aggregated_prover_only_bytes: &[u8],
-        aggregated_common_bytes: &[u8],
         leaf_common_bytes: &[u8],
         leaf_verifier_only_bytes: &[u8],
         dummy_proof_bytes: &[u8],
         num_leaf_proofs: usize,
     ) -> Result<Self> {
-        let gate_serializer = DefaultGateSerializer;
-        let generator_serializer = DefaultGeneratorSerializer::<C, D> {
-            _phantom: Default::default(),
-        };
-
         // Validate the batch count at the public byte-loading boundary so a zero
         // or oversized count returns an error instead of panicking inside the
         // circuit builder (#97027, #97070).
@@ -130,8 +130,10 @@ impl PrivateBatchProver {
         let leaf_verifier_data =
             load_canonical_leaf_verifier_data(leaf_common_bytes, leaf_verifier_only_bytes)?;
 
-        // 2) Reconstruct the canonical aggregation circuit once: it provides both the
-        // witness targets and the canonical common data used to pin the prebuilt artifacts.
+        // 2) Rebuild the aggregation circuit from source and take its prover
+        // data directly. The leaf verifier key is pinned above and baked in as
+        // constants, so this prover is a deterministic function of the compiled
+        // circuit code — no serialized prover/common artifact is trusted.
         let circuit = PrivateBatchCircuit::new(
             wormhole_private_batch_circuit_config(),
             &leaf_verifier_data.common,
@@ -139,22 +141,9 @@ impl PrivateBatchProver {
             num_leaf_proofs,
         )?;
         let targets = Some(circuit.targets());
-        let canonical_agg = circuit.build_verifier();
+        let circuit_data = circuit.build_prover();
 
-        // 3) Load prebuilt aggregation circuit prover data and pin common data.
-        let agg_common =
-            CommonCircuitData::from_bytes(aggregated_common_bytes.to_vec(), &gate_serializer)
-                .map_err(|e| anyhow!("failed to deserialize aggregated common data: {}", e))?;
-        ensure_common_matches_canonical(&agg_common, &canonical_agg.common, "private_batch")?;
-
-        let agg_prover_only = ProverOnlyCircuitData::from_bytes(
-            aggregated_prover_only_bytes,
-            &generator_serializer,
-            &agg_common,
-        )
-        .map_err(|e| anyhow!("failed to deserialize aggregated prover data: {}", e))?;
-
-        // 4) Load dummy proof template compatible with the leaf verifier common data
+        // 3) Load dummy proof template compatible with the leaf verifier common data
         let dummy_proof_template =
             load_dummy_proof(dummy_proof_bytes.to_vec(), &leaf_verifier_data.common)
                 .map_err(|e| anyhow!("failed to deserialize dummy proof: {}", e))?;
@@ -166,10 +155,7 @@ impl PrivateBatchProver {
         verify_dummy_leaf_template(&dummy_proof_template, &leaf_verifier_data)?;
 
         Ok(Self {
-            circuit_data: ProverCircuitData {
-                prover_only: agg_prover_only,
-                common: agg_common,
-            },
+            circuit_data,
             partial_witness: PartialWitness::new(),
             targets,
             num_leaf_proofs,
@@ -179,27 +165,12 @@ impl PrivateBatchProver {
 
     /// Create a private-batch aggregation prover from explicit file paths.
     #[cfg(feature = "std")]
-    #[allow(clippy::too_many_arguments)]
     pub fn new_from_files(
-        aggregated_prover_path: &Path,
-        aggregated_common_path: &Path,
         leaf_common_path: &Path,
         leaf_verifier_path: &Path,
         dummy_proof_path: &Path,
         num_leaf_proofs: usize,
     ) -> Result<Self> {
-        let aggregated_prover_only_bytes = fs::read(aggregated_prover_path).with_context(|| {
-            format!(
-                "Failed to read aggregated prover file {:?}",
-                aggregated_prover_path
-            )
-        })?;
-        let aggregated_common_bytes = fs::read(aggregated_common_path).with_context(|| {
-            format!(
-                "Failed to read aggregated common file {:?}",
-                aggregated_common_path
-            )
-        })?;
         let leaf_common_bytes = fs::read(leaf_common_path)
             .with_context(|| format!("Failed to read leaf common file {:?}", leaf_common_path))?;
         let leaf_verifier_only_bytes = fs::read(leaf_verifier_path).with_context(|| {
@@ -209,8 +180,6 @@ impl PrivateBatchProver {
             .with_context(|| format!("Failed to read dummy proof file {:?}", dummy_proof_path))?;
 
         Self::new_from_bytes(
-            &aggregated_prover_only_bytes,
-            &aggregated_common_bytes,
             &leaf_common_bytes,
             &leaf_verifier_only_bytes,
             &dummy_proof_bytes,
@@ -220,9 +189,10 @@ impl PrivateBatchProver {
 
     /// Convenience constructor that loads everything from a generated binaries directory.
     ///
+    /// The aggregation prover circuit is rebuilt from source, so no
+    /// `private_batch_prover.bin` is read.
+    ///
     /// Expected files:
-    /// - `private_batch_prover.bin`
-    /// - `private_batch_common.bin`
     /// - `common.bin`
     /// - `verifier.bin`
     /// - `dummy_proof.bin`
@@ -235,8 +205,6 @@ impl PrivateBatchProver {
         let num_leaf_proofs = bins_config.num_leaf_proofs;
 
         Self::new_from_files(
-            &bins_dir.join("private_batch_prover.bin"),
-            &bins_dir.join("private_batch_common.bin"),
             &bins_dir.join("common.bin"),
             &bins_dir.join("verifier.bin"),
             &bins_dir.join("dummy_proof.bin"),

--- a/wormhole/aggregator/src/private_batch/prover/witness.rs
+++ b/wormhole/aggregator/src/private_batch/prover/witness.rs
@@ -8,6 +8,7 @@ use plonky2::{
 
 use zk_circuits_common::circuit::{C, D, F};
 
+use crate::common::utils::ensure_proof_shape_matches_targets;
 use crate::private_batch::circuit::circuit_logic::PrivateBatchCircuitTargets;
 
 /// Fill the partial witness for the prebuilt private-batch aggregation circuit.
@@ -44,17 +45,11 @@ pub fn fill_private_batch_witness(
     }
 
     for (i, (proof_t, proof)) in targets.leaf_proofs.iter().zip(proofs.iter()).enumerate() {
-        // Reject shape mismatches at this Result boundary: with fewer public
-        // inputs than targets, set_proof_with_pis_target's internal zip would
-        // silently leave trailing PI targets unset instead of erroring.
-        if proof.public_inputs.len() != proof_t.public_inputs.len() {
-            bail!(
-                "leaf proof at slot {} has {} public inputs, but the circuit expects {}",
-                i,
-                proof.public_inputs.len(),
-                proof_t.public_inputs.len()
-            );
-        }
+        // Full proof-shape preflight at this Result boundary: a malformed
+        // proof (wrong PI count, truncated FRI query rounds, inconsistent
+        // opening vectors, ...) would otherwise panic inside plonky2's
+        // witness writer or silently leave targets unset.
+        ensure_proof_shape_matches_targets(proof_t, proof, i, "leaf proof")?;
         pw.set_proof_with_pis_target(proof_t, proof)
             .map_err(|e| anyhow!("failed to set leaf proof target at slot {}: {}", i, e))?;
     }

--- a/wormhole/aggregator/src/public_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/build.rs
@@ -49,8 +49,8 @@ pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
     // count is derived from the (untrusted) common data first, but the subsequent
     // byte-exact comparison against a canonically rebuilt circuit for that count
     // rejects any substituted or stale artifact.
-    let private_batch_common_bytes = read_artifact_file(&output_dir.join("private_batch_common.bin"))
-        .with_context(|| {
+    let private_batch_common_bytes =
+        read_artifact_file(&output_dir.join("private_batch_common.bin")).with_context(|| {
             format!(
                 "Failed to read {}",
                 output_dir.join("private_batch_common.bin").display()
@@ -185,7 +185,10 @@ fn commit_artifact_set(bins_dir: &Path, files: &[(&str, Vec<u8>)]) -> Result<()>
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
                 Err(e) => {
                     return Err(e).with_context(|| {
-                        format!("Failed to move previous {} aside", bins_dir.join(name).display())
+                        format!(
+                            "Failed to move previous {} aside",
+                            bins_dir.join(name).display()
+                        )
                     })
                 }
             }
@@ -351,4 +354,3 @@ mod tests {
         std::fs::remove_dir_all(&dir).unwrap();
     }
 }
-

--- a/wormhole/aggregator/src/public_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/build.rs
@@ -8,7 +8,8 @@
 //! Expects private-batch artifacts to already exist in `output_dir`.
 
 use anyhow::{anyhow, Context, Result};
-use std::fs::{create_dir_all, write};
+use std::fs::{self, create_dir_all};
+use std::io::Write as _;
 use std::path::Path;
 
 use plonky2::plonk::circuit_data::VerifierCircuitData;
@@ -24,6 +25,15 @@ use crate::common::utils::{
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 
 /// Build and write all public-batch artifacts into `output_dir`.
+///
+/// The two public-batch files are published all-or-nothing (see
+/// [`commit_artifact_set`]), so a failed re-run over an existing bins dir
+/// never leaves a fresh `public_batch_common.bin` beside a stale
+/// `public_batch_verifier.bin`. Whole-directory consistency across all
+/// stages (leaf, private-batch, public-batch, `config.json`) is still only
+/// guaranteed by the staging `generate_all_circuit_binaries` flow in
+/// `circuit-builder`; prefer it unless deliberately regenerating this one
+/// stage into an existing set.
 pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
     output_dir: P,
     num_private_batch_proofs: usize,
@@ -119,20 +129,112 @@ fn write_verifier_artifacts(
         .to_bytes()
         .map_err(|e| anyhow!("Failed to serialize public_batch verifier data: {}", e))?;
 
-    write(bins_dir.join("public_batch_common.bin"), common_bytes).with_context(|| {
-        format!(
-            "Failed to write {}",
-            bins_dir.join("public_batch_common.bin").display()
-        )
-    })?;
-    write(bins_dir.join("public_batch_verifier.bin"), verifier_bytes).with_context(|| {
-        format!(
-            "Failed to write {}",
-            bins_dir.join("public_batch_verifier.bin").display()
-        )
-    })?;
+    commit_artifact_set(
+        bins_dir,
+        &[
+            ("public_batch_common.bin", common_bytes),
+            ("public_batch_verifier.bin", verifier_bytes),
+        ],
+    )
+}
 
-    Ok(())
+/// Publish a matched set of artifact files into `bins_dir` all-or-nothing.
+///
+/// `public_batch_common.bin` and `public_batch_verifier.bin` are consumed as a
+/// matched pair (loaders pin them against a canonical circuit rebuild), so a
+/// directory holding a fresh file from one generation beside a stale file from
+/// another is rejected until regenerated. Naive in-place writes create exactly
+/// that state whenever a re-run fails between files.
+///
+/// Instead, every file is first staged under a fresh unpredictable temp name
+/// in the same directory (exclusive create, so a pre-planted entry or symlink
+/// is never adopted), and only after all stages succeed are the previous
+/// artifacts moved aside and the staged files renamed into place. Any failure
+/// rolls the moved-aside originals back, so an error always leaves either the
+/// complete previous set or the complete new set — never a mix. The unwritten
+/// window shrinks from the whole multi-minute build-and-write to the instants
+/// between renames of already-complete files.
+fn commit_artifact_set(bins_dir: &Path, files: &[(&str, Vec<u8>)]) -> Result<()> {
+    let unique = format!("{}-{:016x}", std::process::id(), rand::random::<u64>());
+    let tmp_path = |name: &str| bins_dir.join(format!(".{name}.tmp-{unique}"));
+    let old_path = |name: &str| bins_dir.join(format!(".{name}.old-{unique}"));
+
+    // Phase 1: stage every file. Any failure here leaves the originals untouched.
+    for (i, (name, bytes)) in files.iter().enumerate() {
+        let path = tmp_path(name);
+        let staged = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .and_then(|mut f| f.write_all(bytes));
+        if let Err(e) = staged {
+            for (name, _) in &files[..=i] {
+                let _ = fs::remove_file(tmp_path(name));
+            }
+            return Err(e).with_context(|| format!("Failed to stage {}", path.display()));
+        }
+    }
+
+    // Phase 2: move previous artifacts aside, then swap the staged set in.
+    let mut moved_aside: Vec<&str> = Vec::new();
+    let mut swapped: Vec<&str> = Vec::new();
+    let swap_result = (|| -> Result<()> {
+        for (name, _) in files {
+            match fs::rename(bins_dir.join(name), old_path(name)) {
+                Ok(()) => moved_aside.push(name),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!("Failed to move previous {} aside", bins_dir.join(name).display())
+                    })
+                }
+            }
+        }
+        for (name, _) in files {
+            fs::rename(tmp_path(name), bins_dir.join(name)).with_context(|| {
+                format!(
+                    "Failed to move staged artifact into place at {}",
+                    bins_dir.join(name).display()
+                )
+            })?;
+            swapped.push(name);
+        }
+        Ok(())
+    })();
+
+    match swap_result {
+        Ok(()) => {
+            // The new set is committed; the moved-aside copies are redundant.
+            for name in moved_aside {
+                let old = old_path(name);
+                if fs::remove_file(&old).is_err() {
+                    let _ = fs::remove_dir_all(&old);
+                }
+            }
+            Ok(())
+        }
+        Err(e) => {
+            // Restore the previous set: renaming the old copy back atomically
+            // overwrites any already-swapped new file; names that had no old
+            // copy get their new file removed instead.
+            for (name, _) in files {
+                let final_path = bins_dir.join(name);
+                if moved_aside.contains(name) {
+                    if fs::rename(old_path(name), &final_path).is_err() {
+                        // A blocking entry (e.g. an already-swapped file under
+                        // a directory-shaped old copy) must not strand the
+                        // rollback in a mixed state.
+                        let _ = fs::remove_file(&final_path);
+                        let _ = fs::rename(old_path(name), &final_path);
+                    }
+                } else if swapped.contains(name) {
+                    let _ = fs::remove_file(&final_path);
+                }
+                let _ = fs::remove_file(tmp_path(name));
+            }
+            Err(e)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -141,6 +243,7 @@ mod tests {
     use crate::common::utils::MAX_ARTIFACT_FILE_BYTES;
     use std::fs::File;
     use std::path::PathBuf;
+    use test_helpers::fake_leaf::build_fake_leaf_circuit;
 
     fn temp_dir(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
@@ -169,6 +272,80 @@ mod tests {
         assert!(
             format!("{err:#}").contains("exceeds the"),
             "oversized artifact must be rejected by the size cap, got: {err:#}"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// `public_batch_common.bin` and `public_batch_verifier.bin` are a matched
+    /// set: consumers load both and pin them against a canonical rebuild, so a
+    /// directory holding one new file beside one stale file is rejected until
+    /// regenerated. A publish that fails partway must therefore either leave
+    /// the previous set fully intact or replace it wholesale — never mix.
+    #[test]
+    fn failed_artifact_publish_never_leaves_mixed_verifier_set() {
+        let dir = temp_dir("mixed-set");
+        std::fs::write(dir.join("public_batch_common.bin"), b"old common").unwrap();
+        // A directory squatting on the verifier path makes a naive in-place
+        // write of the second file fail after the first was already clobbered.
+        create_dir_all(dir.join("public_batch_verifier.bin")).unwrap();
+
+        let verifier_data = build_fake_leaf_circuit().0.verifier_data();
+        let result = write_verifier_artifacts(&dir, &verifier_data);
+
+        let common_now = std::fs::read(dir.join("public_batch_common.bin")).unwrap();
+        match result {
+            Err(_) => assert_eq!(
+                common_now, b"old common",
+                "a failed publish must leave the previous artifact set untouched, \
+                 not a fresh common beside a stale verifier"
+            ),
+            Ok(()) => {
+                assert_ne!(
+                    common_now, b"old common",
+                    "a successful publish must replace the set wholesale"
+                );
+                assert!(
+                    dir.join("public_batch_verifier.bin").is_file(),
+                    "a successful publish must leave a real verifier artifact"
+                );
+            }
+        }
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A successful re-publish over an existing set must replace both files
+    /// and leave no staging or moved-aside droppings behind in the bins dir.
+    #[test]
+    fn artifact_publish_replaces_set_wholesale_without_droppings() {
+        let dir = temp_dir("clean-publish");
+        std::fs::write(dir.join("public_batch_common.bin"), b"old common").unwrap();
+        std::fs::write(dir.join("public_batch_verifier.bin"), b"old verifier").unwrap();
+
+        let verifier_data = build_fake_leaf_circuit().0.verifier_data();
+        write_verifier_artifacts(&dir, &verifier_data).unwrap();
+
+        assert_ne!(
+            std::fs::read(dir.join("public_batch_common.bin")).unwrap(),
+            b"old common"
+        );
+        assert_ne!(
+            std::fs::read(dir.join("public_batch_verifier.bin")).unwrap(),
+            b"old verifier"
+        );
+        let mut names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "public_batch_common.bin".to_string(),
+                "public_batch_verifier.bin".to_string()
+            ],
+            "publish must not leave temp/old files behind"
         );
 
         std::fs::remove_dir_all(&dir).unwrap();

--- a/wormhole/aggregator/src/public_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/build.rs
@@ -1,6 +1,9 @@
 //! Build + serialize public-batch aggregation circuit artifacts.
 //!
-//! Generates: `public_batch_common.bin`, `public_batch_verifier.bin`, `public_batch_prover.bin` (optional)
+//! Generates: `public_batch_common.bin`, `public_batch_verifier.bin`
+//! No `public_batch_prover.bin` is emitted: `PublicBatchProver` always rebuilds
+//! the circuit from source, because a poisoned prover artifact could exfiltrate
+//! witness data through the proof's public-input list.
 //!
 //! Expects private-batch artifacts to already exist in `output_dir`.
 
@@ -8,8 +11,8 @@ use anyhow::{anyhow, Context, Result};
 use std::fs::{create_dir_all, write};
 use std::path::Path;
 
-use plonky2::plonk::circuit_data::{ProverCircuitData, VerifierCircuitData};
-use plonky2::util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer};
+use plonky2::plonk::circuit_data::VerifierCircuitData;
+use plonky2::util::serialization::DefaultGateSerializer;
 
 use qp_wormhole_inputs::validate_proof_count;
 use zk_circuits_common::circuit::{wormhole_public_batch_circuit_config, C, D, F};
@@ -24,7 +27,6 @@ use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
     output_dir: P,
     num_private_batch_proofs: usize,
-    include_prover: bool,
 ) -> Result<()> {
     let output_dir = output_dir.as_ref();
     // Bound the per-layer count before any circuit construction (#97021, #97070).
@@ -73,14 +75,8 @@ pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
         private_batch_num_leaves,
     )?;
 
-    let circuit_data = public_batch_circuit.build_circuit();
-    let verifier_data = circuit_data.verifier_data();
+    let verifier_data = public_batch_circuit.build_verifier();
     write_verifier_artifacts(output_dir, &verifier_data)?;
-
-    if include_prover {
-        let prover_data = circuit_data.prover_data();
-        write_prover_artifact(output_dir, &prover_data)?;
-    }
 
     println!(
         "Public-batch circuit artifacts written to {} (num_private_batch_proofs={}, private_batch_num_leaves={})",
@@ -139,22 +135,3 @@ fn write_verifier_artifacts(
     Ok(())
 }
 
-fn write_prover_artifact(bins_dir: &Path, prover_data: &ProverCircuitData<F, C, D>) -> Result<()> {
-    let generator_serializer = DefaultGeneratorSerializer::<C, D> {
-        _phantom: Default::default(),
-    };
-
-    let prover_bytes = prover_data
-        .prover_only
-        .to_bytes(&generator_serializer, &prover_data.common)
-        .map_err(|e| anyhow!("Failed to serialize public_batch prover data: {}", e))?;
-
-    write(bins_dir.join("public_batch_prover.bin"), prover_bytes).with_context(|| {
-        format!(
-            "Failed to write {}",
-            bins_dir.join("public_batch_prover.bin").display()
-        )
-    })?;
-
-    Ok(())
-}

--- a/wormhole/aggregator/src/public_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/build.rs
@@ -19,7 +19,7 @@ use zk_circuits_common::circuit::{wormhole_public_batch_circuit_config, C, D, F}
 
 use crate::common::utils::{
     canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
-    private_batch_num_leaves_from_padded_pi_len,
+    private_batch_num_leaves_from_padded_pi_len, read_artifact_file,
 };
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 
@@ -39,15 +39,15 @@ pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
     // count is derived from the (untrusted) common data first, but the subsequent
     // byte-exact comparison against a canonically rebuilt circuit for that count
     // rejects any substituted or stale artifact.
-    let private_batch_common_bytes = std::fs::read(output_dir.join("private_batch_common.bin"))
+    let private_batch_common_bytes = read_artifact_file(&output_dir.join("private_batch_common.bin"))
         .with_context(|| {
             format!(
                 "Failed to read {}",
                 output_dir.join("private_batch_common.bin").display()
             )
         })?;
-    let private_batch_verifier_bytes = std::fs::read(output_dir.join("private_batch_verifier.bin"))
-        .with_context(|| {
+    let private_batch_verifier_bytes =
+        read_artifact_file(&output_dir.join("private_batch_verifier.bin")).with_context(|| {
             format!(
                 "Failed to read {}",
                 output_dir.join("private_batch_verifier.bin").display()
@@ -133,5 +133,45 @@ fn write_verifier_artifacts(
     })?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::utils::MAX_ARTIFACT_FILE_BYTES;
+    use std::fs::File;
+    use std::path::PathBuf;
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "qp-public-batch-build-{}-{}",
+            tag,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// An oversized (sparse) private-batch artifact must be rejected by the
+    /// size cap before its contents are allocated into memory and fed into
+    /// `peek_common_num_public_inputs`'s full deserialization.
+    #[test]
+    fn oversized_private_batch_common_artifact_is_rejected_by_size_cap() {
+        let dir = temp_dir("oversized-common");
+        File::create(dir.join("private_batch_common.bin"))
+            .unwrap()
+            .set_len(MAX_ARTIFACT_FILE_BYTES + 1)
+            .unwrap();
+        std::fs::write(dir.join("private_batch_verifier.bin"), b"irrelevant").unwrap();
+
+        let err = generate_public_batch_circuit_binaries(&dir, 1).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("exceeds the"),
+            "oversized artifact must be rejected by the size cap, got: {err:#}"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 }
 

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -748,10 +748,8 @@ mod tests {
 
     /// Prove one valid all-dummy private-batch proof and build matching
     /// 1-slot public-batch targets.
-    fn valid_private_batch_proof_and_targets() -> (
-        ProofWithPublicInputs<F, C, D>,
-        PublicBatchCircuitTargets,
-    ) {
+    fn valid_private_batch_proof_and_targets(
+    ) -> (ProofWithPublicInputs<F, C, D>, PublicBatchCircuitTargets) {
         let (leaf, leaf_targets) = build_fake_leaf_circuit();
         let dummy_leaf = prove_fake_leaf(&leaf, &leaf_targets, [F::ZERO; 21]);
         let proof = make_all_dummy_private_batch_template(&leaf, &dummy_leaf);

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -1,7 +1,9 @@
-//! Public-batch aggregation prover (prebuilt-circuit proving API).
+//! Public-batch aggregation prover.
 //!
 //! The private-batch verifier key is baked in as constants at circuit build time to prevent
-//! verifier key substitution attacks.
+//! verifier key substitution attacks. The public-batch circuit (and its prover-only data)
+//! is always rebuilt from source rather than loaded from a serialized artifact; see
+//! [`PublicBatchProver::new_from_bytes`].
 
 use anyhow::{anyhow, bail, Context, Result};
 use plonky2::field::types::PrimeField64;
@@ -10,12 +12,11 @@ use plonky2::{
     iop::witness::PartialWitness,
     plonk::{
         circuit_data::{
-            CircuitConfig, CommonCircuitData, ProverCircuitData, ProverOnlyCircuitData,
-            VerifierCircuitData, VerifierOnlyCircuitData,
+            CircuitConfig, CommonCircuitData, ProverCircuitData, VerifierCircuitData,
+            VerifierOnlyCircuitData,
         },
         proof::ProofWithPublicInputs,
     },
-    util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer},
 };
 use qp_wormhole_inputs::{validate_proof_count, BytesDigest, PrivateBatchPublicInputs};
 
@@ -29,8 +30,8 @@ use zk_circuits_common::{
 
 use crate::{
     common::utils::{
-        canonical_leaf_verifier_data, ensure_common_matches_canonical,
-        ensure_proof_public_input_len, load_canonical_private_batch_verifier_data,
+        canonical_leaf_verifier_data, ensure_proof_public_input_len,
+        load_canonical_private_batch_verifier_data,
     },
     public_batch::{
         circuit::{
@@ -113,19 +114,19 @@ impl PublicBatchProver {
     }
 
     /// Create a public-batch prover from serialized bytes.
+    ///
+    /// The public-batch circuit itself (including its `ProverOnlyCircuitData`)
+    /// is always rebuilt from source rather than deserialized: prover-only data
+    /// decides which witness wires are exposed as public inputs, so a poisoned
+    /// prover artifact could exfiltrate witness data through the proof's
+    /// public-input list. The full circuit build was already required here to
+    /// pin the loaded artifacts, so rebuilding adds no extra cost.
     pub fn new_from_bytes(
-        public_batch_prover_only_bytes: &[u8],
-        public_batch_common_bytes: &[u8],
         private_batch_common_bytes: &[u8],
         private_batch_verifier_only_bytes: &[u8],
         dummy_private_batch_proof_bytes: &[u8],
         config: (usize, usize), // (num_leaf_proofs, num_private_batch_proofs)
     ) -> Result<Self> {
-        let gate_serializer = DefaultGateSerializer;
-        let generator_serializer = DefaultGeneratorSerializer::<C, D> {
-            _phantom: Default::default(),
-        };
-
         let (num_leaf_proofs, num_private_batch_proofs) = config;
 
         // Validate batch counts at the public byte-loading boundary so a zero or
@@ -156,8 +157,8 @@ impl PublicBatchProver {
             );
         }
 
-        // 2) Reconstruct the canonical public-batch circuit once: it provides both the
-        // witness targets and the canonical common data used to pin the prebuilt artifacts.
+        // 2) Rebuild the canonical public-batch circuit from source. Its prover
+        // data is used directly instead of loading a serialized prover artifact.
         let circuit = PublicBatchCircuit::new(
             wormhole_public_batch_circuit_config(),
             private_batch_verifier_data.common.clone(),
@@ -166,26 +167,9 @@ impl PublicBatchProver {
             num_leaf_proofs,
         )?;
         let targets = Some(circuit.targets());
-        let canonical_public = circuit.build_verifier();
+        let circuit_data = circuit.build_prover();
 
-        // 3) Load prebuilt public-batch circuit prover data and pin common data.
-        let public_batch_common =
-            CommonCircuitData::from_bytes(public_batch_common_bytes.to_vec(), &gate_serializer)
-                .map_err(|e| anyhow!("failed to deserialize public_batch common data: {}", e))?;
-        ensure_common_matches_canonical(
-            &public_batch_common,
-            &canonical_public.common,
-            "public_batch",
-        )?;
-
-        let public_batch_prover_only = ProverOnlyCircuitData::from_bytes(
-            public_batch_prover_only_bytes,
-            &generator_serializer,
-            &public_batch_common,
-        )
-        .map_err(|e| anyhow!("failed to deserialize public_batch prover data: {}", e))?;
-
-        // 4) Load the dummy private-batch proof template used to pad partial batches
+        // 3) Load the dummy private-batch proof template used to pad partial batches
         let dummy_proof_template = ProofWithPublicInputs::<F, C, D>::from_bytes(
             dummy_private_batch_proof_bytes.to_vec(),
             &private_batch_verifier_data.common,
@@ -198,10 +182,7 @@ impl PublicBatchProver {
         verify_dummy_private_batch_template(&dummy_proof_template, &private_batch_verifier_data)?;
 
         Ok(Self {
-            circuit_data: ProverCircuitData {
-                prover_only: public_batch_prover_only,
-                common: public_batch_common,
-            },
+            circuit_data,
             partial_witness: PartialWitness::new(),
             targets,
             num_private_batch_proofs,
@@ -211,20 +192,12 @@ impl PublicBatchProver {
     }
 
     #[cfg(feature = "std")]
-    #[allow(clippy::too_many_arguments)]
     pub fn new_from_files(
-        public_batch_prover_path: &Path,
-        public_batch_common_path: &Path,
         private_batch_common_path: &Path,
         private_batch_verifier_path: &Path,
         dummy_private_batch_proof_path: &Path,
         config: (usize, usize),
     ) -> Result<Self> {
-        let public_batch_prover_only_bytes = fs::read(public_batch_prover_path)
-            .with_context(|| format!("Failed to read {:?}", public_batch_prover_path))?;
-        let public_batch_common_bytes = fs::read(public_batch_common_path)
-            .with_context(|| format!("Failed to read {:?}", public_batch_common_path))?;
-
         let private_batch_common_bytes = fs::read(private_batch_common_path)
             .with_context(|| format!("Failed to read {:?}", private_batch_common_path))?;
         let private_batch_verifier_only_bytes = fs::read(private_batch_verifier_path)
@@ -233,8 +206,6 @@ impl PublicBatchProver {
             .with_context(|| format!("Failed to read {:?}", dummy_private_batch_proof_path))?;
 
         Self::new_from_bytes(
-            &public_batch_prover_only_bytes,
-            &public_batch_common_bytes,
             &private_batch_common_bytes,
             &private_batch_verifier_only_bytes,
             &dummy_private_batch_proof_bytes,
@@ -245,13 +216,14 @@ impl PublicBatchProver {
     /// Convenience constructor from a generated binaries directory.
     ///
     /// Expected files:
-    /// - `public_batch_prover.bin`
-    /// - `public_batch_common.bin`
     /// - `private_batch_common.bin`             (private-batch common)
     /// - `private_batch_verifier.bin`           (private-batch verifier-only)
     /// - `dummy_private_batch_proof.bin`        (padding template)
     /// - `config.json`
     ///
+    /// The public-batch circuit itself is rebuilt from source (see
+    /// [`Self::new_from_bytes`]); no `public_batch_prover.bin` or
+    /// `public_batch_common.bin` is read.
     #[cfg(feature = "std")]
     pub fn new_from_binaries_dir(bins_dir: &Path) -> Result<Self> {
         let bins_config = crate::config::CircuitBinsConfig::load(bins_dir)?;
@@ -264,8 +236,6 @@ impl PublicBatchProver {
         let config = (bins_config.num_leaf_proofs, num_private_batch_proofs);
 
         Self::new_from_files(
-            &bins_dir.join("public_batch_prover.bin"),
-            &bins_dir.join("public_batch_common.bin"),
             &bins_dir.join("private_batch_common.bin"),
             &bins_dir.join("private_batch_verifier.bin"),
             &bins_dir.join("dummy_private_batch_proof.bin"),

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -762,4 +762,106 @@ mod tests {
             "got: {err}"
         );
     }
+
+    // -------------------------------------------------------------------------
+    // Witness-fill proof-shape preflight
+    //
+    // A proof with the expected public-input length can still carry internally
+    // inconsistent proof vectors. The pinned qp-plonky2 witness writer assigns
+    // those through zip_eq / debug-only length checks, so without a full shape
+    // preflight a malformed proof panics inside fill_public_batch_witness
+    // (or silently leaves targets unset) instead of returning Err. Mirrors the
+    // private-batch witness-fill preflight one layer down.
+    // -------------------------------------------------------------------------
+
+    /// Prove one valid all-dummy private-batch proof and build matching
+    /// 1-slot public-batch targets.
+    fn valid_private_batch_proof_and_targets() -> (
+        ProofWithPublicInputs<F, C, D>,
+        PublicBatchCircuitTargets,
+    ) {
+        let (leaf, leaf_targets) = build_fake_leaf_circuit();
+        let dummy_leaf = prove_fake_leaf(&leaf, &leaf_targets, [F::ZERO; 21]);
+        let proof = make_all_dummy_private_batch_template(&leaf, &dummy_leaf);
+
+        let private_batch = PrivateBatchCircuit::new(
+            wormhole_private_batch_circuit_config(),
+            &leaf.common,
+            &leaf.verifier_only,
+            1,
+        )
+        .unwrap()
+        .build_verifier();
+
+        let targets = PublicBatchCircuit::new(
+            wormhole_public_batch_circuit_config(),
+            private_batch.common,
+            &private_batch.verifier_only,
+            1,
+            1,
+        )
+        .unwrap()
+        .targets();
+
+        (proof, targets)
+    }
+
+    fn fill_witness_with_proof(
+        targets: &PublicBatchCircuitTargets,
+        proof: ProofWithPublicInputs<F, C, D>,
+    ) -> Result<()> {
+        let mut pw = PartialWitness::new();
+        fill_public_batch_witness(
+            &mut pw,
+            targets,
+            &[proof],
+            bytes_to_digest(BytesDigest::default()),
+        )
+    }
+
+    /// Control: an untampered proof must still pass the shape preflight.
+    #[test]
+    fn witness_fill_accepts_well_shaped_proof() {
+        let (proof, targets) = valid_private_batch_proof_and_targets();
+        fill_witness_with_proof(&targets, proof)
+            .expect("a valid, well-shaped proof must fill the witness");
+    }
+
+    /// A shortened FRI query-round list panics in plonky2's zip_eq without a
+    /// shape preflight; it must instead be rejected with an error.
+    #[test]
+    fn witness_fill_rejects_truncated_fri_query_rounds() {
+        let (mut proof, targets) = valid_private_batch_proof_and_targets();
+        proof.proof.opening_proof.query_round_proofs.pop();
+
+        let err = fill_witness_with_proof(&targets, proof)
+            .expect_err("proof with truncated FRI query rounds must be rejected");
+        assert!(err.to_string().contains("query_round_proofs"), "got: {err}");
+    }
+
+    /// A truncated opening set trips a debug-only length check in plonky2's
+    /// witness writer (silent partial assignment in release); it must instead
+    /// be rejected with an error.
+    #[test]
+    fn witness_fill_rejects_truncated_openings() {
+        let (mut proof, targets) = valid_private_batch_proof_and_targets();
+        proof.proof.openings.wires.pop();
+
+        let err = fill_witness_with_proof(&targets, proof)
+            .expect_err("proof with truncated openings must be rejected");
+        assert!(err.to_string().contains("openings.wires"), "got: {err}");
+    }
+
+    /// A shortened wires Merkle cap is assigned through a plain zip, silently
+    /// leaving trailing cap targets unset and deferring failure to prove time;
+    /// it must instead be rejected with an error.
+    #[test]
+    fn witness_fill_rejects_truncated_wires_cap() {
+        let (mut proof, targets) = valid_private_batch_proof_and_targets();
+        proof.proof.wires_cap.0.pop();
+
+        let err = fill_witness_with_proof(&targets, proof)
+            .expect_err("proof with truncated wires_cap must be rejected");
+        assert!(err.to_string().contains("wires_cap"), "got: {err}");
+    }
 }

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -21,13 +21,15 @@ use plonky2::{
 use qp_wormhole_inputs::{validate_proof_count, BytesDigest, PrivateBatchPublicInputs};
 
 #[cfg(feature = "std")]
-use std::{fs, path::Path};
+use std::path::Path;
 
 use zk_circuits_common::{
     circuit::{wormhole_public_batch_circuit_config, C, D, F},
     utils::bytes_to_digest,
 };
 
+#[cfg(feature = "std")]
+use crate::common::utils::read_artifact_file;
 use crate::{
     common::utils::{
         canonical_leaf_verifier_data, ensure_proof_public_input_len,
@@ -198,11 +200,11 @@ impl PublicBatchProver {
         dummy_private_batch_proof_path: &Path,
         config: (usize, usize),
     ) -> Result<Self> {
-        let private_batch_common_bytes = fs::read(private_batch_common_path)
+        let private_batch_common_bytes = read_artifact_file(private_batch_common_path)
             .with_context(|| format!("Failed to read {:?}", private_batch_common_path))?;
-        let private_batch_verifier_only_bytes = fs::read(private_batch_verifier_path)
+        let private_batch_verifier_only_bytes = read_artifact_file(private_batch_verifier_path)
             .with_context(|| format!("Failed to read {:?}", private_batch_verifier_path))?;
-        let dummy_private_batch_proof_bytes = fs::read(dummy_private_batch_proof_path)
+        let dummy_private_batch_proof_bytes = read_artifact_file(dummy_private_batch_proof_path)
             .with_context(|| format!("Failed to read {:?}", dummy_private_batch_proof_path))?;
 
         Self::new_from_bytes(

--- a/wormhole/aggregator/src/public_batch/prover/witness.rs
+++ b/wormhole/aggregator/src/public_batch/prover/witness.rs
@@ -7,6 +7,7 @@ use plonky2::plonk::proof::ProofWithPublicInputs;
 use zk_circuits_common::circuit::{C, D, F};
 use zk_circuits_common::utils::Digest;
 
+use crate::common::utils::ensure_proof_shape_matches_targets;
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuitTargets;
 
 /// Fill a partial witness for the public-batch aggregation circuit.
@@ -38,17 +39,11 @@ pub fn fill_public_batch_witness(
         .zip(private_batch_proofs.iter())
         .enumerate()
     {
-        // Reject shape mismatches at this Result boundary: with fewer public
-        // inputs than targets, set_proof_with_pis_target's internal zip would
-        // silently leave trailing PI targets unset instead of erroring.
-        if proof.public_inputs.len() != proof_t.public_inputs.len() {
-            bail!(
-                "private-batch proof at slot {} has {} public inputs, but the circuit expects {}",
-                i,
-                proof.public_inputs.len(),
-                proof_t.public_inputs.len()
-            );
-        }
+        // Full proof-shape preflight at this Result boundary: a malformed
+        // proof (wrong PI count, truncated FRI query rounds, inconsistent
+        // opening vectors, ...) would otherwise panic inside plonky2's
+        // witness writer or silently leave targets unset.
+        ensure_proof_shape_matches_targets(proof_t, proof, i, "private-batch proof")?;
         pw.set_proof_with_pis_target(proof_t, proof)?;
     }
 

--- a/wormhole/circuit-builder/Cargo.toml
+++ b/wormhole/circuit-builder/Cargo.toml
@@ -17,8 +17,8 @@ zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", pa
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 clap = { version = "=4.6.1", features = ["derive"] }
-rand = "=0.8.6"
 qp-plonky2 = { workspace = true, features = ["default"] }
+rand = "=0.8.6"
 wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.1.0", path = "../aggregator", default-features = false, features = [
 	"std",
 ] }

--- a/wormhole/circuit-builder/Cargo.toml
+++ b/wormhole/circuit-builder/Cargo.toml
@@ -17,6 +17,7 @@ zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", pa
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 clap = { version = "=4.6.1", features = ["derive"] }
+rand = "=0.8.6"
 qp-plonky2 = { workspace = true, features = ["default"] }
 wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=3.1.0", path = "../aggregator", default-features = false, features = [
 	"std",

--- a/wormhole/circuit-builder/README.md
+++ b/wormhole/circuit-builder/README.md
@@ -8,7 +8,7 @@ cargo run --release -p qp-wormhole-circuit-builder -- --num-leaf-proofs <N> [--n
 
 Produces prover and verifier binaries for a given aggregation shape (number of leaf proofs and number of inner proofs for private_batch and public_batch respectively). Use the generated artifacts with the aggregator provers and [qp-wormhole-verifier] to run proofs at scale.
 
-Note: the leaf circuit only emits verifier artifacts (`common.bin`, `verifier.bin`, `dummy_proof.bin`). [qp-wormhole-prover] always builds the leaf circuit from source, so there is no leaf `prover.bin`; `--skip-prover` only affects the batch aggregation circuits.
+Note: neither the leaf circuit nor the private-batch circuit emits a `prover.bin`. [qp-wormhole-prover] and `PrivateBatchProver` always rebuild those circuits from source, because a poisoned prover artifact could exfiltrate witness data through the proof's public-input list. `--skip-prover` therefore only affects the public-batch prover binary and the dummy private-batch proof used for public-batch padding.
 
 ## Usage
 

--- a/wormhole/circuit-builder/README.md
+++ b/wormhole/circuit-builder/README.md
@@ -6,9 +6,9 @@ CLI to generate Wormhole circuit binaries for proving and verification.
 cargo run --release -p qp-wormhole-circuit-builder -- --num-leaf-proofs <N> [--num-private-batch-proofs <M>] --output generated-bins
 ```
 
-Produces prover and verifier binaries for a given aggregation shape (number of leaf proofs and number of inner proofs for private_batch and public_batch respectively). Use the generated artifacts with the aggregator provers and [qp-wormhole-verifier] to run proofs at scale.
+Produces verifier binaries (plus the dummy proofs used for padding) for a given aggregation shape (number of leaf proofs and number of inner proofs for private_batch and public_batch respectively). Use the generated artifacts with the aggregator provers and [qp-wormhole-verifier] to run proofs at scale.
 
-Note: neither the leaf circuit nor the private-batch circuit emits a `prover.bin`. [qp-wormhole-prover] and `PrivateBatchProver` always rebuild those circuits from source, because a poisoned prover artifact could exfiltrate witness data through the proof's public-input list. `--skip-prover` therefore only affects the public-batch prover binary and the dummy private-batch proof used for public-batch padding.
+Note: no circuit emits a `prover.bin`. [qp-wormhole-prover], `PrivateBatchProver`, and `PublicBatchProver` always rebuild their circuits from source, because a poisoned prover artifact could exfiltrate witness data through the proof's public-input list. `--skip-prover` therefore only affects the dummy private-batch proof used for public-batch padding (which requires a proving run to generate).
 
 ## Usage
 

--- a/wormhole/circuit-builder/examples/public_batch_bench.rs
+++ b/wormhole/circuit-builder/examples/public_batch_bench.rs
@@ -3,7 +3,8 @@
 //! For each branching factor M (number of private-batch proofs per public batch):
 //! 1. Generates the public-batch circuit binaries (leaf + private-batch circuits are
 //!    built once and reused, since they don't depend on M).
-//! 2. Loads the prover from the serialized binaries (measures aggregator startup).
+//! 2. Loads the prover, which rebuilds the circuit from source (measures aggregator
+//!    startup).
 //! 3. Proves a public batch padded entirely with the dummy private-batch template.
 //!    Proving cost is witness-independent, so this is representative of real batches.
 //!
@@ -66,24 +67,26 @@ fn main() -> anyhow::Result<()> {
     for &m in &branching_factors {
         println!("== M = {m} ==");
 
-        // 1) Build + serialize the public-batch circuit.
+        // 1) Build + serialize the public-batch verifier artifacts.
         let build_start = Instant::now();
-        generate_public_batch_circuit_binaries(&dir, m, true)?;
+        generate_public_batch_circuit_binaries(&dir, m)?;
         let build_time = build_start.elapsed();
         CircuitBinsConfig::new(NUM_LEAF_PROOFS, Some(m))?.save(&dir)?;
-        let prover_bin_size = file_size(&dir.join("public_batch_prover.bin"));
+        let verifier_bins_size = file_size(&dir.join("public_batch_common.bin"))
+            + file_size(&dir.join("public_batch_verifier.bin"));
         println!(
-            "  circuit build + serialize: {:.1}s (prover.bin: {:.1} MB)",
+            "  circuit build + serialize: {:.1}s (verifier bins: {:.1} KB)",
             build_time.as_secs_f64(),
-            prover_bin_size as f64 / 1e6
+            verifier_bins_size as f64 / 1e3
         );
 
-        // 2) Load the prover from binaries (aggregator startup cost).
+        // 2) Load the prover (aggregator startup cost; rebuilds the circuit
+        // from source — no prover.bin exists).
         let load_start = Instant::now();
         let prover = PublicBatchProver::new_from_binaries_dir(&dir)?;
         let load_time = load_start.elapsed();
         println!(
-            "  prover load from bins:     {:.1}s",
+            "  prover load (rebuild):     {:.1}s",
             load_time.as_secs_f64()
         );
 
@@ -113,32 +116,24 @@ fn main() -> anyhow::Result<()> {
             proof.public_inputs.len()
         );
 
-        results.push((
-            m,
-            build_time,
-            load_time,
-            prove_time,
-            proof_size,
-            prover_bin_size,
-        ));
+        results.push((m, build_time, load_time, prove_time, proof_size));
         println!();
     }
 
     println!("== Summary (N={NUM_LEAF_PROOFS} leaves/private batch, 2N outputs each) ==");
     println!(
-        "{:>5} {:>8} {:>12} {:>10} {:>10} {:>12} {:>14}",
-        "M", "outputs", "build (s)", "load (s)", "prove (s)", "proof (KB)", "prover (MB)"
+        "{:>5} {:>8} {:>12} {:>10} {:>10} {:>12}",
+        "M", "outputs", "build (s)", "load (s)", "prove (s)", "proof (KB)"
     );
-    for (m, build, load, prove, proof_size, prover_bin) in &results {
+    for (m, build, load, prove, proof_size) in &results {
         println!(
-            "{:>5} {:>8} {:>12.1} {:>10.1} {:>10.1} {:>12.1} {:>14.1}",
+            "{:>5} {:>8} {:>12.1} {:>10.1} {:>10.1} {:>12.1}",
             m,
             m * NUM_LEAF_PROOFS * 2,
             build.as_secs_f64(),
             load.as_secs_f64(),
             prove.as_secs_f64(),
             *proof_size as f64 / 1e3,
-            *prover_bin as f64 / 1e6,
         );
     }
 

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -187,10 +187,7 @@ fn create_staging_dir(output_dir: &Path) -> Result<PathBuf> {
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(e) => {
                 return Err(e).with_context(|| {
-                    format!(
-                        "failed to create staging directory {}",
-                        candidate.display()
-                    )
+                    format!("failed to create staging directory {}", candidate.display())
                 })
             }
         }

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -89,8 +89,10 @@ pub fn generate_circuit_binaries<P: AsRef<Path>>(output_dir: P) -> Result<()> {
 ///
 /// # Arguments
 /// * `output_dir` - Directory to write the binaries to
-/// * `include_prover` - Whether to include the prover binaries for the batch aggregation
-///   circuits (the leaf circuit never emits a prover binary; see [`generate_circuit_binaries`])
+/// * `include_prover` - Whether to generate the dummy private-batch proof used for
+///   public-batch padding (requires a private-batch proving run). No circuit emits a
+///   prover binary: provers always rebuild their circuits from source (see
+///   [`generate_circuit_binaries`])
 /// * `num_leaf_proofs` - Number of leaf proofs aggregated into a single proof (must be > 0)
 /// * `num_private_batch_proofs` - Optional param for number of inner proofs (for public-batch circuit). Set to none if you only want private-batch aggregation.
 ///
@@ -122,11 +124,7 @@ pub fn generate_all_circuit_binaries<P: AsRef<Path>>(
 
         // If num_private_batch_proofs is specified, generate public-batch aggregation circuit binaries
         if let Some(num_private_batch_proofs) = config.num_private_batch_proofs {
-            generate_public_batch_circuit_binaries(
-                &staging_path,
-                num_private_batch_proofs,
-                include_prover,
-            )?;
+            generate_public_batch_circuit_binaries(&staging_path, num_private_batch_proofs)?;
         }
 
         // Save config file alongside binaries. Written last: its presence marks

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -109,7 +109,7 @@ pub fn generate_all_circuit_binaries<P: AsRef<Path>>(
     let config = CircuitBinsConfig::new(num_leaf_proofs, num_private_batch_proofs)?;
 
     let output_path = output_dir.as_ref();
-    let staging_path = staging_dir_for(output_path)?;
+    let staging_path = create_staging_dir(output_path)?;
 
     let generated = (|| -> Result<()> {
         // Generate regular circuit binaries
@@ -144,16 +144,63 @@ pub fn generate_all_circuit_binaries<P: AsRef<Path>>(
     commit_staging_dir(&staging_path, output_path)
 }
 
-/// A unique staging directory on the same filesystem as `output_dir` (a
-/// sibling), so the final `rename` is atomic.
-fn staging_dir_for(output_dir: &Path) -> Result<PathBuf> {
+/// Create the private staging directory that artifact generation writes into:
+/// a sibling of `output_dir` (same filesystem, so the final `rename` is
+/// atomic), created exclusively under an unpredictable name.
+///
+/// Exclusive `create_dir` (create-new semantics) is the symlink-safety
+/// guarantee: `mkdir` refuses to follow a symlink at the final component and
+/// fails if anything already exists at the path, so a local attacker with
+/// write access to the output parent can never get a pre-planted symlink (or
+/// a directory seeded with artifact-name symlinks) adopted as the staging
+/// dir and redirect the builder's `std::fs::write` calls onto arbitrary
+/// files. The random suffix makes the path unpredictable, so a planted entry
+/// cannot even force an error, and the pid keeps stale leftovers attributable.
+fn create_staging_dir(output_dir: &Path) -> Result<PathBuf> {
     let Some(name) = output_dir.file_name().and_then(|n| n.to_str()) else {
         bail!(
             "output dir {} has no usable directory name; pass an explicit directory path",
             output_dir.display()
         );
     };
-    Ok(output_dir.with_file_name(format!(".{}.staging-{}", name, std::process::id())))
+    if let Some(parent) = output_dir.parent() {
+        if !parent.as_os_str().is_empty() {
+            create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create output parent directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+    // A few attempts are plenty: a collision requires an identical 64-bit
+    // random suffix to appear in the same parent under the same pid.
+    for _ in 0..8 {
+        let candidate = output_dir.with_file_name(format!(
+            ".{}.staging-{}-{:016x}",
+            name,
+            std::process::id(),
+            rand::random::<u64>()
+        ));
+        match fs::create_dir(&candidate) {
+            Ok(()) => return Ok(candidate),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!(
+                        "failed to create staging directory {}",
+                        candidate.display()
+                    )
+                })
+            }
+        }
+    }
+    bail!(
+        "failed to create a fresh staging directory next to {}; \
+         remove stale .{}.staging-* entries and retry",
+        output_dir.display(),
+        name
+    );
 }
 
 /// Replace `output_dir` with the fully staged `staging_dir` via directory
@@ -178,6 +225,23 @@ fn commit_staging_dir_impl(
     output_dir: &Path,
     rename: impl Fn(&Path, &Path) -> std::io::Result<()>,
 ) -> Result<()> {
+    // Never publish a staging path we did not stage as a real directory:
+    // renaming a symlink into place would hand out an artifact dir whose
+    // contents remain mutable by whoever owns the link target.
+    let staging_meta = fs::symlink_metadata(staging_dir).with_context(|| {
+        format!(
+            "failed to inspect staged artifact dir {}",
+            staging_dir.display()
+        )
+    })?;
+    if !staging_meta.is_dir() {
+        bail!(
+            "staged artifact path {} is not a plain directory (symlink or file); \
+             refusing to publish it as the artifact dir",
+            staging_dir.display()
+        );
+    }
+
     let mut old_name = staging_dir.file_name().unwrap_or_default().to_os_string();
     old_name.push(".old");
     let old_path = staging_dir.with_file_name(old_name);
@@ -273,12 +337,12 @@ mod tests {
     fn commit_replaces_existing_output_dir_wholesale() {
         let root = unique_tmp_dir("commit-replace");
         let _ = fs::remove_dir_all(&root);
+        create_dir_all(&root).unwrap();
         let output = root.join("bins");
-        let staging = staging_dir_for(&output).unwrap();
+        let staging = create_staging_dir(&output).unwrap();
 
         create_dir_all(&output).unwrap();
         write(output.join("stale.bin"), b"old artifact").unwrap();
-        create_dir_all(&staging).unwrap();
         write(staging.join("fresh.bin"), b"new artifact").unwrap();
 
         commit_staging_dir(&staging, &output).unwrap();
@@ -299,9 +363,8 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
         create_dir_all(&root).unwrap();
         let output = root.join("bins");
-        let staging = staging_dir_for(&output).unwrap();
+        let staging = create_staging_dir(&output).unwrap();
 
-        create_dir_all(&staging).unwrap();
         write(staging.join("fresh.bin"), b"new artifact").unwrap();
 
         commit_staging_dir(&staging, &output).unwrap();
@@ -311,21 +374,105 @@ mod tests {
         fs::remove_dir_all(&root).unwrap();
     }
 
+    /// Staging paths must be minted fresh on every call (exclusive creation
+    /// under an unpredictable name), never re-derived from the pid alone: a
+    /// predictable path is what lets a local attacker pre-create it.
     #[test]
-    fn staging_dir_is_a_sibling_of_the_output_dir() {
-        let staging = staging_dir_for(Path::new("/some/where/bins")).unwrap();
-        assert_eq!(staging.parent(), Some(Path::new("/some/where")));
-        assert!(staging
-            .file_name()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .starts_with(".bins.staging-"));
+    fn create_staging_dir_mints_a_fresh_unique_directory_per_call() {
+        let root = unique_tmp_dir("staging-fresh");
+        let _ = fs::remove_dir_all(&root);
+        create_dir_all(&root).unwrap();
+        let output = root.join("bins");
+
+        let a = create_staging_dir(&output).unwrap();
+        let b = create_staging_dir(&output).unwrap();
+        assert_ne!(
+            a, b,
+            "staging paths must be unique per call, not a pid-only derivation"
+        );
+        for dir in [&a, &b] {
+            let meta = fs::symlink_metadata(dir).unwrap();
+            assert!(
+                meta.is_dir() && !meta.file_type().is_symlink(),
+                "staging path must be a freshly created real directory"
+            );
+            assert_eq!(
+                dir.parent(),
+                Some(root.as_path()),
+                "staging dir must stay a sibling of the output dir"
+            );
+            assert!(dir
+                .file_name()
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .starts_with(".bins.staging-"));
+        }
+
+        fs::remove_dir_all(&root).unwrap();
     }
 
-    /// A failed generation must not disturb pre-existing output contents.
-    /// Uses an invalid proof count to trip the earliest failure path, and a
-    /// crafted failure later via a file blocking the staging path.
+    /// A local attacker with write access to the output parent plants a
+    /// symlink at the predictable staging path. The builder must not adopt it:
+    /// artifact writes would land in attacker-controlled storage.
+    #[cfg(unix)]
+    #[test]
+    fn create_staging_dir_does_not_adopt_a_planted_symlink() {
+        let root = unique_tmp_dir("staging-symlink");
+        let _ = fs::remove_dir_all(&root);
+        create_dir_all(&root).unwrap();
+        let output = root.join("bins");
+        let attacker_target = root.join("attacker-target");
+        create_dir_all(&attacker_target).unwrap();
+
+        // The historical (predictable) staging name: .<name>.staging-<pid>.
+        let planted = output.with_file_name(format!(".bins.staging-{}", std::process::id()));
+        std::os::unix::fs::symlink(&attacker_target, &planted).unwrap();
+
+        let staging = create_staging_dir(&output).unwrap();
+        let meta = fs::symlink_metadata(&staging).unwrap();
+        assert!(
+            meta.is_dir() && !meta.file_type().is_symlink(),
+            "staging dir must be a freshly created real directory, not the planted symlink"
+        );
+        write(staging.join("probe.bin"), b"artifact").unwrap();
+        assert!(
+            !attacker_target.join("probe.bin").exists(),
+            "artifact writes must not land in attacker-controlled storage"
+        );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// The commit phase must refuse to publish a staging path that is not a
+    /// plain directory: renaming a symlink into place would hand out an
+    /// artifact dir whose contents remain attacker-mutable.
+    #[cfg(unix)]
+    #[test]
+    fn commit_refuses_to_publish_a_symlinked_staging_dir() {
+        let root = unique_tmp_dir("commit-symlink");
+        let _ = fs::remove_dir_all(&root);
+        create_dir_all(&root).unwrap();
+        let output = root.join("bins");
+        let attacker_target = root.join("attacker-target");
+        create_dir_all(&attacker_target).unwrap();
+        write(attacker_target.join("fresh.bin"), b"attacker mutable").unwrap();
+        let staging = root.join(".bins.staging-evil");
+        std::os::unix::fs::symlink(&attacker_target, &staging).unwrap();
+
+        let err = commit_staging_dir(&staging, &output).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("not a plain directory"),
+            "got: {err:#}"
+        );
+        assert!(
+            fs::symlink_metadata(&output).is_err(),
+            "a symlinked staging path must never be published as the artifact dir"
+        );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
     fn io_fail() -> std::io::Error {
         std::io::Error::other("injected rename failure")
     }
@@ -338,10 +485,9 @@ mod tests {
         let root = unique_tmp_dir("swap-rollback");
         let _ = fs::remove_dir_all(&root);
         let output = root.join("bins");
-        let staging = staging_dir_for(&output).unwrap();
+        let staging = create_staging_dir(&output).unwrap();
         create_dir_all(&output).unwrap();
         write(output.join("previous.bin"), b"previous").unwrap();
-        create_dir_all(&staging).unwrap();
         write(staging.join("fresh.bin"), b"fresh").unwrap();
 
         // Fail only the staging -> output rename; move-aside and rollback work.
@@ -372,10 +518,9 @@ mod tests {
         let root = unique_tmp_dir("swap-rollback-fail");
         let _ = fs::remove_dir_all(&root);
         let output = root.join("bins");
-        let staging = staging_dir_for(&output).unwrap();
+        let staging = create_staging_dir(&output).unwrap();
         create_dir_all(&output).unwrap();
         write(output.join("previous.bin"), b"previous").unwrap();
-        create_dir_all(&staging).unwrap();
         write(staging.join("fresh.bin"), b"fresh").unwrap();
 
         // Fail every rename INTO output_dir: the swap-in and the rollback.
@@ -416,8 +561,7 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
         create_dir_all(&root).unwrap();
         let output = root.join("bins");
-        let staging = staging_dir_for(&output).unwrap();
-        create_dir_all(&staging).unwrap();
+        let staging = create_staging_dir(&output).unwrap();
         write(staging.join("fresh.bin"), b"fresh").unwrap();
 
         let err = commit_staging_dir_impl(&staging, &output, |_, _| Err(io_fail())).unwrap_err();
@@ -438,10 +582,9 @@ mod tests {
         let root = unique_tmp_dir("swap-aside-fail");
         let _ = fs::remove_dir_all(&root);
         let output = root.join("bins");
-        let staging = staging_dir_for(&output).unwrap();
+        let staging = create_staging_dir(&output).unwrap();
         create_dir_all(&output).unwrap();
         write(output.join("previous.bin"), b"previous").unwrap();
-        create_dir_all(&staging).unwrap();
         write(staging.join("fresh.bin"), b"fresh").unwrap();
 
         let output_src = output.clone();
@@ -461,6 +604,7 @@ mod tests {
         fs::remove_dir_all(&root).unwrap();
     }
 
+    /// A failed generation must not disturb pre-existing output contents.
     #[test]
     fn failed_generation_leaves_existing_output_untouched() {
         let root = unique_tmp_dir("gen-fail");
@@ -473,12 +617,38 @@ mod tests {
         assert!(generate_all_circuit_binaries(&output, false, 0, None).is_err());
         assert!(output.join("existing.bin").exists());
 
-        // Block staging-dir creation with a plain file at the staging path:
-        // generation fails mid-stage, output must still be untouched and the
-        // blocking file (not a dir) must not be swapped in.
-        let staging = staging_dir_for(&output).unwrap();
-        write(&staging, b"not a directory").unwrap();
-        assert!(generate_all_circuit_binaries(&output, false, 1, None).is_err());
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// If the staging directory cannot be created at all, generation must fail
+    /// before any circuit work begins and leave existing output untouched.
+    #[cfg(unix)]
+    #[test]
+    fn unwritable_parent_fails_before_building_and_leaves_output_untouched() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = unique_tmp_dir("gen-parent-ro");
+        let _ = fs::remove_dir_all(&root);
+        let output = root.join("bins");
+        create_dir_all(&output).unwrap();
+        write(output.join("existing.bin"), b"keep me").unwrap();
+
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o555)).unwrap();
+        // Running as root bypasses permission bits; nothing to exercise then.
+        if fs::create_dir(root.join(".probe")).is_ok() {
+            fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).unwrap();
+            fs::remove_dir_all(&root).unwrap();
+            return;
+        }
+
+        let result = generate_all_circuit_binaries(&output, false, 1, None);
+        fs::set_permissions(&root, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let err = result.unwrap_err();
+        assert!(
+            format!("{err:#}").contains("staging directory"),
+            "got: {err:#}"
+        );
         assert!(output.join("existing.bin").exists());
         assert!(!output.join("common.bin").exists());
 

--- a/wormhole/circuit-builder/src/main.rs
+++ b/wormhole/circuit-builder/src/main.rs
@@ -26,12 +26,15 @@ struct Args {
     output: String,
 
     /// Number of leaf proofs aggregated into a single private-batch proof (must be 1-64)
-    #[arg(short, long, value_parser = parse_proof_count)]
+    // Long-form only: a bare `short` on the two proof-count fields would infer
+    // `-n` for both, which clap rejects (panics in debug builds, and silently
+    // binds `-n` to the first-declared field in release builds).
+    #[arg(long, value_parser = parse_proof_count)]
     num_leaf_proofs: usize,
 
     /// Number of inner private-batch proofs aggregated into a single public-batch proof (must be 1-64 if specified)
     /// Omit this flag to only generate private-batch artifacts.
-    #[arg(short, long, value_parser = parse_proof_count)]
+    #[arg(long, value_parser = parse_proof_count)]
     num_private_batch_proofs: Option<usize>,
 
     /// Skip prover binary generation for the batch aggregation circuits (only generate
@@ -60,4 +63,20 @@ fn main() -> Result<()> {
         args.num_leaf_proofs,
         args.num_private_batch_proofs,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// clap only checks the argument definition via debug assertions inside
+    /// `Command::build()`; a duplicate short flag (e.g. two fields inferring
+    /// `-n`) panics every debug-build invocation and silently resolves to the
+    /// first-declared field in release builds. Run those assertions as a test
+    /// so an invalid CLI definition fails CI instead of operators.
+    #[test]
+    fn cli_definition_is_valid() {
+        use clap::CommandFactory;
+        Args::command().debug_assert();
+    }
 }

--- a/wormhole/circuit/src/block_header/header.rs
+++ b/wormhole/circuit/src/block_header/header.rs
@@ -75,7 +75,6 @@ impl HeaderTargets {
     }
 }
 
-#[derive(Debug)]
 pub struct HeaderInputs {
     /// parent_hash uses 4 felts (8 bytes/felt) for hash outputs
     pub parent_hash: Digest,
@@ -87,6 +86,25 @@ pub struct HeaderInputs {
     /// zk_tree_root uses 4 felts (8 bytes/felt) for hash outputs
     pub zk_tree_root: Digest,
     pub digest: [F; DIGEST_LOGS_FELTS],
+}
+
+/// Redacting `Debug`: `digest` is the felt-encoded copy of the private
+/// `PrivateCircuitInputs::digest` witness field (merkle-path material that
+/// identifies the leaf's block-header preimage), so it must stay redacted
+/// here too. The remaining header fields are public chain data fully
+/// determined by the proof's public `block_hash` and stay visible for
+/// debugging header hash mismatches.
+impl core::fmt::Debug for HeaderInputs {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HeaderInputs")
+            .field("parent_hash", &self.parent_hash)
+            .field("block_number", &self.block_number)
+            .field("state_root", &self.state_root)
+            .field("extrinsics_root", &self.extrinsics_root)
+            .field("zk_tree_root", &self.zk_tree_root)
+            .field("digest", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl HeaderInputs {
@@ -135,5 +153,43 @@ impl TryFrom<&CircuitInputs> for HeaderInputs {
             inputs.private.zk_tree_root.try_into()?,
             &inputs.private.digest,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use plonky2::field::types::PrimeField64;
+
+    /// `PrivateCircuitInputs` redacts `digest` as private witness material
+    /// (it identifies the leaf's block-header preimage), so the felt-encoded
+    /// copy held by `HeaderInputs` must not become printable again.
+    #[test]
+    fn header_inputs_debug_redacts_digest() {
+        let digest = [0xEE_u8; DIGEST_LOGS_SIZE];
+        let header = HeaderInputs::new(
+            BytesDigest::default(),
+            1,
+            BytesDigest::default(),
+            BytesDigest::default(),
+            BytesDigest::default(),
+            &digest,
+        )
+        .unwrap();
+
+        let dump = alloc::format!("{:?}", header);
+        for felt in header.digest.iter() {
+            let value = felt.to_canonical_u64();
+            // Skip tiny felts (e.g. terminator chunks) that could collide with
+            // unrelated small numbers in the output.
+            if value > 0xFFFF {
+                let needle = alloc::format!("{}", value);
+                assert!(
+                    !dump.contains(&needle),
+                    "digest felt {} leaked in Debug output",
+                    needle
+                );
+            }
+        }
     }
 }

--- a/wormhole/circuit/src/block_header/mod.rs
+++ b/wormhole/circuit/src/block_header/mod.rs
@@ -146,3 +146,40 @@ impl CircuitFragment for BlockHeader {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_header::header::DIGEST_LOGS_SIZE;
+    use plonky2::field::types::PrimeField64;
+
+    /// `BlockHeader` wraps `HeaderInputs`, so its Debug output must inherit
+    /// the redaction of the private `digest` witness field.
+    #[test]
+    fn block_header_debug_redacts_digest() {
+        let digest = [0xEE_u8; DIGEST_LOGS_SIZE];
+        let header = HeaderInputs::new(
+            BytesDigest::default(),
+            1,
+            BytesDigest::default(),
+            BytesDigest::default(),
+            BytesDigest::default(),
+            &digest,
+        )
+        .unwrap();
+        let block_header = BlockHeader::new(BytesDigest::default(), header).unwrap();
+
+        let dump = alloc::format!("{:?}", block_header);
+        for felt in block_header.header.digest.iter() {
+            let value = felt.to_canonical_u64();
+            if value > 0xFFFF {
+                let needle = alloc::format!("{}", value);
+                assert!(
+                    !dump.contains(&needle),
+                    "digest felt {} leaked in Debug output",
+                    needle
+                );
+            }
+        }
+    }
+}

--- a/wormhole/circuit/src/circuit.rs
+++ b/wormhole/circuit/src/circuit.rs
@@ -1,32 +1,19 @@
 //! Wormhole Circuit.
 //!
 //! This module defines the zero-knowledge circuit for the Wormhole protocol.
-use alloc::vec::Vec;
-use plonky2::{
-    plonk::circuit_data::CircuitData,
-    util::serialization::{DefaultGateSerializer, DefaultGeneratorSerializer},
-};
-use zk_circuits_common::circuit::{C, D, F};
-
-pub fn circuit_data_to_bytes(
-    data: &CircuitData<F, C, D>,
-) -> Result<Vec<u8>, plonky2::util::serialization::IoError> {
-    let gate_serializer = DefaultGateSerializer;
-    let generator_serializer = DefaultGeneratorSerializer::<C, D> {
-        _phantom: Default::default(),
-    };
-    data.to_bytes(&gate_serializer, &generator_serializer)
-}
-
-pub fn circuit_data_from_bytes(
-    bytes: &[u8],
-) -> Result<CircuitData<F, C, D>, plonky2::util::serialization::IoError> {
-    let gate_serializer = DefaultGateSerializer;
-    let generator_serializer = DefaultGeneratorSerializer::<C, D> {
-        _phantom: Default::default(),
-    };
-    CircuitData::from_bytes(bytes, &gate_serializer, &generator_serializer)
-}
+//!
+//! Note: this crate deliberately provides no (de)serializer for the full leaf
+//! [`CircuitData`](plonky2::plonk::circuit_data::CircuitData). A full
+//! `CircuitData` carries the prover-only data — the witness generators and the
+//! target list that decides which witness values become `public_inputs` — so a
+//! poisoned serialized artifact could exfiltrate private witness material (e.g.
+//! the Wormhole `secret`) through a proof's `public_inputs`, or silently
+//! substitute a circuit with weaker constraints. The leaf circuit builds from
+//! source in ~40 ms (release), which is about the same cost as validating and
+//! deserializing an artifact, so serialized full-circuit artifacts are never
+//! needed: always construct [`circuit_logic::WormholeCircuit`] directly.
+//! Verifier-side artifacts are loaded through the pinned, fail-closed loader in
+//! `qp-wormhole-verifier` instead.
 
 #[cfg(feature = "std")]
 pub mod circuit_logic {

--- a/wormhole/circuit/src/unspendable_account.rs
+++ b/wormhole/circuit/src/unspendable_account.rs
@@ -32,10 +32,14 @@ pub struct UnspendableAccount {
     pub secret: Secret,
 }
 
+/// Redacting `Debug`: `secret` is the spend credential, and `account_id` is
+/// the unspendable deposit account — the direct deposit/withdrawal link that
+/// `PrivateCircuitInputs` redacts as `unspendable_account`. Neither may reach
+/// logs, error contexts, or telemetry via `{:?}`.
 impl core::fmt::Debug for UnspendableAccount {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("UnspendableAccount")
-            .field("account_id", &self.account_id)
+            .field("account_id", &"[REDACTED]")
             .field("secret", &"[REDACTED]")
             .finish()
     }
@@ -224,3 +228,25 @@ impl CircuitFragment for UnspendableAccount {
 // reached for `UnspendableAccount::default()` created an account anyone could
 // drain. Constructing an account must always require an explicit secret
 // (`from_secret`) or an explicit (account_id, secret) pair (`new`).
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The account id is the unspendable deposit account, which
+    /// `PrivateCircuitInputs` redacts as the direct deposit/withdrawal link.
+    /// The secret is the spend credential. Neither may appear in Debug output.
+    #[test]
+    fn unspendable_account_debug_redacts_account_id_and_secret() {
+        let account = UnspendableAccount::new(
+            BytesDigest::try_from([0xCD; 32].as_slice()).unwrap(),
+            BytesDigest::try_from([0xAB; 32].as_slice()).unwrap(),
+        );
+        let dump = alloc::format!("{:?}", account);
+        assert!(dump.contains("[REDACTED]"));
+        // account_id felts: each 8-byte chunk of [0xCD; 32].
+        assert!(!dump.contains("14829735431805717965"));
+        // secret felts: each 8-byte chunk of [0xAB; 32].
+        assert!(!dump.contains("12370169555311111083"));
+    }
+}

--- a/wormhole/circuit/src/zk_merkle_proof.rs
+++ b/wormhole/circuit/src/zk_merkle_proof.rs
@@ -182,7 +182,7 @@ impl ZkMerkleProofTargets {
 // ============================================================================
 
 /// Leaf data for the ZK Merkle proof.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ZkLeafData {
     /// Recipient account (32 bytes)
     pub to_account: [F; HASH_NUM_FELTS],
@@ -198,6 +198,25 @@ pub struct ZkLeafData {
     pub output_amount_2: F,
     /// Volume fee in bps
     pub volume_fee_bps: F,
+}
+
+/// Redacting `Debug`: `to_account` (the unspendable deposit account — the
+/// direct deposit/withdrawal link), `transfer_count`, and `input_amount` are
+/// felt-encoded copies of fields redacted on `PrivateCircuitInputs`.
+/// `asset_id`, the output amounts, and `volume_fee_bps` are public inputs and
+/// stay visible.
+impl core::fmt::Debug for ZkLeafData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ZkLeafData")
+            .field("to_account", &"[REDACTED]")
+            .field("transfer_count", &"[REDACTED]")
+            .field("asset_id", &self.asset_id)
+            .field("input_amount", &"[REDACTED]")
+            .field("output_amount_1", &self.output_amount_1)
+            .field("output_amount_2", &self.output_amount_2)
+            .field("volume_fee_bps", &self.volume_fee_bps)
+            .finish()
+    }
 }
 
 impl ZkLeafData {
@@ -237,7 +256,7 @@ impl ZkLeafData {
 }
 
 /// Runtime data for ZK Merkle proof verification.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ZkMerkleProofData {
     /// Root hash (32 bytes as 4 felts)
     pub root_hash: [F; HASH_NUM_FELTS],
@@ -251,6 +270,24 @@ pub struct ZkMerkleProofData {
     pub leaf: ZkLeafData,
     /// Whether this is a real proof (not dummy)
     pub is_not_dummy: bool,
+}
+
+/// Redacting `Debug`: `siblings` and `positions` are the merkle-path witness
+/// (they identify the deposit leaf and are redacted on
+/// `PrivateCircuitInputs`); `leaf` uses `ZkLeafData`'s own redacted `Debug`.
+/// `root_hash` (the public zk_tree_root), `depth`, and `is_not_dummy` stay
+/// visible for debugging.
+impl core::fmt::Debug for ZkMerkleProofData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ZkMerkleProofData")
+            .field("root_hash", &self.root_hash)
+            .field("depth", &self.depth)
+            .field("siblings", &"[REDACTED]")
+            .field("positions", &"[REDACTED]")
+            .field("leaf", &self.leaf)
+            .field("is_not_dummy", &self.is_not_dummy)
+            .finish()
+    }
 }
 
 impl ZkMerkleProofData {
@@ -615,5 +652,52 @@ impl CircuitFragment for ZkMerkleProofData {
         pw.set_target(targets.leaf.volume_fee_bps, self.leaf.volume_fee_bps)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    /// The leaf data copies `unspendable_account` (as `to_account`),
+    /// `transfer_count`, and `input_amount` out of the private circuit
+    /// inputs; all three are redacted on `PrivateCircuitInputs` because they
+    /// identify the deposit. They must stay redacted here.
+    #[test]
+    fn zk_leaf_data_debug_redacts_private_fields() {
+        let leaf = ZkLeafData::new(
+            [0xCD; 32],
+            0x0BAD_CAFE_DEAD_BEEF,
+            7,
+            313_131_313,
+            50,
+            49,
+            10,
+        );
+        let dump = alloc::format!("{:?}", leaf);
+        // to_account felts: each 8-byte chunk of [0xCD; 32].
+        assert!(!dump.contains("14829735431805717965"));
+        // transfer_count limbs (high, low).
+        assert!(!dump.contains("195906302"));
+        assert!(!dump.contains("3735928559"));
+        // input_amount (pre-fee deposit amount).
+        assert!(!dump.contains("313131313"));
+    }
+
+    /// Sibling hashes and position hints identify the leaf's location in the
+    /// ZK tree (the deposit/withdrawal link); `PrivateCircuitInputs` redacts
+    /// them, so the felt-encoded copies here must not be printable.
+    #[test]
+    fn zk_merkle_proof_data_debug_redacts_path_material() {
+        let leaf = ZkLeafData::new([0xCD; 32], 1, 0, 100, 50, 49, 10);
+        let siblings = vec![[[0xAB; 32]; SIBLINGS_PER_LEVEL]];
+        let proof_data = ZkMerkleProofData::new([0x11; 32], siblings, vec![2], leaf, true);
+
+        let dump = alloc::format!("{:?}", proof_data);
+        // Sibling hash felts: each 8-byte chunk of [0xAB; 32].
+        assert!(!dump.contains("12370169555311111083"));
+        // Position hints must not be printed as a list.
+        assert!(!dump.contains("positions: ["));
     }
 }

--- a/wormhole/memprof/README.md
+++ b/wormhole/memprof/README.md
@@ -86,6 +86,10 @@ top of the production `wormhole_private_batch_circuit_config()` (currently
 RowBlinding ZK, `num_wires=135`, `num_routed_wires=60`). Run
 `cargo run -p wormhole-memprof --release -- --help` for the full list. Safe
 (non-security-affecting) knobs include `--zk-mode {polyfri,rowblinding}`,
-`--rate-bits` (auto-rebalances `num_query_rounds`), `--num-wires`,
-`--num-routed-wires`, and `--max-quotient-degree-factor`. Anything that lowers
-soundness or removes ZK is gated behind `--allow-weakening-security`.
+`--rate-bits` (auto-rebalances `num_query_rounds`), `--num-wires` (>= 135),
+`--num-routed-wires` (>= 37, <= num_wires), and
+`--max-quotient-degree-factor` (>= 7). Values below the documented structural
+floors are rejected at the CLI: they cannot express the recursion stack's
+gates, so profiling them would label broken circuit shapes as viable. Anything
+that lowers soundness or removes ZK is gated behind
+`--allow-weakening-security`.

--- a/wormhole/memprof/src/config.rs
+++ b/wormhole/memprof/src/config.rs
@@ -74,8 +74,9 @@ pub struct AggConfigArgs {
     #[arg(long)]
     pub num_wires: Option<usize>,
 
-    /// Number of routed wires. Must be <= num_wires (routed wires are a
-    /// prefix of the wire columns). Production: 60.
+    /// Number of routed wires. Must be >= 37 (recursion gate floor) and
+    /// <= num_wires (routed wires are a prefix of the wire columns).
+    /// Production: 60.
     #[arg(long)]
     pub num_routed_wires: Option<usize>,
 
@@ -118,15 +119,34 @@ const MIN_NUM_WIRES: usize = 135;
 /// cannot express them and fails during circuit construction.
 const MIN_MAX_QUOTIENT_DEGREE_FACTOR: usize = 7;
 
+/// Structural routed-wire floor for the pinned plonky2 recursion stack.
+///
+/// Gates pack operations into the routed-wire prefix, and several derive
+/// their op count from `num_routed_wires`: base arithmetic uses 4 routed
+/// wires per op, extension arithmetic `4*D = 8`, and the FRI verifier's
+/// random-access gate `2 + 2^4 = 18` per copy (arity/cap lists are 16
+/// entries under the production `ConstantArityBits(4, 5)` / `cap_height=4`
+/// FRI shape). Below a gate's width it instantiates with ZERO operation
+/// slots: `find_slot`'s `num_ops - 1` underflows (debug panic; in release an
+/// under-constraining zero-op gate is added and the build only dies later on
+/// a routability assert). The binding floor is the 16-point
+/// coset-interpolation gate, which routes `1 + 16*D + D + D = 37` wires
+/// outright; plonky2's own `check_recursion_config` assert for it fires only
+/// mid-build, after the expensive leaf context already exists. Reject all of
+/// these at the CLI boundary — none is a sound or profitable circuit shape,
+/// so none should ever be profiled as a safe memory-saving configuration.
+const MIN_NUM_ROUTED_WIRES: usize = 37;
+
 impl AggConfigArgs {
     /// Validate the override knobs:
     ///   1. Numeric knobs must be > 0 (zero would silently break the
     ///      FRI soundness product or trip a panic deep inside plonky2).
     ///   2. Structural circuit floors documented on the flags
     ///      (`num_wires >= 135`, `max_quotient_degree_factor >= 7`,
-    ///      `num_routed_wires <= num_wires`) are enforced here so bad
+    ///      `37 <= num_routed_wires <= num_wires`) are enforced here so bad
     ///      sweeps fail at the CLI boundary instead of panicking after the
-    ///      leaf context is already built.
+    ///      leaf context is already built (or, worse, instantiating
+    ///      zero-op-slot gates — see [`MIN_NUM_ROUTED_WIRES`]).
     ///   3. Security-affecting knobs must be gated by
     ///      `--allow-weakening-security`.
     pub fn validate(&self) -> Result<(), String> {
@@ -164,6 +184,13 @@ impl AggConfigArgs {
             }
         }
         if let Some(routed) = self.num_routed_wires {
+            if routed < MIN_NUM_ROUTED_WIRES {
+                return Err(format!(
+                    "--num-routed-wires must be >= {MIN_NUM_ROUTED_WIRES} (recursion gate floor: \
+                     the FRI coset-interpolation gate routes 37 wires, and narrower widths leave \
+                     slot-packed gates with zero operation slots), got {routed}"
+                ));
+            }
             let effective_num_wires = self
                 .num_wires
                 .unwrap_or_else(|| wormhole_private_batch_circuit_config().num_wires);
@@ -335,6 +362,29 @@ mod tests {
             .validate()
             .unwrap_err();
         assert!(err.contains(">= 7"), "got: {err}");
+    }
+
+    /// The pinned plonky2 recursion stack packs operations into routed wires:
+    /// base arithmetic gates use 4 per op, extension arithmetic 4*D=8, FRI
+    /// random-access 18 per copy, and the 16-point coset-interpolation gate
+    /// routes 37 wires outright. Below a gate's width it instantiates with
+    /// ZERO operation slots (slot-index underflow / under-constrained gate
+    /// shape) or trips asserts only after the expensive leaf context is
+    /// already built. A knob documented as safe must reject such values at
+    /// the CLI boundary instead of profiling them as viable configurations.
+    #[test]
+    fn routed_wires_below_recursion_gate_floor_are_rejected() {
+        for routed in [1, 2, 3, 4, 17, 36] {
+            let err = args_with(|a| a.num_routed_wires = Some(routed))
+                .validate()
+                .expect_err(&format!(
+                    "--num-routed-wires {routed} cannot express the recursion \
+                     stack's gates and must be rejected"
+                ));
+            assert!(err.contains(">= 37"), "got: {err}");
+        }
+        // The floor itself passes CLI validation (build may still fail loudly).
+        args_with(|a| a.num_routed_wires = Some(37)).validate().unwrap();
     }
 
     #[test]

--- a/wormhole/memprof/src/config.rs
+++ b/wormhole/memprof/src/config.rs
@@ -384,7 +384,9 @@ mod tests {
             assert!(err.contains(">= 37"), "got: {err}");
         }
         // The floor itself passes CLI validation (build may still fail loudly).
-        args_with(|a| a.num_routed_wires = Some(37)).validate().unwrap();
+        args_with(|a| a.num_routed_wires = Some(37))
+            .validate()
+            .unwrap();
     }
 
     #[test]

--- a/wormhole/memprof/src/main.rs
+++ b/wormhole/memprof/src/main.rs
@@ -45,7 +45,9 @@ struct Args {
 
     /// Limit the rayon thread pool. `1` = single-threaded; `0` = system
     /// default. Useful for comparing parallel vs serial allocation patterns.
-    #[arg(long, default_value_t = 0)]
+    /// Capped at the host's available parallelism: this flag only ever
+    /// shrinks the pool, never grows it.
+    #[arg(long, default_value_t = 0, value_parser = parse_rayon_threads)]
     rayon_threads: usize,
 
     /// Skip leaf-proof generation entirely (use cloned dummy proof). Isolates
@@ -72,6 +74,32 @@ struct Args {
 
     #[command(flatten)]
     agg_cfg: AggConfigArgs,
+}
+
+/// Upper bound for `--rayon-threads`: the host's available parallelism.
+fn max_rayon_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+/// Value parser for `--rayon-threads`. The flag exists to LIMIT the rayon
+/// pool below the system default; a value above the host's available
+/// parallelism has no profiling use and would only force the process to
+/// spawn that many OS threads (`build_global` creates them eagerly), so it
+/// is rejected before any thread-pool setup or circuit work.
+fn parse_rayon_threads(s: &str) -> Result<usize, String> {
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("'{s}' is not a valid number"))?;
+    let max = max_rayon_threads();
+    if n > max {
+        return Err(format!(
+            "value must be at most the host's available parallelism ({max}); \
+             use 0 for the system default"
+        ));
+    }
+    Ok(n)
 }
 
 fn validate_workload_counts(num_leaf_proofs: usize, real_proofs: usize) -> Result<()> {
@@ -104,6 +132,13 @@ fn main() -> Result<()> {
     print_config_summary("leaf", &leaf_cfg);
     print_config_summary("agg", &agg_cfg);
 
+    let num_leaf_proofs = args.num_leaf_proofs;
+    let real_proofs = args.real_proofs.unwrap_or(num_leaf_proofs);
+    // Bound the circuit dimension before construction while permitting an
+    // all-dummy profiling run (`real_proofs == 0`). Validated before the
+    // thread-pool setup so a rejected workload never spawns worker threads.
+    validate_workload_counts(num_leaf_proofs, real_proofs)?;
+
     if args.rayon_threads > 0 {
         eprintln!("Configuring rayon with {} threads", args.rayon_threads);
         rayon::ThreadPoolBuilder::new()
@@ -116,12 +151,6 @@ fn main() -> Result<()> {
                 )
             })?;
     }
-
-    let num_leaf_proofs = args.num_leaf_proofs;
-    let real_proofs = args.real_proofs.unwrap_or(num_leaf_proofs);
-    // Bound the circuit dimension before construction while permitting an
-    // all-dummy profiling run (`real_proofs == 0`).
-    validate_workload_counts(num_leaf_proofs, real_proofs)?;
 
     let mut report = PhaseReport::new(args.sample_period_ms)?;
 
@@ -168,7 +197,38 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_workload_counts;
+    use super::{validate_workload_counts, Args};
+    use clap::Parser;
+
+    /// `--rayon-threads` exists to LIMIT the pool; values beyond the host's
+    /// available parallelism have no legitimate use and only serve to exhaust
+    /// OS threads, so they must be rejected at argument-parse time.
+    #[test]
+    fn rayon_threads_beyond_available_parallelism_is_rejected_at_parse_time() {
+        let err = Args::try_parse_from(["wormhole-memprof", "--rayon-threads", "1000000"]);
+        assert!(
+            err.is_err(),
+            "an absurd --rayon-threads value must be rejected before any thread creation"
+        );
+
+        let max = super::max_rayon_threads();
+        let just_over = (max + 1).to_string();
+        assert!(
+            Args::try_parse_from(["wormhole-memprof", "--rayon-threads", &just_over]).is_err(),
+            "values above available parallelism ({max}) must be rejected"
+        );
+    }
+
+    #[test]
+    fn rayon_threads_within_capacity_is_accepted() {
+        let max = super::max_rayon_threads().to_string();
+        for value in ["0", "1", &max] {
+            assert!(
+                Args::try_parse_from(["wormhole-memprof", "--rayon-threads", value]).is_ok(),
+                "--rayon-threads {value} must be accepted"
+            );
+        }
+    }
 
     #[test]
     fn zero_real_proofs_is_valid_for_all_dummy_profile() {

--- a/wormhole/prover/src/lib.rs
+++ b/wormhole/prover/src/lib.rs
@@ -95,11 +95,25 @@ use wormhole_circuit::{
     unspendable_account::UnspendableAccount, zk_merkle_proof::ZkMerkleProofData,
 };
 
-#[derive(Debug)]
 pub struct WormholeProver {
     pub circuit_data: ProverCircuitData<F, C, D>,
     partial_witness: PartialWitness<F>,
     targets: Option<CircuitTargets>,
+}
+
+/// Redacting `Debug`: after [`WormholeProver::commit`], `partial_witness`
+/// holds every private witness value — including the raw spend secret written
+/// by `Nullifier::fill_targets` — so it must never reach logs, error
+/// contexts, or telemetry via `{:?}`. `circuit_data` is public circuit
+/// structure but far too large to print usefully.
+impl core::fmt::Debug for WormholeProver {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WormholeProver")
+            .field("circuit_data", &"[ProverCircuitData]")
+            .field("partial_witness", &"[REDACTED]")
+            .field("committed", &self.targets.is_none())
+            .finish()
+    }
 }
 
 /// Builds a fresh [`WormholeProver`] with the default leaf circuit configuration (non-ZK).
@@ -196,4 +210,56 @@ pub fn fill_witness(
     block_header.fill_targets(pw, targets.block_header.clone())?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wormhole_circuit::inputs::{PrivateCircuitInputs, PublicCircuitInputs};
+
+    /// After `commit`, the `PartialWitness` holds every private witness value,
+    /// including the raw spend secret written by `Nullifier::fill_targets`.
+    /// Formatting a committed prover with `{:?}` must not expose any of it.
+    #[test]
+    fn committed_prover_debug_does_not_leak_private_witness() {
+        let inputs = CircuitInputs {
+            private: PrivateCircuitInputs {
+                secret: [0xAB; 32].try_into().unwrap(),
+                transfer_count: 0,
+                unspendable_account: [0xCD; 32].try_into().unwrap(),
+                parent_hash: [5u8; 32].try_into().unwrap(),
+                state_root: [3u8; 32].try_into().unwrap(),
+                extrinsics_root: [4u8; 32].try_into().unwrap(),
+                digest: [0xEE; 110],
+                input_amount: 1000,
+                zk_tree_root: [0u8; 32],
+                zk_merkle_siblings: vec![],
+                zk_merkle_positions: vec![],
+            },
+            public: PublicCircuitInputs {
+                asset_id: 0,
+                output_amount_1: 900,
+                output_amount_2: 99,
+                volume_fee_bps: 10,
+                nullifier: [1u8; 32].try_into().unwrap(),
+                block_hash: [0u8; 32].try_into().unwrap(),
+                exit_account_1: [2u8; 32].try_into().unwrap(),
+                exit_account_2: [3u8; 32].try_into().unwrap(),
+                block_number: 1,
+            },
+        };
+
+        let prover = build_fresh().commit(&inputs).unwrap();
+        let dump = format!("{:?}", prover);
+        // Spend secret felts: each 8-byte chunk of [0xAB; 32].
+        assert!(
+            !dump.contains("12370169555311111083"),
+            "raw secret leaked from committed prover Debug output"
+        );
+        // Unspendable (deposit) account felts: each 8-byte chunk of [0xCD; 32].
+        assert!(
+            !dump.contains("14829735431805717965"),
+            "deposit account leaked from committed prover Debug output"
+        );
+    }
 }

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -383,7 +383,11 @@ fn private_batch_prover_ignores_prover_artifact() {
     };
 
     // Garbage in place of the prover artifact must not affect loading or proving.
-    std::fs::write(dir.join("private_batch_prover.bin"), b"not a prover artifact").unwrap();
+    std::fs::write(
+        dir.join("private_batch_prover.bin"),
+        b"not a prover artifact",
+    )
+    .unwrap();
     aggregate_and_verify(&dir);
 
     // Nor must its absence: the file is not part of the trusted input set.
@@ -526,7 +530,11 @@ fn public_batch_prover_ignores_prover_artifact() {
     };
 
     // Garbage in place of the prover artifact must not affect loading or proving.
-    std::fs::write(dir.join("public_batch_prover.bin"), b"not a prover artifact").unwrap();
+    std::fs::write(
+        dir.join("public_batch_prover.bin"),
+        b"not a prover artifact",
+    )
+    .unwrap();
     aggregate_and_verify(&dir);
 
     // Nor must its absence: the file is not part of the trusted input set.

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -352,6 +352,48 @@ fn private_batch_prover_rejects_poisoned_dummy_template() {
 }
 
 #[test]
+fn private_batch_prover_ignores_prover_artifact() {
+    // The private-batch aggregation prover is rebuilt from source, so it must
+    // never read private_batch_prover.bin. ProverOnlyCircuitData carries the
+    // witness generators and the public-input target list that decides which
+    // witness values are exposed in the returned proof; trusting a serialized
+    // prover artifact would let a poisoned file exfiltrate batch witness
+    // material (e.g. dummy-nullifier preimages) through the emitted proof. This
+    // test poisons and then deletes that artifact and shows loading and proving
+    // are unaffected, matching the leaf prover's build-from-source stance.
+    setup_test_binaries();
+
+    let dir = test_bins_root().join("private-ignored-prover");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    for entry in std::fs::read_dir(private_bins_dir()).unwrap() {
+        let entry = entry.unwrap();
+        std::fs::copy(entry.path(), dir.join(entry.file_name())).unwrap();
+    }
+
+    let aggregate_and_verify = |bins: &std::path::Path| {
+        let proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
+        let aggregated = PrivateBatchProver::new_from_binaries_dir(bins)
+            .expect("prover must load without a trusted prover artifact")
+            .aggregate(vec![proof])
+            .expect("aggregation must succeed");
+        private_batch_verifier()
+            .verify(aggregated)
+            .expect("aggregated proof must verify");
+    };
+
+    // Garbage in place of the prover artifact must not affect loading or proving.
+    std::fs::write(dir.join("private_batch_prover.bin"), b"not a prover artifact").unwrap();
+    aggregate_and_verify(&dir);
+
+    // Nor must its absence: the file is not part of the trusted input set.
+    let _ = std::fs::remove_file(dir.join("private_batch_prover.bin"));
+    aggregate_and_verify(&dir);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn private_batch_build_rejects_substituted_leaf_artifacts() {
     // Regression (build-time verifier-key substitution): the private-batch build
     // bakes the leaf verifier key into the recursive circuit as constants, so it

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -453,7 +453,7 @@ fn public_batch_build_rejects_substituted_private_batch_artifacts() {
     vk_bytes[last] ^= 0x01;
     std::fs::write(dir.join("private_batch_verifier.bin"), vk_bytes).unwrap();
 
-    let err = generate_public_batch_circuit_binaries(&dir, 1, false)
+    let err = generate_public_batch_circuit_binaries(&dir, 1)
         .expect_err("substituted private-batch artifacts must be rejected before baking");
     // `{err:#}` prints the whole context chain; the canonical mismatch is the cause.
     let chain = format!("{err:#}");
@@ -485,6 +485,55 @@ fn make_private_batch_proof_in_public_dir() -> ProofWithPublicInputs<F, C, D> {
                 .expect("private aggregate")
         })
         .clone()
+}
+
+#[test]
+fn public_batch_prover_ignores_prover_artifact() {
+    // Same stance as private_batch_prover_ignores_prover_artifact, one layer
+    // up: the public-batch prover is rebuilt from source, so it must never
+    // read public_batch_prover.bin. ProverOnlyCircuitData carries the
+    // public-input target list that decides which witness values the emitted
+    // proof exposes; trusting a serialized prover artifact would let a
+    // poisoned file exfiltrate batch witness material through the proof's
+    // public inputs. This test plants a garbage artifact (the builder no
+    // longer even emits one) and shows loading, proving, and verification are
+    // unaffected.
+    setup_public_test_binaries();
+
+    let dir = test_bins_root().join("public-ignored-prover");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    for entry in std::fs::read_dir(public_bins_dir()).unwrap() {
+        let entry = entry.unwrap();
+        std::fs::copy(entry.path(), dir.join(entry.file_name())).unwrap();
+    }
+
+    let private_batch_proof = make_private_batch_proof_in_public_dir();
+    let address = BytesDigest::try_from([1u8; 32]).expect("valid address");
+
+    let aggregate_and_verify = |bins: &std::path::Path| {
+        let mut aggregator = PublicBatchAggregator::new(bins, address)
+            .expect("aggregator must load without a trusted prover artifact");
+        let key = aggregator
+            .push_proof(private_batch_proof.clone())
+            .expect("valid private-batch proof must be admitted");
+        let aggregated = aggregator
+            .aggregate(&key)
+            .expect("public aggregation must succeed");
+        aggregator
+            .verify(aggregated)
+            .expect("public-batch proof must verify");
+    };
+
+    // Garbage in place of the prover artifact must not affect loading or proving.
+    std::fs::write(dir.join("public_batch_prover.bin"), b"not a prover artifact").unwrap();
+    aggregate_and_verify(&dir);
+
+    // Nor must its absence: the file is not part of the trusted input set.
+    let _ = std::fs::remove_file(dir.join("public_batch_prover.bin"));
+    aggregate_and_verify(&dir);
+
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]

--- a/wormhole/tests/src/circuit/circuit_data_tests.rs
+++ b/wormhole/tests/src/circuit/circuit_data_tests.rs
@@ -5,31 +5,29 @@ use std::fs;
 use std::path::Path;
 use test_helpers::TestInputs;
 use wormhole_circuit::circuit::circuit_logic::WormholeCircuit;
-use wormhole_circuit::circuit::{circuit_data_from_bytes, circuit_data_to_bytes};
 use wormhole_circuit::inputs::CircuitInputs;
 use wormhole_verifier::WormholeVerifier;
 
+/// The circuit crate must not expose a deserializer for the full leaf
+/// `CircuitData`. A full `CircuitData` carries prover-only data (witness
+/// generators plus the target list that decides which witness values become
+/// `public_inputs`), so loading one from untrusted bytes could exfiltrate
+/// private witness material such as the Wormhole `secret` through a proof's
+/// public inputs. The leaf circuit builds from source in ~40 ms (release), so
+/// there is no need for serialized full-circuit artifacts; provers always
+/// construct `WormholeCircuit` directly and verifiers load pinned artifacts
+/// through `WormholeVerifier::new_from_bytes`.
+///
+/// This is a compile-time guarantee: if `circuit_data_from_bytes` (or a
+/// similar unauthenticated full-circuit loader) is ever reintroduced, this
+/// test file is where its fail-closed behavior must be covered again.
 #[test]
-fn test_circuit_data_serialization() {
-    // Build the circuit from source
+fn full_circuit_data_loader_is_not_exposed() {
+    // `wormhole_circuit::circuit` intentionally only exposes `circuit_logic`.
+    // Building from source is the only way to obtain leaf CircuitData.
     let config = CircuitConfig::standard_recursion_config();
-    let circuit = WormholeCircuit::new(config);
-    let built_circuit_data = circuit.build_circuit();
-
-    // Serialize the circuit data to bytes
-    let serialized_bytes =
-        circuit_data_to_bytes(&built_circuit_data).expect("Failed to serialize circuit data");
-
-    // Deserialize the bytes back to circuit data
-    let deserialized_circuit_data =
-        circuit_data_from_bytes(&serialized_bytes).expect("Failed to deserialize circuit data");
-
-    // Re-serialize the deserialized circuit data
-    let reserialized_bytes = circuit_data_to_bytes(&deserialized_circuit_data)
-        .expect("Failed to re-serialize circuit data");
-
-    // Assert that the original and re-serialized bytes are identical
-    assert_eq!(serialized_bytes, reserialized_bytes);
+    let circuit_data = WormholeCircuit::new(config).build_circuit();
+    assert_eq!(circuit_data.common.num_public_inputs, 21);
 }
 
 #[test]


### PR DESCRIPTION

Fixes three security-review findings. Each was verified against the current code, reproduced with a failing (red) test, fixed, and re-verified green. None of the findings affects proof soundness of correctly generated artifacts; all three concern availability, artifact consistency, or operator misconfiguration at tooling boundaries.

## 1. Publish the public-batch artifact pair all-or-nothing (`10226e1`)

**Finding.** `generate_public_batch_circuit_binaries` wrote `public_batch_common.bin` and then `public_batch_verifier.bin` directly in place into a possibly pre-existing bins directory. A re-run that failed or was interrupted between the two writes left a fresh common file beside a stale verifier file. Consumers (`PublicBatchAggregator::new`) load the pair as a matched set and pin it against a canonical circuit rebuild, so a mixed directory is rejected until regenerated — a reversible aggregation outage.

Parts of the original finding were stale: `include_prover` and `public_batch_prover.bin` no longer exist (provers are always rebuilt from source since `5944a7d`), so the "stale prover artifact" scenario is obsolete.

**Fix.** `write_verifier_artifacts` now publishes through a new `commit_artifact_set` helper:

- Both files are staged under unpredictable temp names in the same directory using exclusive-create opens (consistent with the symlink-safety pattern in `create_staging_dir`).
- Only after all stages succeed are the previous files moved aside and the staged files renamed into place.
- Any failure rolls the moved-aside originals back, so an error always leaves the complete previous set or the complete new set — never a mix.

The residual exposure shrinks from "any failure during the multi-minute build-and-write" to a process kill between two renames of already-complete files. Whole-directory consistency across stages remains the job of the staging + atomic-swap flow in `generate_all_circuit_binaries`, which the docs now point to.

**Tests.** `failed_artifact_publish_never_leaves_mixed_verifier_set` (red on old code: a forced failure between the two files clobbered the old common) and `artifact_publish_replaces_set_wholesale_without_droppings`.

## 2. Drop colliding `-n` short flags from the circuit-builder CLI (`6540dcf`)

**Finding.** In the `qp-wormhole-circuit-builder` argument struct, both `num_leaf_proofs` and `num_private_batch_proofs` used a bare `#[arg(short, long)]`, so clap derived `-n` for both. Debug builds panicked on every invocation (including `--help`) via clap's duplicate-short assertion; release builds compiled the assertion out and silently bound `-n` to `num_leaf_proofs`, letting an operator set the wrong proof-count dimension. Reproduced directly.

**Fix.** Removed the short forms from both proof-count arguments, keeping `--num-leaf-proofs` and `--num-private-batch-proofs` (the only forms the READMEs ever advertised; nothing in the repo used `-n`). Dropping the shorts rather than assigning new letters avoids an ambiguous single-letter alias for two easily confused parameters. `-o`/`--output` is unambiguous and unchanged.

**Tests.** `cli_definition_is_valid` runs `Args::command().debug_assert()` — clap's recommended CLI-validity check — so an invalid argument definition fails CI instead of operators (red on old code with the duplicate-`-n` panic).

## 3. Enforce a routed-wire recursion floor at the memprof CLI boundary (`688f4ba`)

**Finding.** `AggConfigArgs` documents `--num-routed-wires` as a safe (non-security-affecting) override but only validated `> 0` and `<= num_wires`. In the pinned qp-plonky2, slot-packed gates derive their op count from `num_routed_wires` (base arithmetic: 4 wires/op), so sub-floor widths instantiate gates with zero operation slots: `find_slot`'s `num_ops - 1` underflows (debug panic; in release a zero-constraint gate is added and the build dies later on a routability assert), and plonky2's own `check_recursion_config` assert fires only mid-build, after the expensive leaf context is built. The profiler therefore accepted and labeled broken circuit shapes as viable memory-saving configurations.

The floor is higher than the finding's base-arithmetic analysis: extension arithmetic needs `4*D = 8` routed wires, the FRI random-access gate `2 + 2^4 = 18` per copy, and the binding constraint is the 16-point coset-interpolation gate at `1 + 16*D + D + D = 37` under the production FRI shape.

**Fix.** Added `MIN_NUM_ROUTED_WIRES = 37` (with a comment deriving each gate's requirement) and enforced it in `AggConfigArgs::validate`, alongside the existing `num_wires >= 135` and `max_quotient_degree_factor >= 7` floors. Flag help and the memprof README now document the floor. Like `MIN_NUM_WIRES`, this is a documented structural minimum, not a build-success guarantee; values at or above it that still fail do so loudly.

**Tests.** `routed_wires_below_recursion_gate_floor_are_rejected` checks 1, 2, 3, 4, 17, and 36 are rejected with the floor message and 37 passes validation (red on old code: `--num-routed-wires 1` was accepted).

## Test plan

- [x] `cargo test -p qp-wormhole-aggregator --lib` — 77/77 pass (release)
- [x] `cargo test -p qp-wormhole-circuit-builder` — CLI validity test passes; `--help` runs cleanly in a debug build
- [x] `cargo test -p wormhole-memprof` — 10/10 pass
- [x] `cargo clippy` clean on all three touched packages
- [x] Each new test confirmed red on the pre-fix code before applying the fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches proof pooling, Merkle verification, untrusted JSON/artifact loading, and prover artifact trust model—security-sensitive paths where mistakes could affect availability, information leakage, or verification semantics.
> 
> **Overview**
> This PR is a broad **security and availability** pass across common parsing, Merkle verification, wormhole aggregation, and operator-facing tooling.
> 
> **Untrusted input and crypto helpers.** `TransferProofJson` gains a raw **8 MiB** cap and `from_json_str` as the entry point for attacker-supplied JSON, closing escape-inflation gaps before Serde decodes strings. `hash_bytes_compact` now returns `Result` and enforces `MAX_SERIALIZED_BYTES`. Byte-level ZK Merkle verification rejects **noncanonical Goldilocks limb encodings** via `is_canonical_hash`, blocking field-alias membership tricks.
> 
> **Aggregator and artifacts.** Circuit `*.bin` reads go through **`read_artifact_file`** (64 MiB cap, stat + `take`). **`ensure_proof_shape_matches_targets`** preflights malformed recursive proofs before witness fill (avoids panics/silent partial assignment). The proof pool runs **duplicate-nullifier checks only after verification**, with **generic errors** so submitters cannot probe staged spends. **No `prover.bin` is emitted or loaded** for private/public batch (or leaf full-circuit serde): provers **rebuild from source** so poisoned prover-only data cannot steer public inputs. Public-batch verifier files publish via **`commit_artifact_set`** (all-or-nothing staging/rename/rollback). Circuit-builder staging uses **exclusive, unpredictable** dirs and refuses symlinked staging at commit.
> 
> **Tooling and leakage.** Circuit-builder drops colliding **`-n`** short flags; memprof enforces **`num_routed_wires >= 37`**. **`Debug` is redacted** on provers and private witness structs. Dummy padding templates must include **`asset_id == 0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 688f4ba79b21ba1b4ebf424e6e30377261469f89. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->