### PR TITLE
V12 run 5089

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,7 @@ version = "3.1.0"
 dependencies = [
  "anyhow",
  "criterion",
+ "libc",
  "qp-plonky2-verifier",
  "qp-wormhole-inputs",
  "tiny-keccak",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,7 @@ dependencies = [
  "criterion",
  "env_logger",
  "hex",
+ "libc",
  "qp-plonky2",
  "qp-wormhole-circuit",
  "qp-wormhole-inputs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,8 +1126,10 @@ dependencies = [
  "qp-plonky2",
  "qp-wormhole-aggregator",
  "qp-wormhole-circuit",
+ "qp-wormhole-prover",
  "qp-zk-circuits-common",
  "rand 0.8.6",
+ "test-helpers",
 ]
 
 [[package]]

--- a/common/src/gadgets.rs
+++ b/common/src/gadgets.rs
@@ -240,37 +240,193 @@ pub fn digest4_lt<F: RichField + Extendable<D>, const D: usize>(
     lt
 }
 
+/// Lexicographic `lhs < rhs` over 8 range-checked 32-bit half-limbs (most
+/// significant first). Inputs must already be range-constrained to 32 bits;
+/// no splits are performed here (see [`sort_digests4`]).
+fn halves8_lt<F: RichField + Extendable<D>, const D: usize>(
+    b: &mut CircuitBuilder<F, D>,
+    lhs: &[Target; 8],
+    rhs: &[Target; 8],
+) -> BoolTarget {
+    // Fold from the least-significant half up:
+    // lt = lt_0 OR (eq_0 AND (lt_1 OR (eq_1 AND ...)))
+    let mut lt = b._false();
+    for i in (0..8).rev() {
+        let lt_i = u32_lt(b, lhs[i], rhs[i]);
+        let eq_i = b.is_equal(lhs[i], rhs[i]);
+        let carry = b.and(eq_i, lt);
+        lt = b.or(lt_i, carry);
+    }
+    lt
+}
+
 /// Sort 4-limb digests ascending (lexicographic, limb 0 most significant)
 /// with an odd-even transposition network of compare-and-swap stages.
 ///
+/// Range-check work is hoisted out of the quadratic part: each digest limb is
+/// split into canonical 32-bit halves ONCE at ingress (4 splits per digest),
+/// the 8-half representation is routed through the O(n²) comparator network
+/// (comparators use only [`u32_lt`], no further splits), and the halves are
+/// recombined into limbs at egress. Re-splitting inside every comparator, as
+/// a naive implementation would, costs ~3x more gates.
+///
 /// Two layers of guarantees:
 ///
-/// 1. The output is ALWAYS a permutation of the input, structurally: each
-///    comparator emits `select(lt, a, b)` and `select(lt, b, a)`, which is
-///    `{a, b}` as a multiset for either value of the (boolean-constrained)
-///    flag — independent of any comparison correctness.
-/// 2. The ascending ORDER is also enforced against malicious provers: every
-///    comparator's limb splits are canonicity-constrained (see
-///    [`split_canonical_u32_halves`]), so no witness choice can flip a
-///    comparison and mis-order the output.
+/// 1. The output is ALWAYS a permutation of the input: `split_low_high`
+///    constrains `limb = lo + hi * 2^32`, each comparator emits
+///    `select(lt, a, b)` / `select(lt, b, a)` — which is `{a, b}` as a
+///    multiset for either value of the (boolean-constrained) flag, moving
+///    each digest's 8 halves under one flag — and egress recombination
+///    computes exactly `hi * 2^32 + lo`. So each output digest equals some
+///    input digest independent of any comparison correctness.
+/// 2. The ascending ORDER is also enforced against malicious provers: the
+///    ingress splits are canonicity-constrained (see
+///    [`split_canonical_u32_halves`], which excludes the `x + p` alias), the
+///    comparators only ever route these constrained halves, so no witness
+///    choice can flip a comparison and mis-order the output.
+///
+/// The recombination here satisfies the packing rules noted above (limbs
+/// range-checked AND wraparound region excluded): both come from the ingress
+/// canonical split.
 pub fn sort_digests4<F: RichField + Extendable<D>, const D: usize>(
     b: &mut CircuitBuilder<F, D>,
     values: Vec<[Target; 4]>,
 ) -> Vec<[Target; 4]> {
     let n = values.len();
-    let mut v = values;
+    if n <= 1 {
+        return values;
+    }
+
+    // Ingress: one canonical split per limb. Halves are ordered most
+    // significant first ([hi0, lo0, hi1, lo1, ...]) so half-wise
+    // lexicographic order equals limb-wise canonical-u64 order.
+    let mut v: Vec<[Target; 8]> = values
+        .into_iter()
+        .map(|d| {
+            let mut halves = [d[0]; 8];
+            for j in 0..4 {
+                let (lo, hi) = split_canonical_u32_halves(b, d[j]);
+                halves[2 * j] = hi;
+                halves[2 * j + 1] = lo;
+            }
+            halves
+        })
+        .collect();
+
     for round in 0..n {
         let mut i = round % 2;
         while i + 1 < n {
             let lhs = v[i];
             let rhs = v[i + 1];
-            let lhs_lt = digest4_lt(b, lhs, rhs);
-            for j in 0..4 {
+            let lhs_lt = halves8_lt(b, &lhs, &rhs);
+            for j in 0..8 {
                 v[i][j] = b.select(lhs_lt, lhs[j], rhs[j]);
                 v[i + 1][j] = b.select(lhs_lt, rhs[j], lhs[j]);
             }
             i += 2;
         }
     }
-    v
+
+    // Egress: recombine each digest's halves back into 64-bit limbs.
+    let two_pow_32 = F::from_canonical_u64(1 << 32);
+    v.into_iter()
+        .map(|halves| {
+            core::array::from_fn(|j| b.mul_const_add(two_pow_32, halves[2 * j], halves[2 * j + 1]))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::circuit::{wormhole_private_batch_circuit_config, C, D, F};
+    use alloc::vec;
+    use plonky2::field::types::{Field, PrimeField64};
+    use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+
+    /// Gates added by `sort_digests4` over `n` virtual digests under the
+    /// production private-batch circuit config.
+    fn sort_gate_cost(n: usize) -> usize {
+        let mut b = CircuitBuilder::<F, D>::new(wormhole_private_batch_circuit_config());
+        let values: Vec<[Target; 4]> = (0..n)
+            .map(|_| core::array::from_fn(|_| b.add_virtual_target()))
+            .collect();
+        let before = b.num_gates();
+        let _ = sort_digests4(&mut b, values);
+        b.num_gates() - before
+    }
+
+    /// The sorting network's cost is quadratic in the batch size (`n_leaf`
+    /// is operator-configurable up to `MAX_PROOF_COUNT = 64`), so its
+    /// per-comparator cost must stay hoisted: limbs are split once at
+    /// ingress, not re-split inside every comparator (which costs ~3x more
+    /// range-check work and at n=64 enough gates to risk crossing a
+    /// power-of-two degree boundary). Budgets are the measured cost of the
+    /// hoisted implementation plus ~15% headroom; the naive re-splitting
+    /// implementation exceeds them by ~60% and must fail.
+    #[test]
+    fn sort_digests4_gate_cost_stays_hoisted() {
+        for (n, budget) in [(8usize, 900), (64usize, 57_000)] {
+            let cost = sort_gate_cost(n);
+            std::println!("sort_digests4 n={n}: {cost} gates (budget {budget})");
+            assert!(
+                cost <= budget,
+                "n={n}: {cost} gates exceeds budget {budget}"
+            );
+        }
+    }
+
+    /// Prove a circuit that sorts a fixed set of digests and exposes the
+    /// result as public inputs; the proved order must equal the native
+    /// `[u64; 4]` sort the spec's `digestLt` is pinned against. Exercises
+    /// duplicate digests, shared prefixes that differ only in the last limb,
+    /// half-limb boundary values (2^32 - 1 vs 2^32), and the canonical
+    /// maximum p - 1.
+    #[test]
+    fn sort_digests4_proves_native_sort_order() {
+        const P: u64 = 0xFFFF_FFFF_0000_0001;
+        let inputs: Vec<[u64; 4]> = vec![
+            [7, 7, 7, 7],
+            [0, 0, 0, 0],
+            [P - 1, P - 1, P - 1, P - 1],
+            [7, 7, 7, 6],
+            [0, (1 << 32) - 1, 0, 0],
+            [0, 1 << 32, 0, 0],
+            [7, 7, 7, 7], // duplicate
+            [1, 0, 0, P - 1],
+        ];
+
+        // Not the production (zk) config: blinding needs plonky2's `rand`
+        // feature, which this crate doesn't enable, and sort order is
+        // independent of blinding.
+        let config = plonky2::plonk::circuit_data::CircuitConfig::standard_recursion_config();
+        let mut b = CircuitBuilder::<F, D>::new(config);
+        let targets: Vec<[Target; 4]> = (0..inputs.len())
+            .map(|_| core::array::from_fn(|_| b.add_virtual_target()))
+            .collect();
+        for sorted in sort_digests4(&mut b, targets.clone()) {
+            for t in sorted {
+                b.register_public_input(t);
+            }
+        }
+        let data = b.build::<C>();
+
+        let mut pw = PartialWitness::new();
+        for (digest_t, digest_v) in targets.iter().zip(&inputs) {
+            for (t, v) in digest_t.iter().zip(digest_v) {
+                pw.set_target(*t, F::from_canonical_u64(*v)).unwrap();
+            }
+        }
+        let proof = data.prove(pw).unwrap();
+        data.verify(proof.clone()).unwrap();
+
+        let mut expected = inputs;
+        expected.sort();
+        let proved: Vec<[u64; 4]> = proof
+            .public_inputs
+            .chunks_exact(4)
+            .map(|c| core::array::from_fn(|i| c[i].to_canonical_u64()))
+            .collect();
+        assert_eq!(proved, expected, "in-circuit sort must match native sort");
+    }
 }

--- a/common/src/gadgets.rs
+++ b/common/src/gadgets.rs
@@ -146,3 +146,131 @@ pub fn limb1_at_offset<const LEAF_PI_LEN: usize, const KEY_OFFSET: usize>(
 // could reach a chosen packed value via modular wraparound). If limb packing
 // is reintroduced, it must range-check both limbs to 32 bits AND exclude the
 // Goldilocks wraparound region (`hi == 2^32 - 1 && lo >= 1`).
+
+/// Compare two 32-bit values: returns `x < y`.
+///
+/// Both inputs must already be range-constrained to 32 bits by the caller
+/// (e.g. as outputs of `split_low_high`). Computes `t = x + 2^32 - y`, which
+/// lies in `[1, 2^33 - 1]` (no field wraparound: `2^33 < p`); bit 32 of `t`
+/// is exactly `x >= y`.
+fn u32_lt<F: RichField + Extendable<D>, const D: usize>(
+    b: &mut CircuitBuilder<F, D>,
+    x: Target,
+    y: Target,
+) -> BoolTarget {
+    let two_pow_32 = b.constant(F::from_canonical_u64(1 << 32));
+    let x_shifted = b.add(x, two_pow_32);
+    let t = b.sub(x_shifted, y);
+    // high part is a single bit, range-checked to 1 bit by split_low_high.
+    let (_low, ge_bit) = b.split_low_high(t, 32, 33);
+    let ge = BoolTarget::new_unsafe(ge_bit);
+    b.not(ge)
+}
+
+/// Split a field element into 32-bit halves, enforcing the CANONICAL
+/// decomposition.
+///
+/// `split_low_high(x, 32, 64)` alone admits two valid decompositions for
+/// values below `2^64 - p = 2^32 - 1`: the canonical one and `x + p`. The
+/// non-canonical representative always lands in the wraparound region
+/// `hi == 2^32 - 1 && lo >= 1` (exactly the integers `>= p` expressible in
+/// 32-bit halves), so excluding that region makes the decomposition unique
+/// and comparisons built on it sound against malicious provers.
+fn split_canonical_u32_halves<F: RichField + Extendable<D>, const D: usize>(
+    b: &mut CircuitBuilder<F, D>,
+    x: Target,
+) -> (Target, Target) {
+    let (lo, hi) = b.split_low_high(x, 32, 64);
+
+    let max_hi = b.constant(F::from_canonical_u64((1u64 << 32) - 1));
+    let hi_is_max = b.is_equal(hi, max_hi);
+    let zero = b.zero();
+    let lo_is_zero = b.is_equal(lo, zero);
+    let lo_nonzero = b.not(lo_is_zero);
+    let in_wraparound = b.and(hi_is_max, lo_nonzero);
+    b.connect(in_wraparound.target, zero);
+
+    (lo, hi)
+}
+
+/// Compare two field elements as 64-bit integers: returns `(x < y, x == y)`.
+///
+/// Each element is split into range-checked, canonicity-enforced 32-bit
+/// halves (see [`split_canonical_u32_halves`]) and compared high-half first,
+/// so the comparison result is sound even against a malicious prover that
+/// hand-picks witness values for the split targets.
+fn felt64_lt_eq<F: RichField + Extendable<D>, const D: usize>(
+    b: &mut CircuitBuilder<F, D>,
+    x: Target,
+    y: Target,
+) -> (BoolTarget, BoolTarget) {
+    let (x_lo, x_hi) = split_canonical_u32_halves(b, x);
+    let (y_lo, y_hi) = split_canonical_u32_halves(b, y);
+
+    let hi_lt = u32_lt(b, x_hi, y_hi);
+    let hi_eq = b.is_equal(x_hi, y_hi);
+    let lo_lt = u32_lt(b, x_lo, y_lo);
+
+    // lt = hi_lt OR (hi_eq AND lo_lt)
+    let lo_decides = b.and(hi_eq, lo_lt);
+    let lt = b.or(hi_lt, lo_decides);
+    let eq = b.is_equal(x, y);
+    (lt, eq)
+}
+
+/// Compare two 4-limb digests lexicographically (limb 0 most significant),
+/// treating each limb as a canonical 64-bit integer: returns `a < b`.
+///
+/// Sound against malicious provers: every limb split is canonicity-enforced
+/// (see [`split_canonical_u32_halves`]), so the comparison result is fully
+/// constrained by the input values.
+pub fn digest4_lt<F: RichField + Extendable<D>, const D: usize>(
+    b: &mut CircuitBuilder<F, D>,
+    lhs: [Target; 4],
+    rhs: [Target; 4],
+) -> BoolTarget {
+    // Fold from the least-significant limb up:
+    // lt = lt_0 OR (eq_0 AND (lt_1 OR (eq_1 AND ...)))
+    let mut lt = b._false();
+    for i in (0..4).rev() {
+        let (lt_i, eq_i) = felt64_lt_eq(b, lhs[i], rhs[i]);
+        let carry = b.and(eq_i, lt);
+        lt = b.or(lt_i, carry);
+    }
+    lt
+}
+
+/// Sort 4-limb digests ascending (lexicographic, limb 0 most significant)
+/// with an odd-even transposition network of compare-and-swap stages.
+///
+/// Two layers of guarantees:
+///
+/// 1. The output is ALWAYS a permutation of the input, structurally: each
+///    comparator emits `select(lt, a, b)` and `select(lt, b, a)`, which is
+///    `{a, b}` as a multiset for either value of the (boolean-constrained)
+///    flag — independent of any comparison correctness.
+/// 2. The ascending ORDER is also enforced against malicious provers: every
+///    comparator's limb splits are canonicity-constrained (see
+///    [`split_canonical_u32_halves`]), so no witness choice can flip a
+///    comparison and mis-order the output.
+pub fn sort_digests4<F: RichField + Extendable<D>, const D: usize>(
+    b: &mut CircuitBuilder<F, D>,
+    values: Vec<[Target; 4]>,
+) -> Vec<[Target; 4]> {
+    let n = values.len();
+    let mut v = values;
+    for round in 0..n {
+        let mut i = round % 2;
+        while i + 1 < n {
+            let lhs = v[i];
+            let rhs = v[i + 1];
+            let lhs_lt = digest4_lt(b, lhs, rhs);
+            for j in 0..4 {
+                v[i][j] = b.select(lhs_lt, lhs[j], rhs[j]);
+                v[i + 1][j] = b.select(lhs_lt, rhs[j], lhs[j]);
+            }
+            i += 2;
+        }
+    }
+    v
+}

--- a/common/src/gadgets.rs
+++ b/common/src/gadgets.rs
@@ -193,52 +193,11 @@ fn split_canonical_u32_halves<F: RichField + Extendable<D>, const D: usize>(
     (lo, hi)
 }
 
-/// Compare two field elements as 64-bit integers: returns `(x < y, x == y)`.
-///
-/// Each element is split into range-checked, canonicity-enforced 32-bit
-/// halves (see [`split_canonical_u32_halves`]) and compared high-half first,
-/// so the comparison result is sound even against a malicious prover that
-/// hand-picks witness values for the split targets.
-fn felt64_lt_eq<F: RichField + Extendable<D>, const D: usize>(
-    b: &mut CircuitBuilder<F, D>,
-    x: Target,
-    y: Target,
-) -> (BoolTarget, BoolTarget) {
-    let (x_lo, x_hi) = split_canonical_u32_halves(b, x);
-    let (y_lo, y_hi) = split_canonical_u32_halves(b, y);
-
-    let hi_lt = u32_lt(b, x_hi, y_hi);
-    let hi_eq = b.is_equal(x_hi, y_hi);
-    let lo_lt = u32_lt(b, x_lo, y_lo);
-
-    // lt = hi_lt OR (hi_eq AND lo_lt)
-    let lo_decides = b.and(hi_eq, lo_lt);
-    let lt = b.or(hi_lt, lo_decides);
-    let eq = b.is_equal(x, y);
-    (lt, eq)
-}
-
-/// Compare two 4-limb digests lexicographically (limb 0 most significant),
-/// treating each limb as a canonical 64-bit integer: returns `a < b`.
-///
-/// Sound against malicious provers: every limb split is canonicity-enforced
-/// (see [`split_canonical_u32_halves`]), so the comparison result is fully
-/// constrained by the input values.
-pub fn digest4_lt<F: RichField + Extendable<D>, const D: usize>(
-    b: &mut CircuitBuilder<F, D>,
-    lhs: [Target; 4],
-    rhs: [Target; 4],
-) -> BoolTarget {
-    // Fold from the least-significant limb up:
-    // lt = lt_0 OR (eq_0 AND (lt_1 OR (eq_1 AND ...)))
-    let mut lt = b._false();
-    for i in (0..4).rev() {
-        let (lt_i, eq_i) = felt64_lt_eq(b, lhs[i], rhs[i]);
-        let carry = b.and(eq_i, lt);
-        lt = b.or(lt_i, carry);
-    }
-    lt
-}
+// NOTE: a standalone whole-digest comparator (`digest4_lt` over
+// `felt64_lt_eq`) used to live here; it re-split both operands at every call,
+// and once `sort_digests4` hoisted splitting to ingress it had no callers
+// left, so it was removed. If a one-off digest comparison is needed again,
+// compose [`split_canonical_u32_halves`] + [`halves8_lt`].
 
 /// Lexicographic `lhs < rhs` over 8 range-checked 32-bit half-limbs (most
 /// significant first). Inputs must already be range-constrained to 32 bits;

--- a/common/src/serialization.rs
+++ b/common/src/serialization.rs
@@ -186,21 +186,33 @@ pub fn bytes_to_felts_compact(input: &[u8]) -> Result<Vec<F>, &'static str> {
 
 /// Hash bytes with Poseidon2 using compact (8 bytes/felt) encoding.
 ///
-/// Uses the lossy `bytes_to_u64s_compact` path so fixed-size merkle-node payloads
+/// Uses the `bytes_to_u64s_compact` path so fixed-size merkle-node payloads
 /// always hash (matching pallet-zk-tree). Prefer this over calling
 /// `qp_poseidon_core::serialization::bytes_to_felts_compact`, which is fallible
 /// in poseidon-core ≥ 3.0.
+///
+/// The compact encoding zero-pads the final 8-byte chunk, so on unaligned
+/// input it is lossy: `x` and `x || 0x00` would encode to the same felt
+/// vector and collide. To keep this helper collision-resistant, the input
+/// length must be a multiple of 8; unaligned input returns an error. On the
+/// aligned domain the encoding is injective and the sponge's 10* padding
+/// separates different felt counts, so distinct inputs hash distinctly.
+/// This helper is deliberately crate-private so it cannot be misused
+/// downstream as a general-purpose variable-length byte commitment.
 ///
 /// Returns an error if `input.len()` exceeds [`MAX_SERIALIZED_BYTES`], matching
 /// the sibling byte-consuming helpers in this module: the intermediate felt
 /// buffer and the hashing work both scale with the input, so an unbounded
 /// public path here would let untrusted caller-supplied data force
 /// size-proportional allocation (audit #97066).
-pub fn hash_bytes_compact(input: &[u8]) -> Result<[u8; 32], &'static str> {
+pub(crate) fn hash_bytes_compact(input: &[u8]) -> Result<[u8; 32], &'static str> {
     use qp_poseidon_core::Goldilocks;
 
     if input.len() > MAX_SERIALIZED_BYTES {
         return Err("hash_bytes_compact: input exceeds maximum serialized length");
+    }
+    if input.len() % 8 != 0 {
+        return Err("hash_bytes_compact: input length must be a multiple of 8");
     }
     let felts: Vec<Goldilocks> = qp_poseidon_core::serialization::bytes_to_u64s_compact(input)
         .into_iter()
@@ -322,6 +334,46 @@ mod tests {
         hash_bytes_compact(&[0x5au8; 128]).expect("merkle-node payload must hash");
         hash_bytes_compact(&vec![0x5au8; MAX_SERIALIZED_BYTES])
             .expect("input at the exact bound must hash");
+    }
+
+    /// The compact encoding zero-pads the final 8-byte chunk, so unaligned
+    /// inputs that differ only by trailing zero bytes (e.g. `x` vs `x || 0x00`)
+    /// would encode to the same felt vector and collide. `hash_bytes_compact`
+    /// must therefore reject inputs whose length is not a multiple of 8; on
+    /// the aligned domain the encoding is injective and the sponge's own
+    /// padding separates different lengths (audit finding: lossy compact
+    /// encoding exposed as a general byte hash).
+    #[test]
+    fn hash_bytes_compact_rejects_unaligned_input() {
+        // The would-be collision pair: identical zero-padded representation.
+        let x = [1u8, 2, 3];
+        let x_padded = [1u8, 2, 3, 0];
+        assert!(
+            hash_bytes_compact(&x).is_err(),
+            "unaligned input must be rejected"
+        );
+        assert!(
+            hash_bytes_compact(&x_padded).is_err(),
+            "unaligned input must be rejected"
+        );
+
+        for len in [1usize, 7, 9, 127, 129] {
+            let err = hash_bytes_compact(&vec![0x5au8; len]).unwrap_err();
+            assert!(err.contains("multiple of 8"), "len {len}: got: {err}");
+        }
+    }
+
+    /// On the accepted (8-byte-aligned) domain, appending a zero chunk must
+    /// change the hash: the sponge's 10* padding binds the felt count.
+    #[test]
+    fn hash_bytes_compact_aligned_trailing_zero_chunk_changes_hash() {
+        let x = [0x5au8; 16];
+        let mut x_extended = x.to_vec();
+        x_extended.extend_from_slice(&[0u8; 8]);
+        assert_ne!(
+            hash_bytes_compact(&x).unwrap(),
+            hash_bytes_compact(&x_extended).unwrap()
+        );
     }
 
     #[test]

--- a/common/src/serialization.rs
+++ b/common/src/serialization.rs
@@ -186,19 +186,20 @@ pub fn bytes_to_felts_compact(input: &[u8]) -> Result<Vec<F>, &'static str> {
 
 /// Hash bytes with Poseidon2 using compact (8 bytes/felt) encoding.
 ///
-/// Uses the `bytes_to_u64s_compact` path so fixed-size merkle-node payloads
-/// always hash (matching pallet-zk-tree). Prefer this over calling
-/// `qp_poseidon_core::serialization::bytes_to_felts_compact`, which is fallible
-/// in poseidon-core ≥ 3.0.
-///
 /// The compact encoding zero-pads the final 8-byte chunk, so on unaligned
 /// input it is lossy: `x` and `x || 0x00` would encode to the same felt
 /// vector and collide. To keep this helper collision-resistant, the input
-/// length must be a multiple of 8; unaligned input returns an error. On the
-/// aligned domain the encoding is injective and the sponge's 10* padding
-/// separates different felt counts, so distinct inputs hash distinctly.
-/// This helper is deliberately crate-private so it cannot be misused
-/// downstream as a general-purpose variable-length byte commitment.
+/// length must be a multiple of 8; unaligned input returns an error.
+///
+/// An 8-byte limb `>=` the Goldilocks modulus `p` is also rejected: the field
+/// map reduces mod `p` (lazily), so a limb `v` and its byte-distinct alias
+/// `v + p` would otherwise hash identically even on the aligned domain. With
+/// both checks the encoding is injective on the accepted domain, and the
+/// sponge's 10* padding separates different felt counts, so distinct accepted
+/// inputs hash distinctly. Hash outputs re-encoded via [`digest_to_bytes`]
+/// (e.g. merkle-node payloads) are always canonical and always pass. This
+/// helper is deliberately crate-private so it cannot be misused downstream
+/// as a general-purpose variable-length byte commitment.
 ///
 /// Returns an error if `input.len()` exceeds [`MAX_SERIALIZED_BYTES`], matching
 /// the sibling byte-consuming helpers in this module: the intermediate felt
@@ -206,18 +207,13 @@ pub fn bytes_to_felts_compact(input: &[u8]) -> Result<Vec<F>, &'static str> {
 /// public path here would let untrusted caller-supplied data force
 /// size-proportional allocation (audit #97066).
 pub(crate) fn hash_bytes_compact(input: &[u8]) -> Result<[u8; 32], &'static str> {
-    use qp_poseidon_core::Goldilocks;
-
     if input.len() > MAX_SERIALIZED_BYTES {
         return Err("hash_bytes_compact: input exceeds maximum serialized length");
     }
     if !input.len().is_multiple_of(8) {
         return Err("hash_bytes_compact: input length must be a multiple of 8");
     }
-    let felts: Vec<Goldilocks> = qp_poseidon_core::serialization::bytes_to_u64s_compact(input)
-        .into_iter()
-        .map(Goldilocks::from_u64)
-        .collect();
+    let felts = qp_poseidon_core::serialization::bytes_to_felts_compact(input)?;
     Ok(qp_poseidon_core::hash_to_bytes(&felts))
 }
 
@@ -361,6 +357,26 @@ mod tests {
             let err = hash_bytes_compact(&vec![0x5au8; len]).unwrap_err();
             assert!(err.contains("multiple of 8"), "len {len}: got: {err}");
         }
+    }
+
+    /// `Goldilocks::from_u64` keeps the raw u64 (lazy reduction), so a limb
+    /// `v` and its byte-distinct alias `v + p` are the same field element and
+    /// hash identically even on the aligned domain. To make the encoding
+    /// injective on the domain it accepts, `hash_bytes_compact` must reject
+    /// non-canonical limbs instead of silently reducing them.
+    #[test]
+    fn hash_bytes_compact_rejects_noncanonical_limb_alias() {
+        const GOLDILOCKS_MODULUS: u64 = 0xFFFF_FFFF_0000_0001;
+        // 16-byte aligned inputs differing only by +p in the first limb.
+        let mut canonical = [0u8; 16];
+        canonical[..8].copy_from_slice(&1u64.to_le_bytes());
+        let mut alias = canonical;
+        alias[..8].copy_from_slice(&(1u64 + GOLDILOCKS_MODULUS).to_le_bytes());
+
+        hash_bytes_compact(&canonical).expect("canonical limbs must hash");
+        let err = hash_bytes_compact(&alias)
+            .expect_err("byte-distinct +p limb alias must be rejected, not hashed identically");
+        assert!(err.contains("Goldilocks modulus"), "got: {err}");
     }
 
     /// On the accepted (8-byte-aligned) domain, appending a zero chunk must

--- a/common/src/serialization.rs
+++ b/common/src/serialization.rs
@@ -211,7 +211,7 @@ pub(crate) fn hash_bytes_compact(input: &[u8]) -> Result<[u8; 32], &'static str>
     if input.len() > MAX_SERIALIZED_BYTES {
         return Err("hash_bytes_compact: input exceeds maximum serialized length");
     }
-    if input.len() % 8 != 0 {
+    if !input.len().is_multiple_of(8) {
         return Err("hash_bytes_compact: input length must be a multiple of 8");
     }
     let felts: Vec<Goldilocks> = qp_poseidon_core::serialization::bytes_to_u64s_compact(input)

--- a/common/src/zk_merkle.rs
+++ b/common/src/zk_merkle.rs
@@ -204,10 +204,12 @@ impl ZkMerkleProof {
     /// This takes unsorted siblings and computes the correct sorted order
     /// and position hints for circuit verification.
     ///
-    /// Returns an error if the supplied path is deeper than [`MAX_DEPTH`].
-    /// The bound is enforced *before* any allocation or hashing so untrusted
-    /// raw siblings cannot force per-level Poseidon work on a proof that
-    /// [`Self::verify_with_positions`] would reject anyway.
+    /// Returns an error if the supplied path is deeper than [`MAX_DEPTH`], or
+    /// if the leaf or any sibling is not canonical hash bytes (see
+    /// [`is_canonical_hash`]). Both bounds are enforced *before* any
+    /// allocation or hashing so untrusted raw siblings cannot force per-level
+    /// Poseidon work on a proof that [`Self::verify_with_positions`] would
+    /// reject anyway.
     pub fn from_unsorted(
         leaf_index: u64,
         unsorted_siblings: Vec<[Hash256; SIBLINGS_PER_LEVEL]>,
@@ -216,6 +218,15 @@ impl ZkMerkleProof {
     ) -> Result<Self, &'static str> {
         if unsorted_siblings.len() > MAX_DEPTH {
             return Err("from_unsorted: proof depth exceeds MAX_DEPTH");
+        }
+        // The node hash rejects noncanonical limbs (they alias mod p), and
+        // `verify_with_positions` would refuse the resulting proof anyway;
+        // reject untrusted raw bytes here instead of panicking mid-hash.
+        if !is_canonical_hash(&leaf_hash) {
+            return Err("from_unsorted: leaf hash bytes are noncanonical");
+        }
+        if !unsorted_siblings.iter().flatten().all(is_canonical_hash) {
+            return Err("from_unsorted: sibling hash bytes are noncanonical");
         }
 
         let mut current_hash = leaf_hash;
@@ -313,6 +324,11 @@ pub fn insert_at_position(
 ///
 /// Unlike `hash_node`, this does NOT sort - it assumes the input is already sorted.
 /// This is used by the circuit verification path.
+///
+/// Children must be canonical hash bytes (see [`is_canonical_hash`]); genuine
+/// hash outputs always are, and `ZkMerkleProof::verify` rejects noncanonical
+/// bytes before reaching this function. A noncanonical child panics here
+/// rather than silently aliasing another child's hash.
 pub fn hash_node_presorted(sorted_children: &[Hash256; ARITY]) -> Hash256 {
     // Concatenate all 4 child hashes (128 bytes total)
     let mut data = Vec::with_capacity(CHILDREN_BYTES);
@@ -320,16 +336,22 @@ pub fn hash_node_presorted(sorted_children: &[Hash256; ARITY]) -> Hash256 {
         data.extend_from_slice(child);
     }
 
-    // Compact encoding (8 bytes/felt); lossy path for fixed-size hash payloads.
-    // 128 bytes is far below MAX_SERIALIZED_BYTES, so this cannot fail.
-    serialization::hash_bytes_compact(&data).expect("128-byte node payload is within bounds")
+    // Compact encoding (8 bytes/felt): 128 bytes is far below
+    // MAX_SERIALIZED_BYTES and canonical children have canonical limbs,
+    // so this cannot fail.
+    serialization::hash_bytes_compact(&data)
+        .expect("node payload is within bounds with canonical limbs")
 }
 
 /// Hash 4 child hashes into a parent node hash.
 ///
 /// Children are sorted before hashing to eliminate the need for path indices.
-/// Uses non-injective Poseidon (8 bytes/felt) - safe because internal nodes
-/// only contain fixed-size hash outputs.
+/// Uses compact Poseidon encoding (8 bytes/felt) - safe because internal
+/// nodes only contain fixed-size hash outputs, whose limbs are canonical.
+///
+/// Children must be canonical hash bytes (see [`is_canonical_hash`]); a
+/// noncanonical child panics here rather than silently aliasing another
+/// child's hash.
 pub fn hash_node(children: &[Hash256; ARITY]) -> Hash256 {
     // Sort children to make hash order-independent
     let mut sorted = *children;
@@ -341,9 +363,11 @@ pub fn hash_node(children: &[Hash256; ARITY]) -> Hash256 {
         data.extend_from_slice(child);
     }
 
-    // Compact encoding (8 bytes/felt); 128 bytes -> 16 felts.
-    // 128 bytes is far below MAX_SERIALIZED_BYTES, so this cannot fail.
-    serialization::hash_bytes_compact(&data).expect("128-byte node payload is within bounds")
+    // Compact encoding (8 bytes/felt): 128 bytes is far below
+    // MAX_SERIALIZED_BYTES and canonical children have canonical limbs,
+    // so this cannot fail.
+    serialization::hash_bytes_compact(&data)
+        .expect("node payload is within bounds with canonical limbs")
 }
 
 /// Empty hash value (all zeros).
@@ -534,12 +558,33 @@ mod tests {
         let bad_proof = ZkMerkleProof::from_unsorted(
             0,
             vec![[leaf1, leaf2, leaf3]],
-            [0xff; 32], // wrong!
+            [0x44; 32], // wrong!
             root,
         )
         .unwrap();
 
         assert!(!bad_proof.verify());
+    }
+
+    /// `from_unsorted` hashes caller-supplied bytes, so noncanonical limbs
+    /// (which the node hash rejects as mod-p aliases) must surface as an
+    /// error, not a panic mid-hash.
+    #[test]
+    fn from_unsorted_rejects_noncanonical_bytes() {
+        let leaf0 = [0x00; 32];
+        let leaf1 = [0x11; 32];
+        let leaf2 = [0x22; 32];
+        let leaf3 = [0x33; 32];
+        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
+
+        // Every limb of 0xff..ff exceeds the Goldilocks modulus.
+        let err = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], [0xff; 32], root)
+            .unwrap_err();
+        assert!(err.contains("leaf hash"), "got: {err}");
+
+        let err = ZkMerkleProof::from_unsorted(0, vec![[leaf1, [0xff; 32], leaf3]], leaf0, root)
+            .unwrap_err();
+        assert!(err.contains("sibling hash"), "got: {err}");
     }
 
     /// Regression (audit): `verify()` used to hash through the

--- a/common/src/zk_merkle.rs
+++ b/common/src/zk_merkle.rs
@@ -466,7 +466,8 @@ mod tests {
         let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
 
         // Create proof for leaf0 using from_unsorted
-        let proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
+        let proof =
+            ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
 
         assert!(proof.verify());
         assert!(proof.verify_with_positions());
@@ -489,7 +490,8 @@ mod tests {
         let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
 
         // leaf0 is smallest, so position should be 0
-        let proof0 = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
+        let proof0 =
+            ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
         assert_eq!(proof0.positions[0], 0);
 
         // leaf3 is largest, so position should be 3
@@ -552,7 +554,8 @@ mod tests {
         let leaf3 = [0x33; 32];
         let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
 
-        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
+        let mut proof =
+            ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
         assert!(proof.verify(), "sanity: correct positions must verify");
 
         // Corrupt the position hint; membership data is untouched.
@@ -610,7 +613,8 @@ mod tests {
         let leaf3 = hash_from_limbs([3, 0, 0, 0]);
         let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
 
-        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
+        let mut proof =
+            ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
         assert!(proof.verify(), "sanity: canonical proof must verify");
 
         // Alias of leaf0: limb 0 replaced by `p`, which reduces to 0 mod p.
@@ -634,7 +638,8 @@ mod tests {
         let leaf3 = hash_from_limbs([3, 0, 0, 0]);
         let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
 
-        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
+        let mut proof =
+            ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
         assert!(proof.verify(), "sanity: canonical proof must verify");
 
         // Replace the first sibling with its noncanonical alias.

--- a/common/src/zk_merkle.rs
+++ b/common/src/zk_merkle.rs
@@ -203,12 +203,21 @@ impl ZkMerkleProof {
     ///
     /// This takes unsorted siblings and computes the correct sorted order
     /// and position hints for circuit verification.
+    ///
+    /// Returns an error if the supplied path is deeper than [`MAX_DEPTH`].
+    /// The bound is enforced *before* any allocation or hashing so untrusted
+    /// raw siblings cannot force per-level Poseidon work on a proof that
+    /// [`Self::verify_with_positions`] would reject anyway.
     pub fn from_unsorted(
         leaf_index: u64,
         unsorted_siblings: Vec<[Hash256; SIBLINGS_PER_LEVEL]>,
         leaf_hash: Hash256,
         root: Hash256,
-    ) -> Self {
+    ) -> Result<Self, &'static str> {
+        if unsorted_siblings.len() > MAX_DEPTH {
+            return Err("from_unsorted: proof depth exceeds MAX_DEPTH");
+        }
+
         let mut current_hash = leaf_hash;
         let mut sorted_siblings = Vec::with_capacity(unsorted_siblings.len());
         let mut positions = Vec::with_capacity(unsorted_siblings.len());
@@ -247,13 +256,13 @@ impl ZkMerkleProof {
             current_hash = hash_node_presorted(&all_four);
         }
 
-        Self {
+        Ok(Self {
             leaf_index,
             siblings: sorted_siblings,
             positions,
             leaf_hash,
             root,
-        }
+        })
     }
 }
 
@@ -457,13 +466,14 @@ mod tests {
         let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
 
         // Create proof for leaf0 using from_unsorted
-        let proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root);
+        let proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
 
         assert!(proof.verify());
         assert!(proof.verify_with_positions());
 
         // Create proof for leaf2 using from_unsorted
-        let proof2 = ZkMerkleProof::from_unsorted(2, vec![[leaf0, leaf1, leaf3]], leaf2, root);
+        let proof2 =
+            ZkMerkleProof::from_unsorted(2, vec![[leaf0, leaf1, leaf3]], leaf2, root).unwrap();
 
         assert!(proof2.verify());
         assert!(proof2.verify_with_positions());
@@ -479,12 +489,34 @@ mod tests {
         let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
 
         // leaf0 is smallest, so position should be 0
-        let proof0 = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root);
+        let proof0 = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
         assert_eq!(proof0.positions[0], 0);
 
         // leaf3 is largest, so position should be 3
-        let proof3 = ZkMerkleProof::from_unsorted(3, vec![[leaf0, leaf1, leaf2]], leaf3, root);
+        let proof3 =
+            ZkMerkleProof::from_unsorted(3, vec![[leaf0, leaf1, leaf2]], leaf3, root).unwrap();
         assert_eq!(proof3.positions[0], 3);
+    }
+
+    /// `from_unsorted` must enforce the same MAX_DEPTH bound that
+    /// `verify_with_positions` enforces, *before* doing per-level allocation,
+    /// sorting, and Poseidon hashing. Otherwise a caller normalizing
+    /// untrusted raw siblings can be forced into work proportional to an
+    /// attacker-controlled depth, only for the proof to be rejected later
+    /// (audit finding: missing depth limit in proof normalization).
+    #[test]
+    fn from_unsorted_rejects_oversized_depth() {
+        let levels = vec![[[0x11u8; 32], [0x22u8; 32], [0x33u8; 32]]; MAX_DEPTH + 1];
+        let err = ZkMerkleProof::from_unsorted(0, levels, [0x42u8; 32], [0u8; 32]).unwrap_err();
+        assert!(err.contains("MAX_DEPTH"), "got: {err}");
+    }
+
+    /// Proofs at exactly MAX_DEPTH must still construct.
+    #[test]
+    fn from_unsorted_accepts_max_depth() {
+        let levels = vec![[[0x11u8; 32], [0x22u8; 32], [0x33u8; 32]]; MAX_DEPTH];
+        ZkMerkleProof::from_unsorted(0, levels, [0x42u8; 32], [0u8; 32])
+            .expect("MAX_DEPTH proof must construct");
     }
 
     #[test]
@@ -502,7 +534,8 @@ mod tests {
             vec![[leaf1, leaf2, leaf3]],
             [0xff; 32], // wrong!
             root,
-        );
+        )
+        .unwrap();
 
         assert!(!bad_proof.verify());
     }
@@ -519,7 +552,7 @@ mod tests {
         let leaf3 = [0x33; 32];
         let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
 
-        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root);
+        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
         assert!(proof.verify(), "sanity: correct positions must verify");
 
         // Corrupt the position hint; membership data is untouched.
@@ -577,7 +610,7 @@ mod tests {
         let leaf3 = hash_from_limbs([3, 0, 0, 0]);
         let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
 
-        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root);
+        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
         assert!(proof.verify(), "sanity: canonical proof must verify");
 
         // Alias of leaf0: limb 0 replaced by `p`, which reduces to 0 mod p.
@@ -601,7 +634,7 @@ mod tests {
         let leaf3 = hash_from_limbs([3, 0, 0, 0]);
         let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
 
-        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root);
+        let mut proof = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
         assert!(proof.verify(), "sanity: canonical proof must verify");
 
         // Replace the first sibling with its noncanonical alias.

--- a/common/src/zk_merkle.rs
+++ b/common/src/zk_merkle.rs
@@ -192,8 +192,13 @@ impl ZkMerkleProof {
                 return false;
             };
 
-            // Hash the sorted children directly (no sorting needed)
-            current_hash = hash_node_presorted(&sorted_children);
+            // Hash the sorted children directly (no sorting needed). The
+            // canonicality pre-check above makes an error unreachable, but a
+            // verifier must never panic on proof bytes.
+            let Ok(parent) = hash_node_presorted(&sorted_children) else {
+                return false;
+            };
+            current_hash = parent;
         }
 
         current_hash == self.root
@@ -263,8 +268,10 @@ impl ZkMerkleProof {
             };
             sorted_siblings.push(sorted_sibs);
 
-            // Compute parent hash for next level
-            current_hash = hash_node_presorted(&all_four);
+            // Compute parent hash for next level (the canonicality check
+            // above makes an error unreachable, but propagate rather than
+            // panic on caller-supplied bytes).
+            current_hash = hash_node_presorted(&all_four)?;
         }
 
         Ok(Self {
@@ -325,11 +332,14 @@ pub fn insert_at_position(
 /// Unlike `hash_node`, this does NOT sort - it assumes the input is already sorted.
 /// This is used by the circuit verification path.
 ///
+/// # Errors
+///
 /// Children must be canonical hash bytes (see [`is_canonical_hash`]); genuine
-/// hash outputs always are, and `ZkMerkleProof::verify` rejects noncanonical
-/// bytes before reaching this function. A noncanonical child panics here
-/// rather than silently aliasing another child's hash.
-pub fn hash_node_presorted(sorted_children: &[Hash256; ARITY]) -> Hash256 {
+/// hash outputs always are. A noncanonical child would silently alias another
+/// child's hash mod p, so it is rejected. This is a public API that may
+/// receive attacker-controlled bytes, so like [`insert_at_position`] it
+/// produces a normal invalid-input error, not a panic.
+pub fn hash_node_presorted(sorted_children: &[Hash256; ARITY]) -> Result<Hash256, &'static str> {
     // Concatenate all 4 child hashes (128 bytes total)
     let mut data = Vec::with_capacity(CHILDREN_BYTES);
     for child in sorted_children {
@@ -337,10 +347,8 @@ pub fn hash_node_presorted(sorted_children: &[Hash256; ARITY]) -> Hash256 {
     }
 
     // Compact encoding (8 bytes/felt): 128 bytes is far below
-    // MAX_SERIALIZED_BYTES and canonical children have canonical limbs,
-    // so this cannot fail.
+    // MAX_SERIALIZED_BYTES, so only a noncanonical limb can fail here.
     serialization::hash_bytes_compact(&data)
-        .expect("node payload is within bounds with canonical limbs")
 }
 
 /// Hash 4 child hashes into a parent node hash.
@@ -349,10 +357,14 @@ pub fn hash_node_presorted(sorted_children: &[Hash256; ARITY]) -> Hash256 {
 /// Uses compact Poseidon encoding (8 bytes/felt) - safe because internal
 /// nodes only contain fixed-size hash outputs, whose limbs are canonical.
 ///
+/// # Errors
+///
 /// Children must be canonical hash bytes (see [`is_canonical_hash`]); a
-/// noncanonical child panics here rather than silently aliasing another
-/// child's hash.
-pub fn hash_node(children: &[Hash256; ARITY]) -> Hash256 {
+/// noncanonical child would silently alias another child's hash mod p, so it
+/// is rejected. This is a public API that may receive attacker-controlled
+/// bytes, so like [`insert_at_position`] it produces a normal invalid-input
+/// error, not a panic.
+pub fn hash_node(children: &[Hash256; ARITY]) -> Result<Hash256, &'static str> {
     // Sort children to make hash order-independent
     let mut sorted = *children;
     sorted.sort();
@@ -364,10 +376,8 @@ pub fn hash_node(children: &[Hash256; ARITY]) -> Hash256 {
     }
 
     // Compact encoding (8 bytes/felt): 128 bytes is far below
-    // MAX_SERIALIZED_BYTES and canonical children have canonical limbs,
-    // so this cannot fail.
+    // MAX_SERIALIZED_BYTES, so only a noncanonical limb can fail here.
     serialization::hash_bytes_compact(&data)
-        .expect("node payload is within bounds with canonical limbs")
 }
 
 /// Empty hash value (all zeros).
@@ -487,7 +497,7 @@ mod tests {
         let leaf3 = [0x33; 32];
 
         // Compute expected root
-        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
+        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]).unwrap();
 
         // Create proof for leaf0 using from_unsorted
         let proof =
@@ -511,7 +521,7 @@ mod tests {
         let leaf2 = [0x22; 32];
         let leaf3 = [0x33; 32];
 
-        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
+        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]).unwrap();
 
         // leaf0 is smallest, so position should be 0
         let proof0 =
@@ -552,7 +562,7 @@ mod tests {
         let leaf2 = [0x22; 32];
         let leaf3 = [0x33; 32];
 
-        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
+        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]).unwrap();
 
         // Wrong leaf hash should fail
         let bad_proof = ZkMerkleProof::from_unsorted(
@@ -566,6 +576,18 @@ mod tests {
         assert!(!bad_proof.verify());
     }
 
+    /// `hash_node` / `hash_node_presorted` are public APIs that may receive
+    /// attacker-controlled bytes; like `insert_at_position`, a noncanonical
+    /// child (whose limbs would alias mod p) must produce a normal
+    /// invalid-input error, not a panic.
+    #[test]
+    fn hash_node_rejects_noncanonical_child_with_error_not_panic() {
+        let bad = [0xff; 32]; // every limb exceeds the Goldilocks modulus
+        let ok = [0x11; 32];
+        assert!(hash_node(&[bad, ok, ok, ok]).is_err());
+        assert!(hash_node_presorted(&[ok, ok, ok, bad]).is_err());
+    }
+
     /// `from_unsorted` hashes caller-supplied bytes, so noncanonical limbs
     /// (which the node hash rejects as mod-p aliases) must surface as an
     /// error, not a panic mid-hash.
@@ -575,7 +597,7 @@ mod tests {
         let leaf1 = [0x11; 32];
         let leaf2 = [0x22; 32];
         let leaf3 = [0x33; 32];
-        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
+        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]).unwrap();
 
         // Every limb of 0xff..ff exceeds the Goldilocks modulus.
         let err = ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], [0xff; 32], root)
@@ -597,7 +619,7 @@ mod tests {
         let leaf1 = [0x11; 32];
         let leaf2 = [0x22; 32];
         let leaf3 = [0x33; 32];
-        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
+        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]).unwrap();
 
         let mut proof =
             ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
@@ -656,7 +678,7 @@ mod tests {
         let leaf1 = hash_from_limbs([1, 0, 0, 0]);
         let leaf2 = hash_from_limbs([2, 0, 0, 0]);
         let leaf3 = hash_from_limbs([3, 0, 0, 0]);
-        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
+        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]).unwrap();
 
         let mut proof =
             ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
@@ -681,7 +703,7 @@ mod tests {
         let leaf1 = hash_from_limbs([1, 0, 0, 0]);
         let leaf2 = hash_from_limbs([2, 0, 0, 0]);
         let leaf3 = hash_from_limbs([3, 0, 0, 0]);
-        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]);
+        let root = hash_node(&[leaf0, leaf1, leaf2, leaf3]).unwrap();
 
         let mut proof =
             ZkMerkleProof::from_unsorted(0, vec![[leaf1, leaf2, leaf3]], leaf0, root).unwrap();
@@ -773,7 +795,7 @@ mod tests {
             positions_list.push(pos);
 
             // Compute parent hash for next level
-            current_hash = hash_node_presorted(&all_four);
+            current_hash = hash_node_presorted(&all_four).unwrap();
         }
 
         let root = current_hash;

--- a/formal/SPEC.md
+++ b/formal/SPEC.md
@@ -83,8 +83,8 @@ hermetic. Toolchain is pinned in `lean-toolchain` (Lean `v4.30`).
 |-------------|-------------|
 | `metadataConsistent` (asset/fee/block across non-dummy) | `build_private_batch_constraints` — `private_batch/circuit/circuit_logic.rs` |
 | `referenceFromFirstReal` (block ref = first non-dummy slot) | prefix-scan selection — `private_batch/circuit/circuit_logic.rs` (the `illuzen/full-shuffle` fix) |
-| `nullifiersReplaced` `DNull(u)=H(H(u))` | `hash_dummy_nullifier_pre_image` — `circuit_logic.rs` |
-| nullifier region canonically sorted (position decorrelated from exit slots) | `sort_digests4` over selected nullifiers — `circuit_logic.rs`; gadget in `common/src/gadgets.rs` |
+| `nullifiersReplaced` `DNull(u)=H(H(u))`, held of the pre-sort list (`∃ raw, … ∧ Perm` in `RPrivateBatch`) | `hash_dummy_nullifier_pre_image` — `circuit_logic.rs` |
+| `nullifiersSorted` over `digestLt`/`digestLE` (region in ascending canonical order; position decorrelated from exit slots) | `sort_digests4` over selected nullifiers — `circuit_logic.rs`; gadget in `common/src/gadgets.rs` |
 | `isDummyPrivateBatch = blockHash=0` (weaker sentinel) | dummy detection at private-batch — `circuit_logic.rs` |
 | `groupExits` / `matchSum` (per-slot group sum + first-occurrence dedup) | exit-account grouping loop — `circuit_logic.rs:214–287` |
 | **thm** `RPrivateBatch_value_conservation`: `outputExitTotal = rawOutputTotal` | derived from the grouping primitive (was an assumed conjunct) |

--- a/formal/SPEC.md
+++ b/formal/SPEC.md
@@ -83,7 +83,8 @@ hermetic. Toolchain is pinned in `lean-toolchain` (Lean `v4.30`).
 |-------------|-------------|
 | `metadataConsistent` (asset/fee/block across non-dummy) | `build_private_batch_constraints` — `private_batch/circuit/circuit_logic.rs` |
 | `referenceFromFirstReal` (block ref = first non-dummy slot) | prefix-scan selection — `private_batch/circuit/circuit_logic.rs` (the `illuzen/full-shuffle` fix) |
-| `nullifiersReplaced` `DNull(u)=H(H(u))` | `hash_dummy_nullifier_pre_image` — `circuit_logic.rs:338–346` |
+| `nullifiersReplaced` `DNull(u)=H(H(u))` | `hash_dummy_nullifier_pre_image` — `circuit_logic.rs` |
+| nullifier region canonically sorted (position decorrelated from exit slots) | `sort_digests4` over selected nullifiers — `circuit_logic.rs`; gadget in `common/src/gadgets.rs` |
 | `isDummyPrivateBatch = blockHash=0` (weaker sentinel) | dummy detection at private-batch — `circuit_logic.rs` |
 | `groupExits` / `matchSum` (per-slot group sum + first-occurrence dedup) | exit-account grouping loop — `circuit_logic.rs:214–287` |
 | **thm** `RPrivateBatch_value_conservation`: `outputExitTotal = rawOutputTotal` | derived from the grouping primitive (was an assumed conjunct) |

--- a/formal/WormholeSpec/Aggregation.lean
+++ b/formal/WormholeSpec/Aggregation.lean
@@ -159,13 +159,14 @@ def nullifiersReplaced (ro : RandomOracle) :
   | _,       _,       _       => False
 
 /-- Strict lexicographic order on digests, limb 0 most significant, each limb a
-    canonical 64-bit integer — exactly the order `digest4_lt` computes in-circuit
-    (`common/src/gadgets.rs`). -/
+    canonical 64-bit integer — exactly the order the `sort_digests4` network
+    computes in-circuit, via `halves8_lt` over the canonical 32-bit halves each
+    limb is split into at ingress (`common/src/gadgets.rs`). -/
 def digestLt (a b : Digest) : Prop :=
   a.x0 < b.x0 ∨ (a.x0 = b.x0 ∧ (a.x1 < b.x1 ∨ (a.x1 = b.x1 ∧
     (a.x2 < b.x2 ∨ (a.x2 = b.x2 ∧ a.x3 < b.x3)))))
 
-/-- Non-strict companion of `digestLt` (`digest4_lt`-or-equal): the condition each
+/-- Non-strict companion of `digestLt` (`halves8_lt`-or-equal): the condition each
     comparator of the sorting network leaves established between adjacent slots. -/
 def digestLE (a b : Digest) : Prop := digestLt a b ∨ a = b
 

--- a/formal/WormholeSpec/Aggregation.lean
+++ b/formal/WormholeSpec/Aggregation.lean
@@ -9,6 +9,10 @@
       position-independent selection from the `illuzen/full-shuffle` fix), with
       an all-dummy batch settling to a zero block hash;
     * dummy-nullifier replacement `DNull(u) = H(H(u))`;
+    * the nullifier region emitted as a *canonically sorted permutation* of the
+      per-slot selections (`sort_digests4`, the `illuzen/v12-5089` privacy fix):
+      output position no longer identifies the producing leaf slot, so payout
+      slots cannot be linked to nullifiers positionally;
     * the exit *grouping/dedup* primitive (`groupExits`) that builds the `2N`
       settled slots.
 
@@ -140,7 +144,12 @@ def referenceFromFirstReal (leaves : List LeafPublic) (out : PrivateBatchOutput)
   | none   => out.blockHash = Digest.zero
 
 /-- Per-slot nullifier output: real children forward `nullifier`; private-batch dummies
-    are replaced by `DNull(u)` for the witnessed preimage `u`. -/
+    are replaced by `DNull(u)` for the witnessed preimage `u`.
+
+    This is the *pre-sort* per-slot correspondence: slot `i` of the list relates
+    to leaf `i`. The circuit no longer emits this list positionally — the output
+    region is a canonically sorted permutation of it (see `nullifiersSorted` and
+    the `∃ raw, … ∧ Perm` conjunct of `RPrivateBatch`). -/
 def nullifiersReplaced (ro : RandomOracle) :
     List LeafPublic → List (List Felt) → List Digest → Prop
   | [],      [],      []      => True
@@ -148,6 +157,23 @@ def nullifiersReplaced (ro : RandomOracle) :
       (n = if isDummyPrivateBatch p then ro.dummyNull u else p.nullifier) ∧
       nullifiersReplaced ro ps us ns
   | _,       _,       _       => False
+
+/-- Strict lexicographic order on digests, limb 0 most significant, each limb a
+    canonical 64-bit integer — exactly the order `digest4_lt` computes in-circuit
+    (`common/src/gadgets.rs`). -/
+def digestLt (a b : Digest) : Prop :=
+  a.x0 < b.x0 ∨ (a.x0 = b.x0 ∧ (a.x1 < b.x1 ∨ (a.x1 = b.x1 ∧
+    (a.x2 < b.x2 ∨ (a.x2 = b.x2 ∧ a.x3 < b.x3)))))
+
+/-- Non-strict companion of `digestLt` (`digest4_lt`-or-equal): the condition each
+    comparator of the sorting network leaves established between adjacent slots. -/
+def digestLE (a b : Digest) : Prop := digestLt a b ∨ a = b
+
+/-- The nullifier region is in ascending canonical order (`sort_digests4`): every
+    pair, not just adjacent ones, is ordered. For the total, transitive `digestLE`
+    this `Pairwise` form is the standard sortedness predicate and coincides with
+    the adjacent-pair chain the network's comparators enforce. -/
+def nullifiersSorted (ns : List Digest) : Prop := ns.Pairwise digestLE
 
 /--
 `RPrivateBatch ro leaves us out` holds iff the private-batch wrapper accepts children `leaves`
@@ -159,13 +185,22 @@ witness layout exactly: `PrivateBatchCircuitTargets.dummy_nullifier_pre_images` 
 per dummy — see `private_batch/circuit/circuit_logic.rs:46–47, 76–85`. The wrapper reads
 slot `i`'s preimage only when slot `i` is a dummy (`select(is_dummy_i, …)`), so the
 per-child length bookkeeping here (`out.nullifiers.length = leaves.length`) lines up
-with the circuit.
+with the circuit (permutation preserves length).
+
+NULLIFIER ORDERING. The output nullifier region is NOT positional: the circuit
+routes the per-slot selections through `sort_digests4` before registering them,
+so `out.nullifiers` is a *canonically sorted permutation* of the per-slot list
+(`∃ raw, nullifiersReplaced … raw ∧ Perm`, plus `nullifiersSorted`). This is the
+`illuzen/v12-5089` privacy fix: exit slots stay in slot order, so a positional
+nullifier region would let an observer link payout `⌊i/2⌋`'s slots to nullifier
+`i`; sorting decorrelates them.
 -/
 def RPrivateBatch (ro : RandomOracle) (leaves : List LeafPublic) (us : List (List Felt))
     (out : PrivateBatchOutput) : Prop :=
   metadataConsistent leaves out ∧
   referenceFromFirstReal leaves out ∧
-  nullifiersReplaced ro leaves us out.nullifiers ∧
+  (∃ raw, nullifiersReplaced ro leaves us raw ∧ out.nullifiers.Perm raw) ∧
+  nullifiersSorted out.nullifiers ∧
   out.nullifiers.length = leaves.length ∧
   -- Primitive exit construction: the settled slots are *exactly* the in-circuit
   -- group/dedup of every child's two (account, amount) outputs. Value
@@ -277,7 +312,7 @@ theorem RPrivateBatch_value_conservation {ro : RandomOracle} {leaves : List Leaf
     {us : List (List Felt)} {out : PrivateBatchOutput} (h : RPrivateBatch ro leaves us out) :
     outputExitTotal out = rawOutputTotal leaves := by
   unfold outputExitTotal
-  rw [h.2.2.2.2]
+  rw [h.2.2.2.2.2]
   exact groupExits_childPairs leaves
 
 -- ── No-wraparound bound (makes the Phase-2 field hypothesis explicit) ────────

--- a/formal/WormholeSpec/AggregationBridge.lean
+++ b/formal/WormholeSpec/AggregationBridge.lean
@@ -15,8 +15,10 @@
   over `Felt = ℕ` and does not import the plonky2 spec). Concretely:
 
     * nullifier per slot      `select(is_dummy, H(H u), real)`  — `Plonky2Spec.Wrapper.nullifier_replacement`
-    * nullifier sort          `sort_digests4` comparator network — gadget-level (canonicity-enforced
-                              comparators; see `common/src/gadgets.rs`), surfaced here as the
+    * nullifier sort          `sort_digests4` comparator network — gadget-level (limbs are split
+                              into canonical 32-bit halves once at ingress; the `halves8_lt`
+                              comparators route those already-constrained halves; see
+                              `common/src/gadgets.rs`), surfaced here as the
                               `nullsPerm`/`nullsSorted` fields of `PrivateBatchCircuit`
     * exit grouping/dedup     `select`/`matchSum`/`groupAux`     — `Plonky2Spec.Wrapper.{match_contribution, dedup_select}`
     * block reference         first-real prefix scan             — `Plonky2Spec.Wrapper.scanFirst_correct`

--- a/formal/WormholeSpec/AggregationBridge.lean
+++ b/formal/WormholeSpec/AggregationBridge.lean
@@ -15,6 +15,9 @@
   over `Felt = ℕ` and does not import the plonky2 spec). Concretely:
 
     * nullifier per slot      `select(is_dummy, H(H u), real)`  — `Plonky2Spec.Wrapper.nullifier_replacement`
+    * nullifier sort          `sort_digests4` comparator network — gadget-level (canonicity-enforced
+                              comparators; see `common/src/gadgets.rs`), surfaced here as the
+                              `nullsPerm`/`nullsSorted` fields of `PrivateBatchCircuit`
     * exit grouping/dedup     `select`/`matchSum`/`groupAux`     — `Plonky2Spec.Wrapper.{match_contribution, dedup_select}`
     * block reference         first-real prefix scan             — `Plonky2Spec.Wrapper.scanFirst_correct`
     * metadata `or`-clause    `or(is_dummy, matches) = 1`        — `Plonky2Spec.Wrapper.{block_consistency, real_block_matches}`
@@ -28,7 +31,8 @@
 
     * `private_batch_bridge` does one piece of real work — relating the *functional*
       `buildNullifiers` the circuit computes to the *relational* `nullifiersReplaced`
-      (`nullifiersReplaced_build`); its other conjuncts (`metaOk`, `ref`, `exits`) are
+      (`nullifiersReplaced_build`), witnessing it as the `raw` list the sorted output
+      region permutes; its other conjuncts (`nullsSorted`, `metaOk`, `ref`, `exits`) are
       shared verbatim with `RPrivateBatch`. So `private_batch_sound` is "the `private_batch_proof_sound` axiom
       + that one modest nullifier lemma".
     * `public_batch_bridge` is the *identity*. The public-batch wrapper conditions are
@@ -88,13 +92,24 @@ theorem buildNullifiers_length (ro : RandomOracle) :
 /-- The private-batch wrapper constraints, as the circuit enforces them on the decoded
     public inputs (`build_private_batch_constraints`). The metadata/reference clauses
     are the satisfied form of the `or(is_dummy, matches)` constraint and the first-real
-    scan; the nullifier/exit clauses are the `select`/grouping outputs. -/
+    scan; the nullifier clauses are the `select` outputs routed through the
+    `sort_digests4` network; the exit clause is the grouping output.
+
+    The two nullifier fields mirror the sorting network's two guarantee layers
+    (`common/src/gadgets.rs::sort_digests4`): the output is structurally a
+    permutation of the per-slot selections (each comparator emits `{a, b}` as a
+    multiset for either flag value), and the ascending order is enforced against
+    malicious provers (canonicity-constrained limb splits). -/
 structure PrivateBatchCircuit (ro : RandomOracle) (leaves : List LeafPublic)
     (us : List (List Felt)) (out : PrivateBatchOutput) : Prop where
   /-- One dummy-nullifier preimage per leaf slot. -/
   uslen : us.length = leaves.length
-  /-- Per-slot `select(is_dummy, H(H u), real)`. -/
-  nulls : out.nullifiers = buildNullifiers ro leaves us
+  /-- The output region is a permutation of the per-slot
+      `select(is_dummy, H(H u), real)` selections (sorting-network guarantee 1). -/
+  nullsPerm : out.nullifiers.Perm (buildNullifiers ro leaves us)
+  /-- The output region is in ascending canonical order (sorting-network
+      guarantee 2). -/
+  nullsSorted : nullifiersSorted out.nullifiers
   /-- The `2N` settled slots are the in-circuit group/dedup of every child's outputs. -/
   exits : out.exitSlots = groupExits (childPairs leaves)
   /-- Each non-dummy child agrees with the aggregate header (the `or`-clause, satisfied). -/
@@ -106,9 +121,11 @@ structure PrivateBatchCircuit (ro : RandomOracle) (leaves : List LeafPublic)
 theorem private_batch_bridge {ro : RandomOracle} {leaves : List LeafPublic}
     {us : List (List Felt)} {out : PrivateBatchOutput}
     (h : PrivateBatchCircuit ro leaves us out) : RPrivateBatch ro leaves us out := by
-  refine ⟨h.metaOk, h.ref, ?_, ?_, h.exits⟩
-  · rw [h.nulls]; exact nullifiersReplaced_build ro leaves us h.uslen
-  · rw [h.nulls]; exact buildNullifiers_length ro leaves us h.uslen
+  refine ⟨h.metaOk, h.ref,
+    ⟨buildNullifiers ro leaves us, nullifiersReplaced_build ro leaves us h.uslen,
+      h.nullsPerm⟩,
+    h.nullsSorted, ?_, h.exits⟩
+  exact h.nullsPerm.length_eq.trans (buildNullifiers_length ro leaves us h.uslen)
 
 /-- **Private-batch soundness (end to end).** A satisfied private-batch aggregation circuit whose
     recursion gadget accepted every child leaf proof attests both the private-batch relation

--- a/wormhole/aggregator/Cargo.toml
+++ b/wormhole/aggregator/Cargo.toml
@@ -20,8 +20,11 @@ wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path =
 wormhole-prover = { package = "qp-wormhole-prover", version = "=3.1.0", path = "../prover", default-features = false }
 zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common" }
 
+# Only used by the std-gated artifact reader (O_NONBLOCK open); optional and
+# std-gated so --no-default-features builds keep libc (and libc/std) out of
+# the dependency graph entirely.
 [target.'cfg(unix)'.dependencies]
-libc = "=0.2.186"
+libc = { version = "=0.2.186", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -35,6 +38,7 @@ no_zk = []
 profile = ["qp-plonky2/rand", "qp-plonky2/timing", "std"]
 std = [
 	"anyhow/std",
+	"dep:libc",
 	"qp-plonky2/std",
 	"wormhole-circuit/std",
 	"wormhole-prover/std",

--- a/wormhole/aggregator/Cargo.toml
+++ b/wormhole/aggregator/Cargo.toml
@@ -20,6 +20,9 @@ wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path =
 wormhole-prover = { package = "qp-wormhole-prover", version = "=3.1.0", path = "../prover", default-features = false }
 zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common" }
 
+[target.'cfg(unix)'.dependencies]
+libc = "=0.2.186"
+
 [dev-dependencies]
 criterion = { workspace = true }
 env_logger = "=0.11.9"

--- a/wormhole/aggregator/benches/aggregator.rs
+++ b/wormhole/aggregator/benches/aggregator.rs
@@ -40,12 +40,30 @@ fn make_private_prover() -> PrivateBatchProver {
         .expect("Failed to load private-batch prover from binaries dir")
 }
 
-/// Generate a dummy private-batch proof over "PUBLIC_BATCH_INNER_NUM_LEAVES" dummy leaves.
-fn generate_dummy_private_batch_proof() -> Proof {
-    let dummy_leaf_proof = load_dummy_leaf_proof();
+/// Generate a REAL private-batch proof: one real leaf (genuine block hash
+/// computed from the test header fields) padded with dummy leaves.
+///
+/// The public-batch benches need a non-dummy proof because
+/// `PublicBatchProver::commit` rejects all-dummy batches (they settle nothing
+/// on-chain). Proving cost is witness-independent, so this measures the same
+/// work as a production batch.
+fn generate_real_private_batch_proof() -> Proof {
+    use test_helpers::TestInputs as _;
+    use wormhole_circuit::block_header::header::HeaderInputs;
+    use wormhole_circuit::inputs::CircuitInputs;
+
+    let mut inputs = CircuitInputs::test_inputs_0();
+    inputs.public.block_hash = HeaderInputs::try_from(&inputs)
+        .expect("header inputs from test inputs")
+        .block_hash();
+    let real_leaf = wormhole_prover::build_fresh()
+        .commit(&inputs)
+        .expect("Failed to commit real leaf inputs")
+        .prove()
+        .expect("Failed to prove real leaf");
     make_private_prover()
-        .aggregate(vec![dummy_leaf_proof; PUBLIC_BATCH_INNER_NUM_LEAVES])
-        .unwrap()
+        .aggregate(vec![real_leaf])
+        .expect("Failed to aggregate real leaf into a private batch")
 }
 
 // A macro for creating an aggregation benchmark with a specified number of leaf proofs.
@@ -135,7 +153,7 @@ macro_rules! prove_public_batch_benchmark {
                     "Failed to generate private_batch circuit binaries for public_batch benchmark",
                 );
 
-            let proof = generate_dummy_private_batch_proof();
+            let proof = generate_real_private_batch_proof();
             generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs).expect(
                 "Failed to generate public_batch circuit binaries for public_batch benchmark",
             );
@@ -152,7 +170,7 @@ macro_rules! prove_public_batch_benchmark {
             let aggregator_address = BytesDigest::try_from(LAYER1_AGGREGATOR_ADDRESS)
                 .expect("Failed to create aggregator address bytes digest");
 
-            // The prover is driven directly: the benchmark batch reuses one dummy
+            // The prover is driven directly: the benchmark batch reuses one real
             // private-batch proof N times, which the ProofPool would reject as
             // duplicate nullifiers (and generating N distinct private batches
             // would dwarf the benchmark setup).
@@ -196,7 +214,7 @@ macro_rules! verify_public_batch_benchmark {
                     "Failed to generate private_batch circuit binaries for public_batch benchmark",
                 );
 
-            let proof = generate_dummy_private_batch_proof();
+            let proof = generate_real_private_batch_proof();
 
             generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs).expect(
                 "Failed to generate public_batch circuit binaries for public_batch benchmark",

--- a/wormhole/aggregator/benches/aggregator.rs
+++ b/wormhole/aggregator/benches/aggregator.rs
@@ -1,13 +1,10 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use plonky2::plonk::circuit_data::CommonCircuitData;
 use plonky2::plonk::proof::ProofWithPublicInputs;
-use plonky2::util::serialization::DefaultGateSerializer;
 use qp_wormhole_aggregator::aggregator::PublicBatchAggregator;
 use qp_wormhole_aggregator::common::utils::{
     canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
 };
 use qp_wormhole_aggregator::config::CircuitBinsConfig;
-use qp_wormhole_aggregator::dummy_proof::load_dummy_proof;
 use qp_wormhole_aggregator::private_batch::circuit::build::generate_private_batch_circuit_binaries;
 use qp_wormhole_aggregator::private_batch::prover::PrivateBatchProver;
 use qp_wormhole_aggregator::public_batch::circuit::build::generate_public_batch_circuit_binaries;
@@ -24,30 +21,19 @@ const LAYER1_AGGREGATOR_ADDRESS: [u8; 32] = [42u8; 32];
 
 type Proof = ProofWithPublicInputs<F, C, D>;
 
-fn load_dummy_leaf_proof() -> Proof {
-    let gate_serializer = DefaultGateSerializer;
-    let proof_bytes = std::fs::read(format!("{}/dummy_proof.bin", BINS_DIR))
-        .expect("Failed to read dummy proof bytes");
-    let common_circuit_data = std::fs::read(format!("{}/common.bin", BINS_DIR))
-        .expect("Failed to read common circuit data bytes");
-    let common = CommonCircuitData::from_bytes(common_circuit_data.to_vec(), &gate_serializer)
-        .expect("Failed to deserialize common circuit data");
-    load_dummy_proof(proof_bytes, &common).expect("Failed to load dummy proof from bytes")
-}
-
 fn make_private_prover() -> PrivateBatchProver {
     PrivateBatchProver::new_from_binaries_dir(Path::new(BINS_DIR))
         .expect("Failed to load private-batch prover from binaries dir")
 }
 
-/// Generate a REAL private-batch proof: one real leaf (genuine block hash
-/// computed from the test header fields) padded with dummy leaves.
+/// Generate a REAL leaf proof (genuine block hash computed from the test
+/// header fields) against the canonical leaf circuit.
 ///
-/// The public-batch benches need a non-dummy proof because
-/// `PublicBatchProver::commit` rejects all-dummy batches (they settle nothing
-/// on-chain). Proving cost is witness-independent, so this measures the same
-/// work as a production batch.
-fn generate_real_private_batch_proof() -> Proof {
+/// The benches need non-dummy leaves because both `PrivateBatchProver::commit`
+/// and `PublicBatchProver::commit` reject all-dummy batches (they settle
+/// nothing on-chain). Proving cost is witness-independent, so batches built
+/// from this proof measure the same work as production batches.
+fn generate_real_leaf_proof() -> Proof {
     use test_helpers::TestInputs as _;
     use wormhole_circuit::block_header::header::HeaderInputs;
     use wormhole_circuit::inputs::CircuitInputs;
@@ -56,13 +42,18 @@ fn generate_real_private_batch_proof() -> Proof {
     inputs.public.block_hash = HeaderInputs::try_from(&inputs)
         .expect("header inputs from test inputs")
         .block_hash();
-    let real_leaf = wormhole_prover::build_fresh()
+    wormhole_prover::build_fresh()
         .commit(&inputs)
         .expect("Failed to commit real leaf inputs")
         .prove()
-        .expect("Failed to prove real leaf");
+        .expect("Failed to prove real leaf")
+}
+
+/// Generate a REAL private-batch proof: one real leaf padded with dummy
+/// leaves; see [`generate_real_leaf_proof`].
+fn generate_real_private_batch_proof() -> Proof {
     make_private_prover()
-        .aggregate(vec![real_leaf])
+        .aggregate(vec![generate_real_leaf_proof()])
         .expect("Failed to aggregate real leaf into a private batch")
 }
 
@@ -70,7 +61,7 @@ fn generate_real_private_batch_proof() -> Proof {
 macro_rules! aggregate_proofs_benchmark {
     ($fn_name:ident, $num_leaf_proofs:expr) => {
         pub fn $fn_name(c: &mut Criterion) {
-            let proof = load_dummy_leaf_proof();
+            let proof = generate_real_leaf_proof();
 
             // Call "generate_private_batch_circuit_binaries" before we instantiate a new prover,
             // to ensure the binaries represent the circuit with the correct number of leaf proofs.
@@ -103,7 +94,7 @@ macro_rules! aggregate_proofs_benchmark {
 macro_rules! verify_aggregate_proof_benchmark {
     ($fn_name:ident, $num_leaf_proofs:expr) => {
         pub fn $fn_name(c: &mut Criterion) {
-            let proof = load_dummy_leaf_proof();
+            let proof = generate_real_leaf_proof();
 
             generate_private_batch_circuit_binaries(BINS_DIR, $num_leaf_proofs, true).expect(
                 "Failed to generate private_batch circuit binaries for aggregation benchmark",

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -41,9 +41,12 @@
 //! settlements observed by the regular
 //! [`PublicBatchAggregator::evict_settled`] cadence during the proving window
 //! are remembered, and [`PublicBatchAggregator::reinsert_batch`] drops the
-//! affected (now-stale) proofs instead of restoring them. Every taken batch
-//! MUST be handed back via [`PublicBatchAggregator::complete_batch`] (success)
-//! or [`PublicBatchAggregator::reinsert_batch`] (failure).
+//! affected (now-stale) proofs instead of restoring them. Hand every taken
+//! batch back via [`PublicBatchAggregator::complete_batch`] (success) or
+//! [`PublicBatchAggregator::reinsert_batch`] (failure); a batch that is
+//! instead dropped (e.g. its proving worker panicked) self-releases its
+//! nullifier reservations at the pool's next operation, so the affected
+//! spends can be resubmitted rather than staying wedged.
 
 use anyhow::{anyhow, bail, Context, Result};
 use plonky2::plonk::{

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -38,6 +38,14 @@ pub const MAX_ARTIFACT_FILE_BYTES: u64 = 64 * 1024 * 1024;
 /// Read a circuit-artifact file, refusing anything larger than
 /// [`MAX_ARTIFACT_FILE_BYTES`] before allocating for its contents.
 ///
+/// Only regular files are accepted. A FIFO, device node, or symlink to one
+/// planted at an artifact path would otherwise block `open` (a FIFO with no
+/// writer) or `read_to_end` (a stream that never reaches EOF) forever,
+/// independent of the size cap below. On unix the open uses `O_NONBLOCK` so
+/// even the FIFO-open case cannot stall; the file type is then checked via
+/// `fstat` on the opened handle before any read. `O_NONBLOCK` has no effect
+/// on regular-file opens or reads.
+///
 /// The size is checked via `fstat` on the already-opened handle (no
 /// stat-then-open race), and the read itself is additionally capped with
 /// `Read::take` in case the file grows after the check.
@@ -45,12 +53,26 @@ pub const MAX_ARTIFACT_FILE_BYTES: u64 = 64 * 1024 * 1024;
 pub fn read_artifact_file(path: &std::path::Path) -> Result<Vec<u8>> {
     use std::io::Read as _;
 
-    let file = std::fs::File::open(path)
+    let mut options = std::fs::File::options();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NONBLOCK);
+    }
+    let file = options
+        .open(path)
         .with_context(|| format!("failed to open artifact file {}", path.display()))?;
-    let claimed_len = file
+    let metadata = file
         .metadata()
-        .with_context(|| format!("failed to stat artifact file {}", path.display()))?
-        .len();
+        .with_context(|| format!("failed to stat artifact file {}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        bail!(
+            "artifact file {} is not a regular file; refusing to load it",
+            path.display()
+        );
+    }
+    let claimed_len = metadata.len();
     if claimed_len > MAX_ARTIFACT_FILE_BYTES {
         bail!(
             "artifact file {} is {} bytes, which exceeds the {} byte limit for \
@@ -552,6 +574,52 @@ mod tests {
             .unwrap();
         let err = read_artifact_file(&oversized).unwrap_err();
         assert!(err.to_string().contains("exceeds the"), "got: {err}");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A FIFO planted at an expected `*.bin` path must produce a prompt
+    /// invalid-artifact error, not a hang: a blocking `File::open` on a FIFO
+    /// with no writer stalls forever, before the size check can run,
+    /// converting artifact loading into a startup denial of service when the
+    /// artifact directory is untrusted (audit finding: non-regular files
+    /// bypass the bounded-read protections).
+    #[cfg(unix)]
+    #[test]
+    fn read_artifact_file_rejects_fifo_without_blocking() {
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let dir =
+            std::env::temp_dir().join(format!("qp-artifact-fifo-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let fifo = dir.join("leaf_common.bin");
+        let c_path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(
+            unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) },
+            0,
+            "mkfifo failed"
+        );
+
+        // Run the read on a helper thread so a regression (blocking open or
+        // read) surfaces as a test failure instead of hanging the suite.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let fifo_for_thread = fifo.clone();
+        std::thread::spawn(move || {
+            let _ = tx.send(read_artifact_file(&fifo_for_thread).map(drop));
+        });
+
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(result) => {
+                let err = result.unwrap_err();
+                assert!(
+                    err.to_string().contains("not a regular file"),
+                    "got: {err}"
+                );
+            }
+            Err(_) => panic!("read_artifact_file blocked on a FIFO artifact path"),
+        }
 
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -116,8 +116,14 @@ pub fn read_artifact_file(path: &std::path::Path) -> Result<Vec<u8>> {
 /// or the complete new set — never a mix. The unwritten window shrinks from
 /// the whole multi-minute build-and-write to the instants between renames of
 /// already-complete files.
+///
+/// Because staging opens with create-new semantics and publication renames
+/// over the final name, a symlink pre-planted at an artifact filename is
+/// replaced as an entry rather than followed, so a write can never be
+/// redirected onto the symlink's target. Public so `circuit-builder` can
+/// publish the leaf artifact set through the same path.
 #[cfg(feature = "std")]
-pub(crate) fn commit_artifact_set(
+pub fn commit_artifact_set(
     bins_dir: &std::path::Path,
     files: &[(&str, Vec<u8>)],
     remove_stale: &[&str],

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -288,11 +288,20 @@ pub fn sweep_stale_artifact_droppings(bins_dir: &std::path::Path) -> Result<usiz
         let path = entry.path();
         // Moved-aside entries can be directory-shaped (a planted directory
         // that a previous publish moved aside), so fall back accordingly.
-        if fs::remove_file(&path).is_err() {
-            let _ = fs::remove_dir_all(&path);
-        }
+        let dir_fallback = match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(_) => fs::remove_dir_all(&path),
+        };
         if !path.exists() {
             removed += 1;
+        } else if let Err(e) = dir_fallback {
+            // Don't fail the rebuild over an unremovable dropping, but don't
+            // let the accumulation this sweep exists to prevent silently
+            // resume either.
+            eprintln!(
+                "warning: failed to remove orphaned artifact dropping {}: {e}",
+                path.display()
+            );
         }
     }
     if removed > 0 {
@@ -807,6 +816,35 @@ mod tests {
         // A missing directory is a no-op, not an error (fresh builder runs).
         std::fs::remove_dir_all(&dir).unwrap();
         assert_eq!(sweep_stale_artifact_droppings(&dir).unwrap(), 0);
+    }
+
+    /// An unremovable dropping must not fail the sweep, and must not be
+    /// counted as removed (it is reported on stderr, not silently skipped —
+    /// the warning itself is not capturable in-process, so this asserts the
+    /// count and survival).
+    #[test]
+    #[cfg(unix)]
+    fn sweep_survives_unremovable_dropping_without_counting_it() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("qp-sweep-stuck-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // A directory-shaped dropping whose contents cannot be unlinked:
+        // remove_file fails (it is a directory) and remove_dir_all fails
+        // (no write permission on the directory itself).
+        let stuck = dir.join(".common.bin.old-42-00112233445566ff");
+        std::fs::create_dir(&stuck).unwrap();
+        std::fs::write(stuck.join("inner"), b"x").unwrap();
+        std::fs::set_permissions(&stuck, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let removed = sweep_stale_artifact_droppings(&dir).unwrap();
+        assert_eq!(removed, 0, "a still-present entry must not be counted");
+        assert!(stuck.exists());
+
+        std::fs::set_permissions(&stuck, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -98,6 +98,126 @@ pub fn read_artifact_file(path: &std::path::Path) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
+/// Publish a matched set of artifact files into `bins_dir` all-or-nothing,
+/// optionally removing stale files that are no longer part of the set.
+///
+/// Artifact files are consumed as matched sets (loaders pin them against a
+/// canonical circuit rebuild and verify templates against the loaded verifier
+/// data), so a directory holding a fresh file from one generation beside a
+/// stale file from another is rejected until regenerated. Naive in-place
+/// writes create exactly that state whenever a re-run fails between files.
+///
+/// Instead, every file is first staged under a fresh unpredictable temp name
+/// in the same directory (exclusive create, so a pre-planted entry or symlink
+/// is never adopted), and only after all stages succeed are the previous
+/// artifacts (including any `remove_stale` entries) moved aside and the
+/// staged files renamed into place. Any failure rolls the moved-aside
+/// originals back, so an error always leaves either the complete previous set
+/// or the complete new set — never a mix. The unwritten window shrinks from
+/// the whole multi-minute build-and-write to the instants between renames of
+/// already-complete files.
+#[cfg(feature = "std")]
+pub(crate) fn commit_artifact_set(
+    bins_dir: &std::path::Path,
+    files: &[(&str, Vec<u8>)],
+    remove_stale: &[&str],
+) -> Result<()> {
+    use std::fs;
+    use std::io::Write as _;
+
+    let unique = format!("{}-{:016x}", std::process::id(), rand::random::<u64>());
+    let tmp_path = |name: &str| bins_dir.join(format!(".{name}.tmp-{unique}"));
+    let old_path = |name: &str| bins_dir.join(format!(".{name}.old-{unique}"));
+    let all_names = || {
+        files
+            .iter()
+            .map(|(name, _)| *name)
+            .chain(remove_stale.iter().copied())
+    };
+
+    // Phase 1: stage every file. Any failure here leaves the originals untouched.
+    for (i, (name, bytes)) in files.iter().enumerate() {
+        let path = tmp_path(name);
+        let staged = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .and_then(|mut f| f.write_all(bytes));
+        if let Err(e) = staged {
+            for (name, _) in &files[..=i] {
+                let _ = fs::remove_file(tmp_path(name));
+            }
+            return Err(e).with_context(|| format!("Failed to stage {}", path.display()));
+        }
+    }
+
+    // Phase 2: move previous artifacts (and stale files) aside, then swap the
+    // staged set in.
+    let mut moved_aside: Vec<&str> = Vec::new();
+    let mut swapped: Vec<&str> = Vec::new();
+    let swap_result = (|| -> Result<()> {
+        for name in all_names() {
+            match fs::rename(bins_dir.join(name), old_path(name)) {
+                Ok(()) => moved_aside.push(name),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!(
+                            "Failed to move previous {} aside",
+                            bins_dir.join(name).display()
+                        )
+                    })
+                }
+            }
+        }
+        for (name, _) in files {
+            fs::rename(tmp_path(name), bins_dir.join(name)).with_context(|| {
+                format!(
+                    "Failed to move staged artifact into place at {}",
+                    bins_dir.join(name).display()
+                )
+            })?;
+            swapped.push(name);
+        }
+        Ok(())
+    })();
+
+    match swap_result {
+        Ok(()) => {
+            // The new set is committed; the moved-aside copies (and moved-aside
+            // stale files) are redundant.
+            for name in moved_aside {
+                let old = old_path(name);
+                if fs::remove_file(&old).is_err() {
+                    let _ = fs::remove_dir_all(&old);
+                }
+            }
+            Ok(())
+        }
+        Err(e) => {
+            // Restore the previous set: renaming the old copy back atomically
+            // overwrites any already-swapped new file; names that had no old
+            // copy get their new file removed instead.
+            for name in all_names() {
+                let final_path = bins_dir.join(name);
+                if moved_aside.contains(&name) {
+                    if fs::rename(old_path(name), &final_path).is_err() {
+                        // A blocking entry (e.g. an already-swapped file under
+                        // a directory-shaped old copy) must not strand the
+                        // rollback in a mixed state.
+                        let _ = fs::remove_file(&final_path);
+                        let _ = fs::rename(old_path(name), &final_path);
+                    }
+                } else if swapped.contains(&name) {
+                    let _ = fs::remove_file(&final_path);
+                }
+                let _ = fs::remove_file(tmp_path(name));
+            }
+            Err(e)
+        }
+    }
+}
+
 /// Load verifier circuit data (common + verifier-only) from serialized bytes.
 pub fn load_verifier_data_from_bytes(
     common_bytes: &[u8],

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -739,10 +739,7 @@ mod tests {
         match rx.recv_timeout(std::time::Duration::from_secs(5)) {
             Ok(result) => {
                 let err = result.unwrap_err();
-                assert!(
-                    err.to_string().contains("not a regular file"),
-                    "got: {err}"
-                );
+                assert!(err.to_string().contains("not a regular file"), "got: {err}");
             }
             Err(_) => panic!("read_artifact_file blocked on a FIFO artifact path"),
         }

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -111,11 +111,23 @@ pub fn read_artifact_file(path: &std::path::Path) -> Result<Vec<u8>> {
 /// in the same directory (exclusive create, so a pre-planted entry or symlink
 /// is never adopted), and only after all stages succeed are the previous
 /// artifacts (including any `remove_stale` entries) moved aside and the
-/// staged files renamed into place. Any failure rolls the moved-aside
-/// originals back, so an error always leaves either the complete previous set
-/// or the complete new set — never a mix. The unwritten window shrinks from
-/// the whole multi-minute build-and-write to the instants between renames of
-/// already-complete files.
+/// staged files renamed into place. Any HANDLED failure rolls the moved-aside
+/// originals back, so an error return always leaves either the complete
+/// previous set or the complete new set — never a mix. The unwritten window
+/// shrinks from the whole multi-minute build-and-write to the instants
+/// between renames of already-complete files.
+///
+/// A hard crash (SIGKILL, power loss) inside that window is NOT rolled back:
+/// dying between the move-aside loop and the rename-in loop leaves the
+/// directory with no live artifacts plus orphaned `.<name>.old-<pid>-<rand>`
+/// (and possibly `.<name>.tmp-<pid>-<rand>`) entries. That state is
+/// fail-closed — loaders see missing artifacts, never a mixed generation —
+/// but it needs regeneration to recover. The builder entry points call
+/// [`sweep_stale_artifact_droppings`] before regenerating so those orphans do
+/// not accumulate. For whole-directory consistency across all stages, the
+/// staging-directory swap in `circuit-builder`'s
+/// `generate_all_circuit_binaries` remains the only true whole-set atomic
+/// primitive.
 ///
 /// Because staging opens with create-new semantics and publication renames
 /// over the final name, a symlink pre-planted at an artifact filename is
@@ -222,6 +234,74 @@ pub fn commit_artifact_set(
             Err(e)
         }
     }
+}
+
+/// Remove orphaned `commit_artifact_set` droppings from `bins_dir`.
+///
+/// A publish hard-killed mid-swap (SIGKILL, power loss) leaves behind
+/// `.<name>.tmp-<pid>-<rand>` staged files and/or `.<name>.old-<pid>-<rand>`
+/// moved-aside originals that no later run adopts (the random suffix is fresh
+/// per call). This sweep deletes exactly those patterns: a leading dot, a
+/// `.tmp-`/`.old-` marker, and the `<pid>-<16 hex>` suffix `commit_artifact_set`
+/// generates. Unrelated dotfiles are left alone.
+///
+/// Only called from the builder entry points, immediately before
+/// regeneration: on the read/prove paths a sweep could race a concurrent
+/// publisher and delete its in-flight staging files, but a builder is about
+/// to replace the whole set anyway. Returns the number of entries removed.
+#[cfg(feature = "std")]
+pub fn sweep_stale_artifact_droppings(bins_dir: &std::path::Path) -> Result<usize> {
+    use std::fs;
+
+    fn is_dropping(name: &str) -> bool {
+        if !name.starts_with('.') {
+            return false;
+        }
+        let Some(idx) = name.rfind(".tmp-").or_else(|| name.rfind(".old-")) else {
+            return false;
+        };
+        // Suffix shape from commit_artifact_set: "<pid>-<16 lowercase hex>".
+        let suffix = &name[idx + ".tmp-".len()..];
+        let Some((pid, rand)) = suffix.split_once('-') else {
+            return false;
+        };
+        !pid.is_empty()
+            && pid.bytes().all(|b| b.is_ascii_digit())
+            && rand.len() == 16
+            && rand.bytes().all(|b| b.is_ascii_hexdigit())
+    }
+
+    let entries = match fs::read_dir(bins_dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(e).with_context(|| format!("Failed to list {}", bins_dir.display())),
+    };
+
+    let mut removed = 0usize;
+    for entry in entries {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !is_dropping(name) {
+            continue;
+        }
+        let path = entry.path();
+        // Moved-aside entries can be directory-shaped (a planted directory
+        // that a previous publish moved aside), so fall back accordingly.
+        if fs::remove_file(&path).is_err() {
+            let _ = fs::remove_dir_all(&path);
+        }
+        if !path.exists() {
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        println!(
+            "Removed {removed} orphaned staging/backup entries from {} (leftovers of an interrupted artifact publish)",
+            bins_dir.display()
+        );
+    }
+    Ok(removed)
 }
 
 /// Load verifier circuit data (common + verifier-only) from serialized bytes.
@@ -672,12 +752,61 @@ pub fn private_batch_num_leaves_from_padded_pi_len(pi_len: usize) -> Result<usiz
 #[cfg(test)]
 mod tests {
     use super::private_batch_num_leaves_from_padded_pi_len;
-    use super::{read_artifact_file, MAX_ARTIFACT_FILE_BYTES};
+    use super::{read_artifact_file, sweep_stale_artifact_droppings, MAX_ARTIFACT_FILE_BYTES};
 
     #[test]
     fn private_batch_num_leaves_from_padded_pi_len_rejects_malformed_lengths() {
         let err = private_batch_num_leaves_from_padded_pi_len(9).unwrap_err();
         assert!(err.to_string().contains("malformed"));
+    }
+
+    /// The sweep must remove exactly the `.<name>.tmp-<pid>-<rand>` /
+    /// `.<name>.old-<pid>-<rand>` patterns `commit_artifact_set` generates —
+    /// including directory-shaped moved-aside entries — and leave everything
+    /// else (live artifacts, unrelated dotfiles, near-miss names) alone.
+    #[test]
+    fn sweep_removes_publish_droppings_and_nothing_else() {
+        let dir = std::env::temp_dir().join(format!("qp-sweep-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Droppings: staged file, moved-aside file, directory-shaped
+        // moved-aside entry (a planted directory a publish moved aside).
+        std::fs::write(dir.join(".common.bin.tmp-42-00112233445566ff"), b"x").unwrap();
+        std::fs::write(dir.join(".verifier.bin.old-42-00112233445566ff"), b"x").unwrap();
+        std::fs::create_dir(dir.join(".config.json.old-42-aabbccddeeff0011")).unwrap();
+
+        // Survivors: live artifact, unrelated dotfiles, near-miss suffixes.
+        std::fs::write(dir.join("common.bin"), b"live").unwrap();
+        std::fs::write(dir.join(".gitignore"), b"*.log").unwrap();
+        std::fs::write(dir.join(".config.json.old-backup"), b"manual backup").unwrap();
+        std::fs::write(dir.join(".x.tmp-notapid-00112233445566ff"), b"x").unwrap();
+        std::fs::write(dir.join(".x.tmp-42-shorthex"), b"x").unwrap();
+        std::fs::write(dir.join("common.bin.tmp-42-00112233445566ff"), b"no dot").unwrap();
+
+        let removed = sweep_stale_artifact_droppings(&dir).unwrap();
+        assert_eq!(removed, 3, "exactly the three droppings must be removed");
+
+        let mut names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                ".config.json.old-backup".to_string(),
+                ".gitignore".to_string(),
+                ".x.tmp-42-shorthex".to_string(),
+                ".x.tmp-notapid-00112233445566ff".to_string(),
+                "common.bin".to_string(),
+                "common.bin.tmp-42-00112233445566ff".to_string(),
+            ]
+        );
+
+        // A missing directory is a no-op, not an error (fresh builder runs).
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert_eq!(sweep_stale_artifact_droppings(&dir).unwrap(), 0);
     }
 
     #[test]

--- a/wormhole/aggregator/src/config.rs
+++ b/wormhole/aggregator/src/config.rs
@@ -56,12 +56,18 @@ impl CircuitBinsConfig {
 
     /// Load config from a directory containing circuit binaries.
     ///
+    /// Reads through [`crate::common::utils::read_artifact_file`], which
+    /// rejects non-regular files and oversized inputs, so an untrusted bins
+    /// directory cannot stall or memory-starve config loading (this runs
+    /// before any of the `*.bin` artifacts are touched).
+    ///
     /// # Errors
     /// Returns an error if the file cannot be read, parsed, or contains invalid values.
     pub fn load<P: AsRef<Path>>(bins_dir: P) -> Result<Self> {
         let config_path = bins_dir.as_ref().join("config.json");
-        let config_str = std::fs::read_to_string(&config_path)
-            .map_err(|e| anyhow!("failed to read {}: {}", config_path.display(), e))?;
+        let config_bytes = crate::common::utils::read_artifact_file(&config_path)?;
+        let config_str = String::from_utf8(config_bytes)
+            .map_err(|e| anyhow!("{} is not valid UTF-8: {}", config_path.display(), e))?;
         let config: Self = serde_json::from_str(&config_str)
             .map_err(|e| anyhow!("failed to parse {}: {}", config_path.display(), e))?;
         config.validate()?;

--- a/wormhole/aggregator/src/config.rs
+++ b/wormhole/aggregator/src/config.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Result};
 pub use qp_wormhole_inputs::validate_proof_count;
 use serde::{Deserialize, Serialize};
-use std::fs::write;
 use std::path::Path;
 
 /// Maximum number of proofs aggregated per layer.
@@ -74,14 +73,22 @@ impl CircuitBinsConfig {
         Ok(config)
     }
 
-    /// Save config to a directory
+    /// Save config to a directory.
+    ///
+    /// Published through [`crate::common::utils::commit_artifact_set`]
+    /// (exclusive-create staging plus rename into place), so a symlink
+    /// pre-planted at `config.json` is replaced rather than followed and a
+    /// failed write never leaves a truncated config behind.
     pub fn save<P: AsRef<Path>>(&self, bins_dir: P) -> Result<()> {
-        let config_path = bins_dir.as_ref().join("config.json");
+        let bins_dir = bins_dir.as_ref();
         let config_str = serde_json::to_string_pretty(self)
             .map_err(|e| anyhow!("failed to serialize config: {}", e))?;
-        write(&config_path, config_str)
-            .map_err(|e| anyhow!("failed to write {}: {}", config_path.display(), e))?;
-        println!("Config saved to {}", config_path.display());
+        crate::common::utils::commit_artifact_set(
+            bins_dir,
+            &[("config.json", config_str.into_bytes())],
+            &[],
+        )?;
+        println!("Config saved to {}", bins_dir.join("config.json").display());
         Ok(())
     }
 }

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -16,7 +16,10 @@
 //! indexed, so duplicate spends are still rejected at admission and
 //! settlements observed by [`ProofPool::evict_settled`] during the proving
 //! window are remembered: `reinsert` drops the affected proofs instead of
-//! restoring dead weight.
+//! restoring dead weight. A batch that is DROPPED instead of handed back
+//! (e.g. the proving worker panicked) self-releases its reservations at the
+//! pool's next operation via [`TakenBatch`]'s drop guard, so no spend is ever
+//! permanently wedged by a lost batch.
 //!
 //! Staleness: a queued proof becomes worthless once any of its nullifiers is
 //! settled on-chain (e.g. another miner included the same private batch, or a
@@ -44,6 +47,7 @@
 //! template.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, ensure, Result};
@@ -156,21 +160,39 @@ struct PooledProof {
     admitted_at: Instant,
 }
 
+/// Shared inbox for nullifier reservations released by a [`TakenBatch`] that
+/// was dropped without being handed back. Drained by the pool at the start of
+/// its next operation. The mutex is only ever held to push or drain a `Vec`,
+/// never across pool logic, so it cannot deadlock with any pool lock the
+/// operator wraps around [`ProofPool`] itself.
+type OrphanedReservations = Arc<Mutex<Vec<BytesDigest>>>;
+
 /// A batch of admission-verified proofs removed from the pool for proving.
 ///
 /// Opaque by design: it can only be produced by [`ProofPool::take_batch`], so
 /// [`ProofPool::reinsert`] can restore it on proving failure without repeating
 /// cryptographic verification.
 ///
-/// Callers MUST hand it back: [`ProofPool::complete`] on proving success or
+/// Hand it back via [`ProofPool::complete`] on proving success or
 /// [`ProofPool::reinsert`] on failure. The pool keeps the batch's nullifiers
 /// indexed while it is out (so duplicates stay rejected and settlements
-/// observed meanwhile are tracked); dropping the batch without either call
-/// leaks those reservations, permanently blocking re-admission of the spends.
+/// observed meanwhile are tracked). If the batch is instead dropped — e.g.
+/// the proving worker panicked and unwound — its `Drop` impl deposits the
+/// reservations into the pool's orphan inbox and the pool releases them at
+/// its next operation, so the affected spends can be resubmitted instead of
+/// being wedged until the aggregator is rebuilt. The dropped proofs
+/// themselves are gone; clients must resubmit them (re-admission re-verifies
+/// as usual).
 #[derive(Debug)]
 pub struct TakenBatch {
     key: BatchKey,
     proofs: Vec<PooledProof>,
+    /// Where `Drop` deposits this batch's reservations; shared with the pool
+    /// that produced it.
+    orphaned: OrphanedReservations,
+    /// Cleared by `complete`/`reinsert` before they consume the batch, so an
+    /// explicit hand-back does not also release through `Drop`.
+    armed: bool,
 }
 
 impl TakenBatch {
@@ -189,6 +211,23 @@ impl TakenBatch {
     /// Clone the contained proofs (e.g. to feed a prover's `commit`).
     pub fn proofs(&self) -> Vec<Proof> {
         self.proofs.iter().map(|q| q.proof.clone()).collect()
+    }
+}
+
+impl Drop for TakenBatch {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // Robust to a poisoned mutex: a panic elsewhere must not turn into a
+        // permanently wedged reservation, which is the bug this guards against.
+        let mut orphaned = self
+            .orphaned
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for queued in &self.proofs {
+            orphaned.extend(queued.nullifiers.iter().copied());
+        }
     }
 }
 
@@ -224,6 +263,10 @@ pub struct ProofPool {
     /// instead of restoring it) and [`Self::complete`]. Bounded by the size of
     /// outstanding taken batches.
     settled_while_taken: HashSet<BytesDigest>,
+    /// Reservations deposited by dropped (not handed-back) [`TakenBatch`]es,
+    /// released by [`Self::reap_orphaned`] at the start of every pool
+    /// operation. Shared with every `TakenBatch` this pool produces.
+    orphaned: OrphanedReservations,
     /// Start of the current verification budget window (fixed-window counter).
     verify_window_started: Instant,
     /// Verification attempts (successful or not) in the current window.
@@ -283,9 +326,30 @@ impl ProofPool {
             nullifier_index: HashMap::new(),
             taken_nullifiers: HashSet::new(),
             settled_while_taken: HashSet::new(),
+            orphaned: Arc::new(Mutex::new(Vec::new())),
             verify_window_started: Instant::now(),
             verifies_in_window: 0,
         })
+    }
+
+    /// Release reservations deposited by dropped (not handed-back)
+    /// [`TakenBatch`]es. Called at the start of every pool operation, so a
+    /// batch lost to a panicking or killed proving worker frees its spends
+    /// for resubmission at the next pool touch instead of wedging them until
+    /// the aggregator is reconstructed.
+    fn reap_orphaned(&mut self) {
+        let orphaned: Vec<BytesDigest> = {
+            let mut inbox = self
+                .orphaned
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            std::mem::take(&mut *inbox)
+        };
+        for nullifier in orphaned {
+            self.nullifier_index.remove(&nullifier);
+            self.taken_nullifiers.remove(&nullifier);
+            self.settled_while_taken.remove(&nullifier);
+        }
     }
 
     /// Total number of proofs across all buckets.
@@ -322,6 +386,7 @@ impl ProofPool {
     /// the global limits) while earlier batches for it are out being proved;
     /// [`Self::take_batch`] takes the oldest `batch_size` proofs at a time.
     pub fn push(&mut self, proof: Proof) -> Result<BatchKey> {
+        self.reap_orphaned();
         if self.len() >= self.limits.max_proofs {
             bail!(
                 "proof pool is full ({} proofs, limit {})",
@@ -433,6 +498,7 @@ impl ProofPool {
     /// longer holds them), but their settlements are remembered: a later
     /// [`Self::reinsert`] drops the affected proofs instead of restoring them.
     pub fn evict_settled(&mut self, settled: &HashSet<BytesDigest>) -> usize {
+        self.reap_orphaned();
         // Settlements hitting out-for-proving proofs can't be evicted now;
         // record them so reinsert doesn't restore dead weight after the
         // settled set of this block has already been consumed.
@@ -514,6 +580,7 @@ impl ProofPool {
     /// observed by [`Self::evict_settled`] meanwhile are remembered so
     /// `reinsert` drops the affected proofs instead of restoring dead weight.
     pub fn take_batch(&mut self, key: &BatchKey) -> Option<TakenBatch> {
+        self.reap_orphaned();
         let bucket = self.buckets.get_mut(key)?;
         let n = bucket.len().min(self.batch_size);
         let taken: Vec<PooledProof> = bucket.drain(..n).collect();
@@ -528,6 +595,8 @@ impl ProofPool {
         Some(TakenBatch {
             key: *key,
             proofs: taken,
+            orphaned: self.orphaned.clone(),
+            armed: true,
         })
     }
 
@@ -535,7 +604,9 @@ impl ProofPool {
     /// reservations (they are about to settle on-chain via the public batch;
     /// the post-submission [`Self::evict_settled`] cadence no longer needs to
     /// track them here).
-    pub fn complete(&mut self, batch: TakenBatch) {
+    pub fn complete(&mut self, mut batch: TakenBatch) {
+        self.reap_orphaned();
+        batch.armed = false;
         for queued in &batch.proofs {
             for nullifier in &queued.nullifiers {
                 self.nullifier_index.remove(nullifier);
@@ -555,9 +626,11 @@ impl ProofPool {
     /// is dropped instead of restored (re-proving it would waste minutes on a
     /// batch the chain refuses). Returns the number of proofs actually
     /// restored.
-    pub fn reinsert(&mut self, batch: TakenBatch) -> usize {
+    pub fn reinsert(&mut self, mut batch: TakenBatch) -> usize {
+        self.reap_orphaned();
+        batch.armed = false;
         let mut restored: Vec<PooledProof> = Vec::with_capacity(batch.proofs.len());
-        for queued in batch.proofs {
+        for queued in std::mem::take(&mut batch.proofs) {
             let stale = queued
                 .nullifiers
                 .iter()
@@ -590,6 +663,7 @@ impl ProofPool {
     /// Used both to drain a bucket after successful aggregation and as an
     /// operator recovery/expiry path for buckets that will never be aggregated.
     pub fn remove_bucket(&mut self, key: &BatchKey) -> Vec<Proof> {
+        self.reap_orphaned();
         self.buckets
             .remove(key)
             .map(|bucket| {
@@ -805,6 +879,47 @@ mod tests {
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].num_proofs, 3);
         assert!(stats[0].is_full());
+    }
+
+    /// A TakenBatch dropped without complete/reinsert — e.g. the minutes-long
+    /// proving worker in the documented split flow panics — must not wedge its
+    /// spends forever. Reservations of a dropped batch must be released (at
+    /// the pool's next operation) so clients can resubmit; no operator-side
+    /// recovery API or pool reconstruction should be needed (audit finding:
+    /// dropped in-flight batch permanently wedges spends).
+    #[test]
+    fn dropped_taken_batch_releases_reservations_for_resubmission() {
+        let (mut pool, data, targets) = make_pool(1, PoolLimits::default());
+        let proof = prove_fake(&data, &targets, &fake(1, 11));
+        let key = pool.push(proof.clone()).unwrap();
+
+        let batch = pool.take_batch(&key).expect("bucket must be takeable");
+        drop(batch);
+
+        pool.push(proof)
+            .expect("resubmission of a spend from a dropped batch must be admitted");
+        assert_eq!(pool.len(), 1);
+    }
+
+    /// The realistic loss mode from the audit finding: the batch is moved into
+    /// a proving worker thread that panics mid-proving. Unwinding drops the
+    /// batch, which must still release its reservations back to the pool.
+    #[test]
+    fn batch_lost_to_panicking_worker_releases_reservations() {
+        let (mut pool, data, targets) = make_pool(1, PoolLimits::default());
+        let proof = prove_fake(&data, &targets, &fake(1, 11));
+        let key = pool.push(proof.clone()).unwrap();
+        let batch = pool.take_batch(&key).unwrap();
+
+        let worker = std::thread::spawn(move || {
+            let _owned = batch;
+            panic!("simulated proving failure");
+        });
+        assert!(worker.join().is_err());
+
+        pool.push(proof)
+            .expect("resubmission after a panicked proving worker must be admitted");
+        assert_eq!(pool.len(), 1);
     }
 
     #[test]

--- a/wormhole/aggregator/src/private_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/build.rs
@@ -18,6 +18,7 @@ use zk_circuits_common::circuit::{wormhole_private_batch_circuit_config, C, D, F
 
 use crate::common::utils::{
     commit_artifact_set, load_canonical_leaf_verifier_data, read_artifact_file,
+    sweep_stale_artifact_droppings,
 };
 use crate::private_batch::circuit::circuit_logic::PrivateBatchCircuit;
 
@@ -44,6 +45,9 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     // Bound the per-layer count before any circuit construction (#97021, #97070).
     validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
     create_dir_all(output_path)?;
+    // A previous publish hard-killed mid-swap leaves orphaned temp/backup
+    // entries behind; we are about to replace the set, so sweep them now.
+    sweep_stale_artifact_droppings(output_path)?;
 
     println!(
         "Building prebuilt private-batch aggregation circuit (num_leaf_proofs={})...",
@@ -308,6 +312,41 @@ mod tests {
                 "verifier.bin".to_string(),
             ],
             "publish must not leave temp/old files behind"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A publish hard-killed mid-swap (SIGKILL/power loss) leaves orphaned
+    /// `.<name>.tmp-*` / `.<name>.old-*` droppings that no later run adopts
+    /// (the random suffix is fresh per call). The builder path must sweep
+    /// them before regenerating so they do not accumulate forever (audit
+    /// finding: crash-path droppings never cleaned up). Unrelated dotfiles
+    /// must survive the sweep.
+    #[test]
+    fn rebuild_sweeps_droppings_of_interrupted_publish() {
+        let dir = temp_dir("crash-droppings");
+        write_canonical_leaf_artifacts(&dir);
+
+        // Simulate the post-SIGKILL state: originals moved aside, staged
+        // files still present, nothing live.
+        let dropping_old = dir.join(".private_batch_common.bin.old-12345-0123456789abcdef");
+        let dropping_tmp = dir.join(".private_batch_verifier.bin.tmp-12345-0123456789abcdef");
+        std::fs::write(&dropping_old, b"moved-aside original").unwrap();
+        std::fs::write(&dropping_tmp, b"orphaned staged file").unwrap();
+        // An unrelated dotfile must not be swept.
+        let innocent = dir.join(".gitignore");
+        std::fs::write(&innocent, b"*.log").unwrap();
+
+        generate_private_batch_circuit_binaries(&dir, 1, false).unwrap();
+
+        assert!(
+            !dropping_old.exists() && !dropping_tmp.exists(),
+            "regeneration must sweep droppings of an interrupted publish"
+        );
+        assert!(
+            innocent.exists(),
+            "the sweep must not touch unrelated dotfiles"
         );
 
         std::fs::remove_dir_all(&dir).unwrap();

--- a/wormhole/aggregator/src/private_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/build.rs
@@ -237,6 +237,39 @@ mod tests {
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
+    /// A symlink pre-planted at an artifact filename must not redirect the
+    /// write onto its target (audit finding: symlink-following artifact
+    /// writes). `commit_artifact_set` stages under exclusive-create temp names
+    /// and renames into place, which replaces the planted entry itself; this
+    /// guards against regressing to direct `std::fs::write` calls.
+    #[cfg(unix)]
+    #[test]
+    fn artifact_writes_do_not_follow_planted_symlinks() {
+        let dir = temp_dir("symlink-clobber");
+        write_canonical_leaf_artifacts(&dir);
+
+        let victim = dir.join("victim.txt");
+        std::fs::write(&victim, b"precious data").unwrap();
+        std::os::unix::fs::symlink(&victim, dir.join("private_batch_verifier.bin")).unwrap();
+
+        let result = generate_private_batch_circuit_binaries(&dir, 1, false);
+
+        assert_eq!(
+            std::fs::read(&victim).unwrap(),
+            b"precious data",
+            "artifact publication must never write through a planted symlink"
+        );
+        if result.is_ok() {
+            let verifier = std::fs::read(dir.join("private_batch_verifier.bin")).unwrap();
+            assert_ne!(
+                verifier, b"precious data",
+                "a successful run must have replaced the planted entry with a real artifact"
+            );
+        }
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
     /// A verifier-only rerun (`include_prover == false`) over a directory that
     /// previously held prover output must not leave the old
     /// `dummy_private_batch_proof.bin` beside freshly regenerated

--- a/wormhole/aggregator/src/private_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/build.rs
@@ -13,16 +13,28 @@
 use anyhow::{anyhow, Context, Result};
 use plonky2::{plonk::circuit_data::CommonCircuitData, util::serialization::DefaultGateSerializer};
 use qp_wormhole_inputs::validate_proof_count;
-use std::{
-    fs::{create_dir_all, write},
-    path::Path,
-};
+use std::{fs::create_dir_all, path::Path};
 use zk_circuits_common::circuit::{wormhole_private_batch_circuit_config, C, D, F};
 
-use crate::common::utils::{load_canonical_leaf_verifier_data, read_artifact_file};
+use crate::common::utils::{
+    commit_artifact_set, load_canonical_leaf_verifier_data, read_artifact_file,
+};
 use crate::private_batch::circuit::circuit_logic::PrivateBatchCircuit;
 
 /// Generate prebuilt Private-batch aggregation circuit binaries.
+///
+/// The private-batch files are published all-or-nothing (see
+/// `commit_artifact_set` in `common::utils`), so a failed re-run over an
+/// existing bins dir never leaves a fresh `private_batch_common.bin` beside a
+/// stale `private_batch_verifier.bin` or `dummy_private_batch_proof.bin`.
+/// When `include_prover` is `false`, any pre-existing
+/// `dummy_private_batch_proof.bin` is removed as part of the same publish: a
+/// stale template would fail verification against the fresh verifier data and
+/// take the whole bins directory offline for public-batch proving.
+/// Whole-directory consistency across all stages (leaf, private-batch,
+/// public-batch, `config.json`) is still only guaranteed by the staging
+/// `generate_all_circuit_binaries` flow in `circuit-builder`; prefer it unless
+/// deliberately regenerating this one stage into an existing set.
 pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     output_dir: P,
     num_leaf_proofs: usize,
@@ -64,24 +76,17 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     // partial public batches. Must happen BEFORE consuming circuit_data below
     // (prove() borrows, prover_data() moves). Only possible/needed when proving
     // artifacts are requested (requires the leaf dummy proof from the same run).
-    if include_prover {
-        let dummy_batch_proof_bytes = generate_dummy_private_batch_proof(
+    let dummy_batch_proof_bytes = if include_prover {
+        Some(generate_dummy_private_batch_proof(
             &circuit_data,
             &agg_targets,
             &leaf.common,
             output_path,
             num_leaf_proofs,
-        )?;
-        write(
-            output_path.join("dummy_private_batch_proof.bin"),
-            &dummy_batch_proof_bytes,
-        )?;
-        println!(
-            "Saved {}/dummy_private_batch_proof.bin ({} bytes)",
-            output_path.display(),
-            dummy_batch_proof_bytes.len()
-        );
-    }
+        )?)
+    } else {
+        None
+    };
 
     let verifier_data = circuit_data.verifier_data();
     let common_data = &verifier_data.common;
@@ -89,20 +94,31 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     let agg_common_bytes = common_data
         .to_bytes(&gate_serializer)
         .map_err(|e| anyhow!("Failed to serialize aggregated common data: {}", e))?;
-    write(
-        output_path.join("private_batch_common.bin"),
-        agg_common_bytes,
-    )?;
-    println!("Saved {}/private_batch_common.bin", output_path.display());
-
     let agg_verifier_only_bytes = verifier_data
         .verifier_only
         .to_bytes()
         .map_err(|e| anyhow!("Failed to serialize aggregated verifier data: {}", e))?;
-    write(
-        output_path.join("private_batch_verifier.bin"),
-        agg_verifier_only_bytes,
-    )?;
+
+    // Publish the whole set all-or-nothing. Without prover output, a stale
+    // dummy template from an earlier run is removed as part of the same swap:
+    // it would fail template verification against the fresh verifier data.
+    let mut files: Vec<(&str, Vec<u8>)> = Vec::new();
+    let mut remove_stale: Vec<&str> = Vec::new();
+    match dummy_batch_proof_bytes {
+        Some(bytes) => {
+            println!(
+                "Publishing {}/dummy_private_batch_proof.bin ({} bytes)",
+                output_path.display(),
+                bytes.len()
+            );
+            files.push(("dummy_private_batch_proof.bin", bytes));
+        }
+        None => remove_stale.push("dummy_private_batch_proof.bin"),
+    }
+    files.push(("private_batch_common.bin", agg_common_bytes));
+    files.push(("private_batch_verifier.bin", agg_verifier_only_bytes));
+    commit_artifact_set(output_path, &files, &remove_stale)?;
+    println!("Saved {}/private_batch_common.bin", output_path.display());
     println!("Saved {}/private_batch_verifier.bin", output_path.display());
 
     Ok(())
@@ -166,6 +182,98 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         create_dir_all(&dir).unwrap();
         dir
+    }
+
+    /// Write canonical leaf artifacts into `dir` so the private-batch
+    /// generation's canonical pinning succeeds.
+    fn write_canonical_leaf_artifacts(dir: &Path) {
+        let leaf = crate::common::utils::canonical_leaf_verifier_data();
+        let gate_serializer = DefaultGateSerializer;
+        std::fs::write(
+            dir.join("common.bin"),
+            leaf.common.to_bytes(&gate_serializer).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(dir.join("verifier.bin"), leaf.verifier_only.to_bytes().unwrap()).unwrap();
+    }
+
+    /// The private-batch files are consumed as a matched set (public-batch
+    /// constructors pin them against a canonical rebuild and verify the dummy
+    /// template against them), so a directory holding a fresh file from one
+    /// generation beside a stale file from another is rejected until
+    /// regenerated. A publish that fails partway must therefore either leave
+    /// the previous set fully intact or replace it wholesale — never mix
+    /// (audit finding: non-atomic artifact-set publication).
+    #[test]
+    fn failed_artifact_publish_never_leaves_mixed_private_batch_set() {
+        let dir = temp_dir("mixed-set");
+        write_canonical_leaf_artifacts(&dir);
+        std::fs::write(dir.join("private_batch_common.bin"), b"old common").unwrap();
+        // A directory squatting on the verifier path makes a naive in-place
+        // write of the second file fail after the first was already clobbered.
+        create_dir_all(dir.join("private_batch_verifier.bin")).unwrap();
+
+        let result = generate_private_batch_circuit_binaries(&dir, 1, false);
+
+        let common_now = std::fs::read(dir.join("private_batch_common.bin")).unwrap();
+        match result {
+            Err(_) => assert_eq!(
+                common_now, b"old common",
+                "a failed publish must leave the previous artifact set untouched, \
+                 not a fresh common beside a stale verifier"
+            ),
+            Ok(()) => {
+                assert_ne!(
+                    common_now, b"old common",
+                    "a successful publish must replace the set wholesale"
+                );
+                assert!(
+                    dir.join("private_batch_verifier.bin").is_file(),
+                    "a successful publish must leave a real verifier artifact"
+                );
+            }
+        }
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A verifier-only rerun (`include_prover == false`) over a directory that
+    /// previously held prover output must not leave the old
+    /// `dummy_private_batch_proof.bin` beside freshly regenerated
+    /// common/verifier data: the public-batch prover verifies the template
+    /// against the pinned private-batch verifier at startup, so a stale
+    /// template takes the whole bins directory offline (audit finding:
+    /// non-atomic artifact-set publication).
+    #[test]
+    fn verifier_only_rerun_removes_stale_dummy_template() {
+        let dir = temp_dir("stale-dummy");
+        write_canonical_leaf_artifacts(&dir);
+        std::fs::write(dir.join("dummy_private_batch_proof.bin"), b"stale template").unwrap();
+
+        generate_private_batch_circuit_binaries(&dir, 1, false).unwrap();
+
+        assert!(
+            !dir.join("dummy_private_batch_proof.bin").exists(),
+            "a verifier-only rerun must remove the stale dummy template"
+        );
+        // No staging or moved-aside droppings either.
+        let mut names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "common.bin".to_string(),
+                "private_batch_common.bin".to_string(),
+                "private_batch_verifier.bin".to_string(),
+                "verifier.bin".to_string(),
+            ],
+            "publish must not leave temp/old files behind"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     /// An oversized (sparse) leaf artifact must be rejected by the size cap

--- a/wormhole/aggregator/src/private_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/build.rs
@@ -194,7 +194,11 @@ mod tests {
             leaf.common.to_bytes(&gate_serializer).unwrap(),
         )
         .unwrap();
-        std::fs::write(dir.join("verifier.bin"), leaf.verifier_only.to_bytes().unwrap()).unwrap();
+        std::fs::write(
+            dir.join("verifier.bin"),
+            leaf.verifier_only.to_bytes().unwrap(),
+        )
+        .unwrap();
     }
 
     /// The private-batch files are consumed as a matched set (public-batch

--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -385,9 +385,10 @@ fn build_private_batch_constraints(
 
     // The sorting network emits a permutation of `selected_nullifiers`
     // unconditionally (multiset integrity is structural, independent of the
-    // comparators), and its comparators are canonicity-enforced, so the
-    // sorted order also holds against a malicious prover — the public record
-    // is guaranteed decorrelated. See `sort_digests4`.
+    // comparators). Limbs are split into canonical 32-bit halves once at
+    // ingress, so the comparators only route already-constrained values and
+    // the sorted order also holds against a malicious prover — the public
+    // record is guaranteed decorrelated. See `sort_digests4`.
     for nullifier in sort_digests4(builder, selected_nullifiers) {
         output_pis.extend_from_slice(&nullifier);
     }

--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -16,7 +16,11 @@
 //! This circuit forwards one nullifier per leaf slot into the aggregated public
 //! inputs (dummy slots get the hash of a fresh random preimage instead, so
 //! padding never produces on-chain nullifier collisions and stays
-//! indistinguishable from real slots). It deliberately does NOT check
+//! indistinguishable from real slots). The region is emitted in canonical
+//! sorted order rather than leaf-slot order, so its positions carry no
+//! correlation with the (positionally bound) exit slots — otherwise a nonzero
+//! exit slot would identify its proof's nullifier as real and pair the public
+//! payout with it. It deliberately does NOT check
 //! nullifiers for uniqueness — not against chain state, and not even across
 //! slots in the same batch. Two leaves spending the same deposit aggregate into
 //! a cryptographically valid batch; the wormhole pallet's persistent settled-
@@ -42,7 +46,7 @@ use qp_wormhole_inputs::validate_proof_count;
 
 use zk_circuits_common::{
     circuit::{C, D, F},
-    gadgets::{bytes_digest_eq, limb1_at_offset, limbs4_at_offset},
+    gadgets::{bytes_digest_eq, limb1_at_offset, limbs4_at_offset, sort_digests4},
 };
 
 use crate::common::recursive::add_recursive_verifiers;
@@ -350,7 +354,19 @@ fn build_private_batch_constraints(
     // =========================================================================
     // Nullifiers (replace dummies with hashes of provided random preimages)
     // =========================================================================
+    //
+    // The selected nullifiers are emitted in CANONICAL SORTED ORDER, not in
+    // leaf-slot order. Exit slots above are positionally bound to proofs
+    // (slots 2i/2i+1 come from proof i, and dummy slots are zero), so if
+    // nullifier i also came from proof i, any nonzero exit slot would mark
+    // its nullifier as real and pair the public payout with it — defeating
+    // the dummy padding and the uniform shuffle (audit finding). Sorting by
+    // value makes the region's order independent of slot position; combined
+    // with value-indistinguishable dummy nullifiers, an observer of the
+    // aggregated public inputs can no longer tell which nullifiers are real.
+    // The chain consumes this region with set semantics, so order is free.
 
+    let mut selected_nullifiers: Vec<[Target; 4]> = Vec::with_capacity(n_leaf);
     for i in 0..n_leaf {
         let pis_i = leaf_pi_targets[i];
         let real_null_i = limbs4_at_offset::<LEAF_PI_LEN, NULLIFIER_START>(pis_i, 0);
@@ -358,13 +374,22 @@ fn build_private_batch_constraints(
             hash_dummy_nullifier_pre_image(builder, targets.dummy_nullifier_pre_images[i]);
         let is_dummy_i = is_dummy_flags[i];
 
-        // output = is_dummy ? hash(dummy_nullifier_pre_image[i]) : real_nullifier[i]
-        output_pis.extend_from_slice(&[
+        // selected = is_dummy ? hash(dummy_nullifier_pre_image[i]) : real_nullifier[i]
+        selected_nullifiers.push([
             builder.select(is_dummy_i, dummy_null_i[0], real_null_i[0]),
             builder.select(is_dummy_i, dummy_null_i[1], real_null_i[1]),
             builder.select(is_dummy_i, dummy_null_i[2], real_null_i[2]),
             builder.select(is_dummy_i, dummy_null_i[3], real_null_i[3]),
         ]);
+    }
+
+    // The sorting network emits a permutation of `selected_nullifiers`
+    // unconditionally (multiset integrity is structural, independent of the
+    // comparators), and its comparators are canonicity-enforced, so the
+    // sorted order also holds against a malicious prover — the public record
+    // is guaranteed decorrelated. See `sort_digests4`.
+    for nullifier in sort_digests4(builder, selected_nullifiers) {
+        output_pis.extend_from_slice(&nullifier);
     }
 
     // =========================================================================
@@ -519,6 +544,21 @@ mod tests {
     fn hash_dummy_nullifier_pre_image_native(pre_image: [F; 4]) -> [F; 4] {
         let inner_hash = Poseidon2Hash::hash_no_pad(&pre_image).elements;
         Poseidon2Hash::hash_no_pad(&inner_hash).elements
+    }
+
+    /// Native mirror of the circuit's canonical nullifier ordering: ascending
+    /// lexicographic over canonical u64 limbs, limb 0 most significant.
+    fn sorted_nullifiers(mut nullifiers: Vec<[F; 4]>) -> Vec<[F; 4]> {
+        nullifiers.sort_by_key(|n| core::array::from_fn::<u64, 4, _>(|i| n[i].to_canonical_u64()));
+        nullifiers
+    }
+
+    /// Read the nullifier region (`n_leaf` entries of 4 felts) from aggregated PIs.
+    fn nullifier_region(pis: &[F], n_leaf: usize) -> Vec<[F; 4]> {
+        let start = ROOT_HEADER_LEN + n_leaf * 2 * aggregated_output::EXIT_SLOT_LEN;
+        (0..n_leaf)
+            .map(|i| core::array::from_fn(|j| pis[start + i * 4 + j]))
+            .collect()
     }
 
     // ---------------- Packing helpers ----------------
@@ -935,14 +975,16 @@ mod tests {
             );
         }
 
-        // Nullifiers (real-proof-only test => should match leaf nullifiers exactly)
-        for (leaf_idx, nullifier_expected) in nullifiers_ref.iter().enumerate() {
+        // Nullifiers (real-proof-only test => region is the canonically sorted
+        // multiset of the leaf nullifiers)
+        let expected_nullifiers = sorted_nullifiers(nullifiers_ref);
+        for (region_idx, nullifier_expected) in expected_nullifiers.iter().enumerate() {
             let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
             idx += 4;
 
             assert_eq!(
                 got, *nullifier_expected,
-                "nullifier mismatch at leaf {leaf_idx}"
+                "nullifier mismatch at sorted region index {region_idx}"
             );
         }
 
@@ -1158,25 +1200,19 @@ mod tests {
         let block_num_circuit = pis[ROOT_BLOCK_NUMBER_IDX];
         assert_eq!(block_num_circuit, common_block_number);
 
-        let nullifier_region_start =
-            ROOT_HEADER_LEN + (pis_list.len() * 2 * aggregated_output::EXIT_SLOT_LEN);
-        for (i, nullifier) in nullifiers_felts.iter().enumerate().take(num_real_proofs) {
-            let idx = nullifier_region_start + i * 4;
-            let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
-            assert_eq!(got, *nullifier, "real nullifier mismatch at leaf {i}");
-        }
-
-        for (i, pre_image) in dummy_nullifier_pre_images
-            .iter()
-            .enumerate()
-            .take(pis_list.len())
-            .skip(num_real_proofs)
-        {
-            let idx = nullifier_region_start + i * 4;
-            let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
-            let expected = hash_dummy_nullifier_pre_image_native(*pre_image);
-            assert_eq!(got, expected, "dummy nullifier hash mismatch at leaf {i}");
-        }
+        // Region = sorted multiset of {real nullifiers} ∪ {dummy replacement hashes}.
+        let mut expected: Vec<[F; 4]> = nullifiers_felts[..num_real_proofs].to_vec();
+        expected.extend(
+            dummy_nullifier_pre_images
+                .iter()
+                .skip(num_real_proofs)
+                .map(|p| hash_dummy_nullifier_pre_image_native(*p)),
+        );
+        assert_eq!(
+            nullifier_region(pis, pis_list.len()),
+            sorted_nullifiers(expected),
+            "nullifier region must be the sorted multiset of real + dummy-replacement nullifiers"
+        );
 
         println!(
             "Successfully aggregated {} real proofs + {} dummy proofs!",
@@ -1282,24 +1318,22 @@ mod tests {
             );
             assert_eq!(pis[ROOT_BLOCK_NUMBER_IDX], common_block_number);
 
-            let nullifier_region_start =
-                ROOT_HEADER_LEN + (N_LEAF * 2 * aggregated_output::EXIT_SLOT_LEN);
-
-            for (i, pre_image) in dummy_nullifier_pre_images.iter().enumerate() {
-                let idx = nullifier_region_start + i * 4;
-                let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
-                if i == real_slot {
-                    // Real nullifier must be forwarded unchanged.
-                    assert_eq!(
-                        got, nullifiers_felts[i],
-                        "real nullifier must be preserved in slot {i}"
-                    );
-                } else {
-                    // Dummy nullifiers must be replaced with hashes of the preimages.
-                    let expected = hash_dummy_nullifier_pre_image_native(*pre_image);
-                    assert_eq!(got, expected, "dummy nullifier hash mismatch at leaf {i}");
-                }
-            }
+            // Region = sorted multiset: the real slot's nullifier forwarded
+            // unchanged, every dummy slot replaced with H(H(pre_image)).
+            let expected: Vec<[F; 4]> = (0..N_LEAF)
+                .map(|i| {
+                    if i == real_slot {
+                        nullifiers_felts[i]
+                    } else {
+                        hash_dummy_nullifier_pre_image_native(dummy_nullifier_pre_images[i])
+                    }
+                })
+                .collect();
+            assert_eq!(
+                nullifier_region(pis, N_LEAF),
+                sorted_nullifiers(expected),
+                "nullifier region mismatch with real proof in slot {real_slot}"
+            );
         }
     }
 
@@ -1370,14 +1404,16 @@ mod tests {
         );
 
         // All nullifiers should be replaced with hashes of the pre-images
-        let nullifier_region_start =
-            ROOT_HEADER_LEN + (pis_list.len() * 2 * aggregated_output::EXIT_SLOT_LEN);
-        for (i, pre_image) in dummy_nullifier_pre_images.iter().enumerate() {
-            let idx = nullifier_region_start + i * 4;
-            let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
-            let expected = hash_dummy_nullifier_pre_image_native(*pre_image);
-            assert_eq!(got, expected, "dummy nullifier hash mismatch at leaf {i}");
-        }
+        // (region is emitted as a sorted multiset).
+        let expected: Vec<[F; 4]> = dummy_nullifier_pre_images
+            .iter()
+            .map(|p| hash_dummy_nullifier_pre_image_native(*p))
+            .collect();
+        assert_eq!(
+            nullifier_region(pis, pis_list.len()),
+            sorted_nullifiers(expected),
+            "all-dummy nullifier region must be the sorted replacement hashes"
+        );
 
         println!("Successfully aggregated all-dummy batch of 8 proofs!");
     }
@@ -1566,43 +1602,103 @@ mod tests {
         root_verifier.verify(root_proof.clone()).unwrap();
 
         let pis = &root_proof.public_inputs;
-        let nullifier_region_start =
-            ROOT_HEADER_LEN + (pis_list.len() * 2 * aggregated_output::EXIT_SLOT_LEN);
+        let region = nullifier_region(pis, pis_list.len());
 
-        // Check real proof nullifier is preserved
-        let real_nullifier_idx = nullifier_region_start;
-        let real_nullifier_got = [
-            pis[real_nullifier_idx],
-            pis[real_nullifier_idx + 1],
-            pis[real_nullifier_idx + 2],
-            pis[real_nullifier_idx + 3],
-        ];
+        // Region = sorted multiset of the preserved real nullifier plus the
+        // dummy replacement hashes.
+        let mut expected: Vec<[F; 4]> = vec![nullifiers_felts[0]];
+        expected.extend(
+            dummy_nullifier_pre_images
+                .iter()
+                .skip(1)
+                .map(|p| hash_dummy_nullifier_pre_image_native(*p)),
+        );
         assert_eq!(
-            real_nullifier_got, nullifiers_felts[0],
-            "real proof nullifier should be preserved"
+            region,
+            sorted_nullifiers(expected),
+            "region must contain the real nullifier and every dummy replacement hash"
         );
 
-        // Check ALL dummy nullifiers are replaced (not equal to original)
-        for i in 1..8 {
-            let idx = nullifier_region_start + i * 4;
-            let got = [pis[idx], pis[idx + 1], pis[idx + 2], pis[idx + 3]];
-            let original = nullifiers_felts[i];
-            let expected_replacement =
-                hash_dummy_nullifier_pre_image_native(dummy_nullifier_pre_images[i]);
-
-            assert_ne!(
-                got, original,
-                "dummy nullifier at index {i} should NOT equal original"
-            );
-            assert_eq!(
-                got, expected_replacement,
-                "dummy nullifier at index {i} should equal H(H(pre_image))"
+        // No dummy slot's ORIGINAL nullifier may leak into the output.
+        for original in nullifiers_felts.iter().skip(1) {
+            assert!(
+                !region.contains(original),
+                "original dummy nullifier must be replaced, not forwarded"
             );
         }
 
         println!(
             "Verified dummy nullifier replacement for {} dummy proofs",
             7
+        );
+    }
+
+    /// Privacy (audit finding): the nullifier region must be emitted in an
+    /// order independent of leaf-slot position. Exit slots are positionally
+    /// bound to proofs (slot 2i/2i+1 come from proof i), so if nullifier i
+    /// also came from proof i, any nonzero exit slot would identify its
+    /// nullifier and pair the public payout with it. The circuit therefore
+    /// sorts the nullifier region canonically (ascending lexicographic over
+    /// canonical limbs), breaking the positional correlation.
+    ///
+    /// The test feeds real proofs whose nullifiers are in strictly DESCENDING
+    /// order, so proof-order emission (the vulnerable behavior) produces a
+    /// region that is maximally different from the required sorted order.
+    #[test]
+    fn nullifier_region_is_canonically_sorted() {
+        const N_LEAF: usize = 4;
+
+        let exits_felts: [[F; 8]; 8] = EXIT_ACCOUNTS.map(limbs8_u64_to_felts);
+        let block_hashes_felts: [[F; 4]; 8] = BLOCK_HASHES.map(limbs4_u64_to_felts);
+        // NULLIFIERS[0..4] have descending leading limbs (0x90.., 0x80.., 0x70.., 0x60..).
+        let nullifiers_felts: [[F; 4]; 8] = NULLIFIERS.map(limbs4_u64_to_felts);
+
+        let common_block_hash = block_hashes_felts[0];
+        let common_block_number = F::from_canonical_u64(42);
+        let asset_id = F::from_canonical_u64(TEST_ASSET_ID_U64);
+        let volume_fee_bps = F::from_canonical_u64(TEST_VOLUME_FEE_BPS);
+
+        let mut pis_list: Vec<[F; LEAF_PI_LEN]> = Vec::with_capacity(N_LEAF);
+        for i in 0..N_LEAF {
+            pis_list.push(make_pi_from_felts(
+                asset_id,
+                F::from_canonical_u64(100 + i as u64),
+                F::ZERO,
+                volume_fee_bps,
+                nullifiers_felts[i],
+                exits_felts[i],
+                [F::ZERO; 8],
+                common_block_hash,
+                common_block_number,
+            ));
+        }
+
+        let leaves = pis_list
+            .clone()
+            .into_iter()
+            .map(prove_fake_leaf_standalone)
+            .collect::<Vec<_>>();
+        let leaf_common = leaves[0].1.common.clone();
+        let leaf_verifier_only = leaves[0].1.verifier_only.clone();
+        let proofs = leaves
+            .into_iter()
+            .map(|(proof, _)| proof)
+            .collect::<Vec<_>>();
+
+        let (root_proof, root_verifier) = aggregate_proofs_private_batch(
+            proofs,
+            leaf_common,
+            leaf_verifier_only,
+            deterministic_dummy_nullifier_pre_images(N_LEAF),
+        )
+        .unwrap();
+        root_verifier.verify(root_proof.clone()).unwrap();
+
+        let got = nullifier_region(&root_proof.public_inputs, N_LEAF);
+        let expected = sorted_nullifiers(nullifiers_felts[..N_LEAF].to_vec());
+        assert_eq!(
+            got, expected,
+            "nullifier region must be canonically sorted, not in leaf-slot order"
         );
     }
 

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -334,7 +334,12 @@ impl PrivateBatchProver {
 ///
 /// - `asset_id` must match across ALL proofs (dummies included),
 /// - `block_hash` and `volume_fee_bps` must match between non-dummy proofs
-///   (`block_hash == 0` slots are exempt).
+///   (`block_hash == 0` slots are exempt),
+/// - at least one proof must be non-dummy: an all-dummy batch settles nothing,
+///   so proving it only burns the proving window. The intentional all-dummy
+///   padding template is built on the circuit-build path, which fills the
+///   witness directly and never calls this. Mirrors
+///   `ensure_private_batch_compatible` at the public-batch layer.
 ///
 /// NOTE: keep in lockstep with the circuit's cross-slot constraints
 /// (`private_batch::circuit::circuit_logic`). The circuit remains the enforcer;
@@ -403,6 +408,12 @@ fn ensure_leaf_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) -> Re
                 }
             }
         }
+    }
+    if reference.is_none() {
+        bail!(
+            "every supplied leaf proof is all-dummy (block_hash == 0): such a batch \
+             settles nothing; supply at least one real leaf proof"
+        );
     }
     Ok(())
 }
@@ -593,6 +604,24 @@ mod tests {
         ];
         let err = ensure_leaf_batch_compatible(&proofs).unwrap_err();
         assert!(err.to_string().contains("volume_fee_bps"), "got: {err}");
+    }
+
+    /// A non-empty batch of only dummy leaf proofs (block_hash == 0) settles
+    /// nothing; proving it burns a full private-batch prove. The intentional
+    /// all-dummy padding template is built on the circuit-build path, which
+    /// fills the witness directly and never calls commit, so this can only be
+    /// a caller bug — reject it at the API boundary, mirroring
+    /// `ensure_private_batch_compatible` at the public-batch layer (audit
+    /// finding: leaf layer skips all-dummy rejection).
+    #[test]
+    fn all_dummy_leaf_batch_is_rejected() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let proofs = vec![
+            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 0)),
+            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 0)),
+        ];
+        let err = ensure_leaf_batch_compatible(&proofs).unwrap_err();
+        assert!(err.to_string().contains("all-dummy"), "got: {err}");
     }
 
     #[test]

--- a/wormhole/aggregator/src/public_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/build.rs
@@ -20,6 +20,7 @@ use zk_circuits_common::circuit::{wormhole_public_batch_circuit_config, C, D, F}
 use crate::common::utils::{
     canonical_leaf_verifier_data, commit_artifact_set, load_canonical_private_batch_verifier_data,
     private_batch_num_leaves_from_padded_pi_len, read_artifact_file,
+    sweep_stale_artifact_droppings,
 };
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 
@@ -42,6 +43,9 @@ pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
     validate_proof_count(num_private_batch_proofs, "num_private_batch_proofs")?;
     create_dir_all(output_dir)
         .with_context(|| format!("Failed to create output dir {}", output_dir.display()))?;
+    // A previous publish hard-killed mid-swap leaves orphaned temp/backup
+    // entries behind; we are about to replace the set, so sweep them now.
+    sweep_stale_artifact_droppings(output_dir)?;
 
     // Pin the private-batch artifacts to the canonical private-batch circuit BEFORE
     // baking their verifier key into the public-batch circuit as constants. The leaf

--- a/wormhole/aggregator/src/public_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/build.rs
@@ -8,8 +8,7 @@
 //! Expects private-batch artifacts to already exist in `output_dir`.
 
 use anyhow::{anyhow, Context, Result};
-use std::fs::{self, create_dir_all};
-use std::io::Write as _;
+use std::fs::create_dir_all;
 use std::path::Path;
 
 use plonky2::plonk::circuit_data::VerifierCircuitData;
@@ -19,8 +18,9 @@ use qp_wormhole_inputs::validate_proof_count;
 use zk_circuits_common::circuit::{wormhole_public_batch_circuit_config, C, D, F};
 
 use crate::common::utils::{
-    canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
-    private_batch_num_leaves_from_padded_pi_len, read_artifact_file,
+    canonical_leaf_verifier_data, commit_artifact_set,
+    load_canonical_private_batch_verifier_data, private_batch_num_leaves_from_padded_pi_len,
+    read_artifact_file,
 };
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 
@@ -129,115 +129,15 @@ fn write_verifier_artifacts(
         .to_bytes()
         .map_err(|e| anyhow!("Failed to serialize public_batch verifier data: {}", e))?;
 
+    // Published all-or-nothing; see `commit_artifact_set` in `common::utils`.
     commit_artifact_set(
         bins_dir,
         &[
             ("public_batch_common.bin", common_bytes),
             ("public_batch_verifier.bin", verifier_bytes),
         ],
+        &[],
     )
-}
-
-/// Publish a matched set of artifact files into `bins_dir` all-or-nothing.
-///
-/// `public_batch_common.bin` and `public_batch_verifier.bin` are consumed as a
-/// matched pair (loaders pin them against a canonical circuit rebuild), so a
-/// directory holding a fresh file from one generation beside a stale file from
-/// another is rejected until regenerated. Naive in-place writes create exactly
-/// that state whenever a re-run fails between files.
-///
-/// Instead, every file is first staged under a fresh unpredictable temp name
-/// in the same directory (exclusive create, so a pre-planted entry or symlink
-/// is never adopted), and only after all stages succeed are the previous
-/// artifacts moved aside and the staged files renamed into place. Any failure
-/// rolls the moved-aside originals back, so an error always leaves either the
-/// complete previous set or the complete new set — never a mix. The unwritten
-/// window shrinks from the whole multi-minute build-and-write to the instants
-/// between renames of already-complete files.
-fn commit_artifact_set(bins_dir: &Path, files: &[(&str, Vec<u8>)]) -> Result<()> {
-    let unique = format!("{}-{:016x}", std::process::id(), rand::random::<u64>());
-    let tmp_path = |name: &str| bins_dir.join(format!(".{name}.tmp-{unique}"));
-    let old_path = |name: &str| bins_dir.join(format!(".{name}.old-{unique}"));
-
-    // Phase 1: stage every file. Any failure here leaves the originals untouched.
-    for (i, (name, bytes)) in files.iter().enumerate() {
-        let path = tmp_path(name);
-        let staged = fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)
-            .and_then(|mut f| f.write_all(bytes));
-        if let Err(e) = staged {
-            for (name, _) in &files[..=i] {
-                let _ = fs::remove_file(tmp_path(name));
-            }
-            return Err(e).with_context(|| format!("Failed to stage {}", path.display()));
-        }
-    }
-
-    // Phase 2: move previous artifacts aside, then swap the staged set in.
-    let mut moved_aside: Vec<&str> = Vec::new();
-    let mut swapped: Vec<&str> = Vec::new();
-    let swap_result = (|| -> Result<()> {
-        for (name, _) in files {
-            match fs::rename(bins_dir.join(name), old_path(name)) {
-                Ok(()) => moved_aside.push(name),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => {
-                    return Err(e).with_context(|| {
-                        format!(
-                            "Failed to move previous {} aside",
-                            bins_dir.join(name).display()
-                        )
-                    })
-                }
-            }
-        }
-        for (name, _) in files {
-            fs::rename(tmp_path(name), bins_dir.join(name)).with_context(|| {
-                format!(
-                    "Failed to move staged artifact into place at {}",
-                    bins_dir.join(name).display()
-                )
-            })?;
-            swapped.push(name);
-        }
-        Ok(())
-    })();
-
-    match swap_result {
-        Ok(()) => {
-            // The new set is committed; the moved-aside copies are redundant.
-            for name in moved_aside {
-                let old = old_path(name);
-                if fs::remove_file(&old).is_err() {
-                    let _ = fs::remove_dir_all(&old);
-                }
-            }
-            Ok(())
-        }
-        Err(e) => {
-            // Restore the previous set: renaming the old copy back atomically
-            // overwrites any already-swapped new file; names that had no old
-            // copy get their new file removed instead.
-            for (name, _) in files {
-                let final_path = bins_dir.join(name);
-                if moved_aside.contains(name) {
-                    if fs::rename(old_path(name), &final_path).is_err() {
-                        // A blocking entry (e.g. an already-swapped file under
-                        // a directory-shaped old copy) must not strand the
-                        // rollback in a mixed state.
-                        let _ = fs::remove_file(&final_path);
-                        let _ = fs::rename(old_path(name), &final_path);
-                    }
-                } else if swapped.contains(name) {
-                    let _ = fs::remove_file(&final_path);
-                }
-                let _ = fs::remove_file(tmp_path(name));
-            }
-            Err(e)
-        }
-    }
 }
 
 #[cfg(test)]

--- a/wormhole/aggregator/src/public_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/build.rs
@@ -18,9 +18,8 @@ use qp_wormhole_inputs::validate_proof_count;
 use zk_circuits_common::circuit::{wormhole_public_batch_circuit_config, C, D, F};
 
 use crate::common::utils::{
-    canonical_leaf_verifier_data, commit_artifact_set,
-    load_canonical_private_batch_verifier_data, private_batch_num_leaves_from_padded_pi_len,
-    read_artifact_file,
+    canonical_leaf_verifier_data, commit_artifact_set, load_canonical_private_batch_verifier_data,
+    private_batch_num_leaves_from_padded_pi_len, read_artifact_file,
 };
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -527,22 +527,40 @@ mod tests {
 
     /// A genuine all-dummy private-batch proof over the fake leaf circuit:
     /// the only template the (now-validating) direct constructor accepts.
+    ///
+    /// Built the way production builds its padding template (the
+    /// circuit-build path): fill the witness with explicit dummy leaves and
+    /// prove directly. It cannot go through `PrivateBatchProver::commit`,
+    /// which rejects all-dummy leaf batches.
     fn make_all_dummy_private_batch_template(
         leaf: &plonky2::plonk::circuit_data::CircuitData<F, C, D>,
         fake_leaf_proof: &ProofWithPublicInputs<F, C, D>,
     ) -> ProofWithPublicInputs<F, C, D> {
-        PrivateBatchProver::new(
+        use plonky2::iop::witness::PartialWitness;
+        use zk_circuits_common::utils::bytes_to_digest;
+
+        let circuit = PrivateBatchCircuit::new(
             wormhole_private_batch_circuit_config(),
-            leaf.common.clone(),
+            &leaf.common,
             &leaf.verifier_only,
             1,
-            fake_leaf_proof.clone(),
         )
-        .unwrap()
-        .commit(vec![fake_leaf_proof.clone()])
-        .unwrap()
-        .prove()
-        .unwrap()
+        .unwrap();
+        let targets = circuit.targets();
+        let circuit_data = circuit.build_circuit();
+
+        let pre_images = vec![bytes_to_digest(
+            crate::dummy_proof::generate_random_nullifier_preimage(),
+        )];
+        let mut pw = PartialWitness::new();
+        crate::private_batch::prover::fill_private_batch_witness(
+            &mut pw,
+            &targets,
+            std::slice::from_ref(fake_leaf_proof),
+            &pre_images,
+        )
+        .unwrap();
+        circuit_data.prove(pw).unwrap()
     }
 
     #[test]

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -256,13 +256,15 @@ impl PublicBatchProver {
     /// and zeroes their forwarded exit slots and nullifiers.
     ///
     /// Fails fast (milliseconds, before the minutes-long proving run) on inputs
-    /// the public-batch circuit could never prove: each supplied proof is
-    /// cryptographically verified against the pinned private-batch verifier,
-    /// and non-dummy proofs must share one (block hash, asset id, fee) triple —
-    /// the cross-proof consistency the circuit enforces. Proofs arriving via
-    /// [`crate::pool::ProofPool`] already satisfy both by construction; this
-    /// protects services that feed untrusted proof vectors to the prover
-    /// directly.
+    /// the public-batch circuit could never prove or that could never settle:
+    /// each supplied proof is cryptographically verified against the pinned
+    /// private-batch verifier, non-dummy proofs must share one (block hash,
+    /// asset id, fee) triple — the cross-proof consistency the circuit
+    /// enforces — and at least one supplied proof must be real (non-dummy),
+    /// since an all-dummy batch produces a proof with zero block references
+    /// that settles nothing. Proofs arriving via [`crate::pool::ProofPool`]
+    /// already satisfy all of these by construction; this protects services
+    /// that feed untrusted proof vectors to the prover directly.
     pub fn commit(mut self, inputs: PublicBatchInputs) -> Result<Self> {
         let Some(targets) = self.targets.take() else {
             bail!("public-batch aggregation prover has already committed to inputs");
@@ -334,7 +336,9 @@ impl PublicBatchProver {
 /// public-batch circuit's cross-proof constraints, so an incompatible batch is
 /// rejected at commit time instead of failing after minutes of proving:
 /// non-dummy proofs (`block_hash != 0`) must share one block hash, asset id,
-/// and volume fee; dummy proofs are exempt.
+/// and volume fee; dummy proofs are exempt. At least one proof must be
+/// non-dummy: an all-dummy batch carries zero block references and settles
+/// nothing on-chain.
 ///
 /// NOTE: keep in lockstep with the circuit's cross-proof constraints
 /// (`public_batch::circuit::circuit_logic`). The circuit remains the enforcer;
@@ -402,6 +406,18 @@ fn ensure_private_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) ->
                 }
             }
         }
+    }
+    // No non-dummy reference found: an all-dummy batch yields a public proof
+    // with zero block references that the chain rejects, so proving it only
+    // burns the proving window. The pool enforces this at admission
+    // (`ProofPool::push`); this guards the direct prover API against
+    // untrusted proof vectors.
+    if reference.is_none() {
+        bail!(
+            "every supplied private-batch proof is all-dummy (block_hash == 0): \
+             such a batch settles nothing on-chain; supply at least one real \
+             private-batch proof"
+        );
     }
     Ok(())
 }
@@ -637,6 +653,45 @@ mod tests {
             err.to_string().contains("failed verification"),
             "got: {err}"
         );
+    }
+
+    /// An all-dummy batch (every proof carries the zero block-hash sentinel)
+    /// produces a public-batch proof with zero block references that settles
+    /// nothing on-chain; the pool rejects such proofs at admission, and the
+    /// direct prover API must equally reject them at commit instead of
+    /// spending a full proving run on unusable output (audit finding).
+    #[test]
+    fn commit_rejects_all_dummy_batch() {
+        let (leaf, leaf_targets) = build_fake_leaf_circuit();
+        let dummy_leaf = prove_fake_leaf(&leaf, &leaf_targets, [F::ZERO; 21]);
+        let private_batch = PrivateBatchCircuit::new(
+            wormhole_private_batch_circuit_config(),
+            &leaf.common,
+            &leaf.verifier_only,
+            1,
+        )
+        .unwrap()
+        .build_verifier();
+
+        let template = make_all_dummy_private_batch_template(&leaf, &dummy_leaf);
+        let prover = PublicBatchProver::new(
+            wormhole_public_batch_circuit_config(),
+            private_batch.common.clone(),
+            &private_batch.verifier_only,
+            2,
+            1,
+            template.clone(),
+        )
+        .unwrap();
+
+        // A cryptographically valid all-dummy proof as the only real input.
+        let err = prover
+            .commit(PublicBatchInputs {
+                proofs: vec![template],
+                aggregator_address: BytesDigest::default(),
+            })
+            .expect_err("an all-dummy public batch must be rejected at commit");
+        assert!(err.to_string().contains("all-dummy"), "got: {err}");
     }
 
     /// Individually valid inner proofs with incompatible batch metadata (here:

--- a/wormhole/circuit-builder/Cargo.toml
+++ b/wormhole/circuit-builder/Cargo.toml
@@ -26,3 +26,9 @@ wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path =
 	"std",
 ] }
 zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common" }
+
+[dev-dependencies]
+test-helpers = { path = "../tests/test-helpers", default-features = false }
+wormhole-prover = { package = "qp-wormhole-prover", version = "=3.1.0", path = "../prover", default-features = false, features = [
+	"std",
+] }

--- a/wormhole/circuit-builder/examples/public_batch_bench.rs
+++ b/wormhole/circuit-builder/examples/public_batch_bench.rs
@@ -5,25 +5,24 @@
 //!    built once and reused, since they don't depend on M).
 //! 2. Loads the prover, which rebuilds the circuit from source (measures aggregator
 //!    startup).
-//! 3. Proves a public batch padded entirely with the dummy private-batch template.
-//!    Proving cost is witness-independent, so this is representative of real batches.
+//! 3. Proves a public batch with one real private-batch proof, padded with the
+//!    dummy template. Proving cost is witness-independent, so this is
+//!    representative of full batches.
 //!
 //! Usage: cargo run --release -p qp-wormhole-circuit-builder --example public_batch_bench -- 32 64 128
 
 use std::{fs, path::Path, time::Instant};
 
-use plonky2::{
-    plonk::{circuit_data::CommonCircuitData, proof::ProofWithPublicInputs},
-    util::serialization::DefaultGateSerializer,
-};
+use test_helpers::TestInputs as _;
 use wormhole_aggregator::{
+    private_batch::prover::PrivateBatchProver,
     public_batch::{
         circuit::generate_public_batch_circuit_binaries,
         prover::{PublicBatchInputs, PublicBatchProver},
     },
     CircuitBinsConfig,
 };
-use zk_circuits_common::circuit::{C, D, F};
+use wormhole_circuit::{block_header::header::HeaderInputs, inputs::CircuitInputs};
 
 const NUM_LEAF_PROOFS: usize = 7;
 
@@ -62,6 +61,26 @@ fn main() -> anyhow::Result<()> {
         setup_start.elapsed().as_secs_f64()
     );
 
+    // One real private-batch proof (a single real leaf padded with dummy
+    // leaves), reused for every M: PublicBatchProver::commit rejects all-dummy
+    // batches (they settle nothing on-chain), and the private-batch circuit
+    // doesn't depend on M.
+    println!("== One-time setup: real private-batch proof ==");
+    let proof_start = Instant::now();
+    CircuitBinsConfig::new(NUM_LEAF_PROOFS, None)?.save(&dir)?;
+    let real_private_batch = {
+        let mut inputs = CircuitInputs::test_inputs_0();
+        inputs.public.block_hash = HeaderInputs::try_from(&inputs)
+            .expect("header inputs from test inputs")
+            .block_hash();
+        let real_leaf = wormhole_prover::build_fresh().commit(&inputs)?.prove()?;
+        PrivateBatchProver::new_from_binaries_dir(&dir)?.aggregate(vec![real_leaf])?
+    };
+    println!(
+        "Real private-batch proof done in {:.1}s\n",
+        proof_start.elapsed().as_secs_f64()
+    );
+
     let mut results = Vec::new();
 
     for &m in &branching_factors {
@@ -90,20 +109,10 @@ fn main() -> anyhow::Result<()> {
             load_time.as_secs_f64()
         );
 
-        // 3) Prove an all-dummy-padded batch (1 template proof, M-1 dummies).
-        let dummy_bytes = fs::read(dir.join("dummy_private_batch_proof.bin"))?;
-        let private_batch_common = CommonCircuitData::<F, D>::from_bytes(
-            fs::read(dir.join("private_batch_common.bin"))?,
-            &DefaultGateSerializer,
-        )
-        .map_err(|e| anyhow::anyhow!("failed to load private-batch common data: {e}"))?;
-        let template =
-            ProofWithPublicInputs::<F, C, D>::from_bytes(dummy_bytes, &private_batch_common)
-                .map_err(|e| anyhow::anyhow!("failed to load dummy template: {e}"))?;
-
+        // 3) Prove a batch with one real private-batch proof (M-1 dummy pads).
         let prove_start = Instant::now();
         let prover = prover.commit(PublicBatchInputs {
-            proofs: vec![template],
+            proofs: vec![real_private_batch.clone()],
             aggregator_address: Default::default(),
         })?;
         let proof = prover.prove()?;

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Context, Result};
 use std::fs;
-use std::fs::{create_dir_all, write};
+use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use wormhole_aggregator::common::utils::commit_artifact_set;
 use wormhole_aggregator::public_batch::circuit::generate_public_batch_circuit_binaries;

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -42,6 +42,9 @@ pub fn generate_circuit_binaries<P: AsRef<Path>>(output_dir: P) -> Result<()> {
 
     let output_path = output_dir.as_ref();
     create_dir_all(output_path)?;
+    // A previous publish hard-killed mid-swap leaves orphaned temp/backup
+    // entries behind; we are about to replace the set, so sweep them now.
+    wormhole_aggregator::common::utils::sweep_stale_artifact_droppings(output_path)?;
 
     // Generate dummy proof BEFORE consuming circuit_data (prove() borrows, prover_data() moves)
     println!("Generating dummy proof for aggregation padding...");

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -327,6 +327,7 @@ fn commit_staging_dir_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::write;
 
     fn unique_tmp_dir(tag: &str) -> PathBuf {
         std::env::temp_dir().join(format!(

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use std::fs;
 use std::fs::{create_dir_all, write};
 use std::path::{Path, PathBuf};
+use wormhole_aggregator::common::utils::commit_artifact_set;
 use wormhole_aggregator::public_batch::circuit::generate_public_batch_circuit_binaries;
 
 use plonky2::util::serialization::DefaultGateSerializer;
@@ -17,11 +18,13 @@ pub use wormhole_aggregator::CircuitBinsConfig;
 /// This is a low-level helper for partial artifact generation. For the full flow that also
 /// emits `config.json`, use [`generate_all_circuit_binaries`].
 ///
-/// WARNING: writes into `output_dir` in place, without clearing pre-existing
-/// files or staging a complete set first. Interrupted or partial runs can
-/// leave a mixed artifact set. [`generate_all_circuit_binaries`] stages and
-/// atomically replaces the directory instead; prefer it unless you are
-/// deliberately regenerating one stage into an existing set.
+/// The three leaf files are published all-or-nothing through the aggregator's
+/// `commit_artifact_set` (exclusive-create staging plus rename into place), so
+/// a failed re-run never leaves a mixed leaf set and a symlink pre-planted at
+/// an artifact filename is replaced rather than followed. Whole-directory
+/// consistency across all stages is still only guaranteed by
+/// [`generate_all_circuit_binaries`]; prefer it unless you are deliberately
+/// regenerating one stage into an existing set.
 ///
 /// Note: no `prover.bin` is emitted for the leaf circuit. `WormholeProver` always builds
 /// the (small, fast-to-build) leaf circuit from source; loading prover-only artifacts was
@@ -44,31 +47,35 @@ pub fn generate_circuit_binaries<P: AsRef<Path>>(output_dir: P) -> Result<()> {
     println!("Generating dummy proof for aggregation padding...");
     let dummy_proof_bytes = wormhole_aggregator::generate_dummy_proof(&circuit_data, &targets)
         .map_err(|e| anyhow!("failed to generate dummy proof: {}", e))?;
-    write(output_path.join("dummy_proof.bin"), &dummy_proof_bytes)?;
-    println!(
-        "Dummy proof saved to {}/dummy_proof.bin ({} bytes)",
-        output_path.display(),
-        dummy_proof_bytes.len()
-    );
 
     println!("Serializing circuit data...");
 
     let verifier_data = circuit_data.verifier_data();
     let common_data = &verifier_data.common;
 
-    // Serialize common data
     let common_bytes = common_data
         .to_bytes(&gate_serializer)
         .map_err(|e| anyhow!("failed to serialize common data: {}", e))?;
-    write(output_path.join("common.bin"), common_bytes)?;
-    println!("Common data saved to {}/common.bin", output_path.display());
-
-    // Serialize verifier only data
     let verifier_only_bytes = verifier_data
         .verifier_only
         .to_bytes()
         .map_err(|e| anyhow!("failed to serialize verifier data: {}", e))?;
-    write(output_path.join("verifier.bin"), verifier_only_bytes)?;
+
+    println!(
+        "Publishing {}/dummy_proof.bin ({} bytes)",
+        output_path.display(),
+        dummy_proof_bytes.len()
+    );
+    commit_artifact_set(
+        output_path,
+        &[
+            ("dummy_proof.bin", dummy_proof_bytes),
+            ("common.bin", common_bytes),
+            ("verifier.bin", verifier_only_bytes),
+        ],
+        &[],
+    )?;
+    println!("Common data saved to {}/common.bin", output_path.display());
     println!(
         "Verifier data saved to {}/verifier.bin",
         output_path.display()
@@ -597,6 +604,42 @@ mod tests {
         assert!(format!("{err:#}").contains("move previous"), "got: {err:#}");
         assert!(output.join("previous.bin").exists());
         assert!(!staging.exists());
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// A symlink pre-planted at an artifact filename must not redirect the
+    /// write onto its target: `std::fs::write` follows symlinks and truncates,
+    /// so an attacker with write access to the output directory could make the
+    /// builder clobber any file writable by the invoking account (audit
+    /// finding: symlink-following artifact writes). Publishing must replace
+    /// the planted entry itself and leave the victim untouched.
+    #[cfg(unix)]
+    #[test]
+    fn leaf_artifact_writes_do_not_follow_planted_symlinks() {
+        let root = unique_tmp_dir("symlink-clobber");
+        let _ = fs::remove_dir_all(&root);
+        let output = root.join("bins");
+        create_dir_all(&output).unwrap();
+
+        let victim = root.join("victim.txt");
+        write(&victim, b"precious data").unwrap();
+        std::os::unix::fs::symlink(&victim, output.join("common.bin")).unwrap();
+
+        let result = generate_circuit_binaries(&output);
+
+        assert_eq!(
+            fs::read(&victim).unwrap(),
+            b"precious data",
+            "artifact publication must never write through a planted symlink"
+        );
+        if result.is_ok() {
+            let common = fs::read(output.join("common.bin")).unwrap();
+            assert_ne!(
+                common, b"precious data",
+                "a successful run must have replaced the planted entry with a real artifact"
+            );
+        }
 
         fs::remove_dir_all(&root).unwrap();
     }

--- a/wormhole/circuit/src/inputs.rs
+++ b/wormhole/circuit/src/inputs.rs
@@ -201,7 +201,7 @@ pub trait ParsePrivateBatchPublicInputs {
 
 impl ParsePrivateBatchPublicInputs for PrivateBatchPublicInputs {
     fn try_from_felts(pis: &[GoldilocksField]) -> anyhow::Result<PrivateBatchPublicInputs> {
-        // Layout: [num_unique_exits, asset_id, volume_fee_bps, block_hash(4), block_number,
+        // Layout: [num_exit_slots, asset_id, volume_fee_bps, block_hash(4), block_number,
         //          [output_sum(1), exit_account(4)] * 2*N, nullifiers(4) * N, padding...]
 
         // Validate layout: total length must be 8 + N * PUBLIC_INPUTS_FELTS_LEN
@@ -231,7 +231,19 @@ impl ParsePrivateBatchPublicInputs for PrivateBatchPublicInputs {
         };
 
         // Parse header (indices 0-7)
-        let num_unique_exits = read_u32(pis[0]).context("num_unique_exits")?;
+        let num_exit_slots = read_u32(pis[0]).context("num_exit_slots")?;
+        // The circuit provably writes the structural constant 2*N (total exit
+        // slots, two per leaf) at index 0; any other value means these felts
+        // did not come from the private-batch aggregation circuit.
+        if num_exit_slots as usize != n_leaf * 2 {
+            anyhow::bail!(
+                "AggregatedPI: num_exit_slots at index 0 is {}, but the layout implies {} \
+                 exit slots ({} leaves); these are not private-batch aggregation PIs",
+                num_exit_slots,
+                n_leaf * 2,
+                n_leaf
+            );
+        }
         let asset_id = read_u32(pis[1]).context("asset_id")?;
         let volume_fee_bps = read_u32(pis[2]).context("volume_fee_bps")?;
         let block_data = BlockData {
@@ -264,7 +276,7 @@ impl ParsePrivateBatchPublicInputs for PrivateBatchPublicInputs {
             .collect::<anyhow::Result<Vec<_>>>()?;
 
         Ok(PrivateBatchPublicInputs {
-            num_unique_exits,
+            num_exit_slots,
             asset_id,
             volume_fee_bps,
             block_data,
@@ -344,15 +356,31 @@ mod tests {
     #[test]
     fn aggregated_try_from_felts_accepts_valid_input() {
         // Valid input: 8 header + 21 (one leaf worth of data)
-        let valid_slice: Vec<GoldilocksField> =
+        let mut valid_slice: Vec<GoldilocksField> =
             vec![GoldilocksField::ZERO; 8 + PUBLIC_INPUTS_FELTS_LEN];
+        valid_slice[0] = GoldilocksField::from_canonical_u64(2); // 2*N exit slots for N = 1
         let result = <PrivateBatchPublicInputs as ParsePrivateBatchPublicInputs>::try_from_felts(
             &valid_slice,
         );
         assert!(result.is_ok(), "Expected valid input to parse successfully");
         let parsed = result.unwrap();
+        assert_eq!(parsed.num_exit_slots, 2);
         assert_eq!(parsed.account_data.len(), 2); // 2 outputs per leaf
         assert_eq!(parsed.nullifiers.len(), 1); // 1 nullifier per leaf
+    }
+
+    /// The aggregation circuit provably writes the structural constant `2*N`
+    /// (total exit slots, two per leaf) at index 0; any other value means the
+    /// felts did not come from that circuit and must be rejected (audit
+    /// finding: aggregated public input mislabels exit-slot count).
+    #[test]
+    fn aggregated_try_from_felts_rejects_header_slot_count_mismatch() {
+        let mut pis = vec![GoldilocksField::ZERO; 8 + PUBLIC_INPUTS_FELTS_LEN];
+        pis[0] = GoldilocksField::from_canonical_u64(1); // must be 2 for one leaf
+        let result =
+            <PrivateBatchPublicInputs as ParsePrivateBatchPublicInputs>::try_from_felts(&pis);
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("exit slot"), "got: {err_msg}");
     }
 
     #[test]

--- a/wormhole/circuit/src/zk_merkle_proof.rs
+++ b/wormhole/circuit/src/zk_merkle_proof.rs
@@ -325,15 +325,24 @@ impl ZkMerkleProofData {
     }
 
     /// Create proof data from unsorted siblings, computing positions automatically.
+    ///
+    /// Returns an error if the supplied path is deeper than [`MAX_DEPTH`].
+    /// The bound is enforced *before* any allocation or hashing so untrusted
+    /// raw siblings cannot force per-level Poseidon work on a proof the
+    /// circuit cannot use anyway.
     pub fn from_unsorted(
         root_hash: [u8; 32],
         unsorted_siblings: Vec<[[u8; 32]; SIBLINGS_PER_LEVEL]>,
         leaf_hash: [u8; 32],
         leaf: ZkLeafData,
         is_not_dummy: bool,
-    ) -> Self {
+    ) -> Result<Self, &'static str> {
         use zk_circuits_common::serialization::bytes_to_digest;
         use zk_circuits_common::zk_merkle::hash_node_presorted;
+
+        if unsorted_siblings.len() > MAX_DEPTH {
+            return Err("from_unsorted: proof depth exceeds MAX_DEPTH");
+        }
 
         let mut current_hash = leaf_hash;
         let mut sorted_siblings_bytes = Vec::with_capacity(unsorted_siblings.len());
@@ -386,14 +395,14 @@ impl ZkMerkleProofData {
             })
             .collect();
 
-        Self {
+        Ok(Self {
             root_hash,
             depth: siblings.len(),
             siblings,
             positions,
             leaf,
             is_not_dummy,
-        }
+        })
     }
 }
 
@@ -683,6 +692,28 @@ mod tests {
         assert!(!dump.contains("3735928559"));
         // input_amount (pre-fee deposit amount).
         assert!(!dump.contains("313131313"));
+    }
+
+    /// `from_unsorted` must reject depths beyond MAX_DEPTH before doing
+    /// per-level sorting and Poseidon hashing, mirroring the bound enforced
+    /// by `ZkMerkleProof::verify_with_positions` (audit finding: missing
+    /// depth limit in proof normalization).
+    #[test]
+    fn from_unsorted_rejects_oversized_depth() {
+        let leaf = ZkLeafData::new([0xCD; 32], 1, 0, 100, 50, 49, 10);
+        let levels = vec![[[0xABu8; 32]; SIBLINGS_PER_LEVEL]; MAX_DEPTH + 1];
+        let err = ZkMerkleProofData::from_unsorted([0x11; 32], levels, [0x42; 32], leaf, true)
+            .unwrap_err();
+        assert!(err.contains("MAX_DEPTH"), "got: {err}");
+    }
+
+    /// Proofs at exactly MAX_DEPTH must still construct.
+    #[test]
+    fn from_unsorted_accepts_max_depth() {
+        let leaf = ZkLeafData::new([0xCD; 32], 1, 0, 100, 50, 49, 10);
+        let levels = vec![[[0xABu8; 32]; SIBLINGS_PER_LEVEL]; MAX_DEPTH];
+        ZkMerkleProofData::from_unsorted([0x11; 32], levels, [0x42; 32], leaf, true)
+            .expect("MAX_DEPTH proof must construct");
     }
 
     /// Sibling hashes and position hints identify the leaf's location in the

--- a/wormhole/circuit/src/zk_merkle_proof.rs
+++ b/wormhole/circuit/src/zk_merkle_proof.rs
@@ -388,8 +388,10 @@ impl ZkMerkleProofData {
             };
             sorted_siblings_bytes.push(sorted_sibs);
 
-            // Compute parent hash for next level
-            current_hash = hash_node_presorted(&all_four);
+            // Compute parent hash for next level (the canonicality check
+            // above makes an error unreachable, but propagate rather than
+            // panic on caller-supplied bytes).
+            current_hash = hash_node_presorted(&all_four)?;
         }
 
         // Convert to felts

--- a/wormhole/circuit/src/zk_merkle_proof.rs
+++ b/wormhole/circuit/src/zk_merkle_proof.rs
@@ -326,10 +326,12 @@ impl ZkMerkleProofData {
 
     /// Create proof data from unsorted siblings, computing positions automatically.
     ///
-    /// Returns an error if the supplied path is deeper than [`MAX_DEPTH`].
-    /// The bound is enforced *before* any allocation or hashing so untrusted
-    /// raw siblings cannot force per-level Poseidon work on a proof the
-    /// circuit cannot use anyway.
+    /// Returns an error if the supplied path is deeper than [`MAX_DEPTH`], or
+    /// if the leaf or any sibling is not canonical hash bytes (each 8-byte
+    /// little-endian limb below the Goldilocks modulus). Both bounds are
+    /// enforced *before* any allocation or hashing so untrusted raw siblings
+    /// cannot force per-level Poseidon work on a proof the circuit cannot use
+    /// anyway.
     pub fn from_unsorted(
         root_hash: [u8; 32],
         unsorted_siblings: Vec<[[u8; 32]; SIBLINGS_PER_LEVEL]>,
@@ -338,10 +340,18 @@ impl ZkMerkleProofData {
         is_not_dummy: bool,
     ) -> Result<Self, &'static str> {
         use zk_circuits_common::serialization::bytes_to_digest;
-        use zk_circuits_common::zk_merkle::hash_node_presorted;
+        use zk_circuits_common::zk_merkle::{hash_node_presorted, is_canonical_hash};
 
         if unsorted_siblings.len() > MAX_DEPTH {
             return Err("from_unsorted: proof depth exceeds MAX_DEPTH");
+        }
+        // The node hash rejects noncanonical limbs (they alias mod p);
+        // reject untrusted raw bytes here instead of panicking mid-hash.
+        if !is_canonical_hash(&leaf_hash) {
+            return Err("from_unsorted: leaf hash bytes are noncanonical");
+        }
+        if !unsorted_siblings.iter().flatten().all(is_canonical_hash) {
+            return Err("from_unsorted: sibling hash bytes are noncanonical");
         }
 
         let mut current_hash = leaf_hash;
@@ -714,6 +724,31 @@ mod tests {
         let levels = vec![[[0xABu8; 32]; SIBLINGS_PER_LEVEL]; MAX_DEPTH];
         ZkMerkleProofData::from_unsorted([0x11; 32], levels, [0x42; 32], leaf, true)
             .expect("MAX_DEPTH proof must construct");
+    }
+
+    /// `from_unsorted` hashes caller-supplied bytes, so noncanonical limbs
+    /// (which the node hash rejects as mod-p aliases) must surface as an
+    /// error, not a panic mid-hash.
+    #[test]
+    fn from_unsorted_rejects_noncanonical_bytes() {
+        // Every limb of 0xff..ff exceeds the Goldilocks modulus.
+        let leaf = ZkLeafData::new([0xCD; 32], 1, 0, 100, 50, 49, 10);
+        let levels = vec![[[0xABu8; 32]; SIBLINGS_PER_LEVEL]];
+
+        let err = ZkMerkleProofData::from_unsorted(
+            [0x11; 32],
+            levels.clone(),
+            [0xff; 32],
+            leaf.clone(),
+            true,
+        )
+        .unwrap_err();
+        assert!(err.contains("leaf hash"), "got: {err}");
+
+        let bad_levels = vec![[[0xffu8; 32]; SIBLINGS_PER_LEVEL]];
+        let err = ZkMerkleProofData::from_unsorted([0x11; 32], bad_levels, [0x42; 32], leaf, true)
+            .unwrap_err();
+        assert!(err.contains("sibling hash"), "got: {err}");
     }
 
     /// Sibling hashes and position hints identify the leaf's location in the

--- a/wormhole/inputs/src/lib.rs
+++ b/wormhole/inputs/src/lib.rs
@@ -240,9 +240,13 @@ pub struct BlockData {
 /// Aggregated public inputs from multiple wormhole proofs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrivateBatchPublicInputs {
-    /// Number of unique exit-account groups reported by the wrapper circuit.
-    /// This is informational only; semantic validation remains the circuit's responsibility.
-    pub num_unique_exits: u32,
+    /// Total number of exit slots in the batch: the structural constant
+    /// `2 * n_leaf` (two outputs per leaf) that the aggregation circuit writes
+    /// at index 0, always equal to `account_data.len()`. NOT a deduplicated
+    /// unique-account count: the circuit zeroes duplicate and dummy slots
+    /// inside `account_data` instead of shrinking it. The parser validates
+    /// this felt against the length-derived leaf count.
+    pub num_exit_slots: u32,
     /// The asset ID of the set (0 for native token).
     pub asset_id: u32,
     /// Volume fee rate in basis points (1 basis point = 0.01%).
@@ -414,7 +418,7 @@ impl PrivateBatchPublicInputs {
     /// Parse aggregated public inputs from a slice of u64 values.
     pub fn try_from_u64_slice(pis: &[u64]) -> anyhow::Result<Self> {
         // Layout in the FINAL (deduped) wrapper proof PIs:
-        // [num_unique_exits, asset_id, volume_fee_bps, block_data(5),
+        // [num_exit_slots, asset_id, volume_fee_bps, block_data(5),
         //  [output_sum(1), exit_account(4)] * 2*N,  <-- 2 outputs per leaf
         //  nullifiers(4) * N, padding...]
         //
@@ -438,9 +442,9 @@ impl PrivateBatchPublicInputs {
             );
         }
 
-        let num_unique_exits: u32 = pis[0]
+        let num_exit_slots: u32 = pis[0]
             .try_into()
-            .context("AggregatedPI: num_unique_exits at index 0 exceeds u32 range")?;
+            .context("AggregatedPI: num_exit_slots at index 0 exceeds u32 range")?;
 
         let asset_id: u32 = pis[1]
             .try_into()
@@ -452,6 +456,19 @@ impl PrivateBatchPublicInputs {
         // Number of leaf proofs (N) is derived from the padded total PI length.
         let n_leaf = payload_len / PUBLIC_INPUTS_FELTS_LEN;
         validate_proof_count(n_leaf, "AggregatedPI: n_leaf")?;
+
+        // The circuit provably writes the structural constant 2*N (total exit
+        // slots, two per leaf) at index 0; any other value means these PIs
+        // did not come from the private-batch aggregation circuit.
+        if num_exit_slots as usize != n_leaf * 2 {
+            bail!(
+                "AggregatedPI: num_exit_slots at index 0 is {}, but the layout implies {} \
+                 exit slots ({} leaves); these are not private-batch aggregation PIs",
+                num_exit_slots,
+                n_leaf * 2,
+                n_leaf
+            );
+        }
 
         let block_hash = hash_u64s_to_bytes_digest(&pis[3..7])
             .context("AggregatedPI: parsing block_hash from indices 3..7")?;
@@ -466,10 +483,11 @@ impl PrivateBatchPublicInputs {
 
         let mut cursor = 8usize;
 
-        // Read 2*N exit account slots (two outputs per leaf proof)
-        let num_exit_slots = n_leaf * 2;
-        let mut account_data = Vec::with_capacity(num_exit_slots);
-        for i in 0..num_exit_slots {
+        // Read 2*N exit account slots (two outputs per leaf proof); validated
+        // above to equal the num_exit_slots header felt.
+        let total_slots = n_leaf * 2;
+        let mut account_data = Vec::with_capacity(total_slots);
+        for i in 0..total_slots {
             if cursor >= pis.len() {
                 bail!(
                     "AggregatedPI: cursor {} out of bounds (pis.len={}) while reading account {}",
@@ -533,7 +551,7 @@ impl PrivateBatchPublicInputs {
 
         // Verify we consumed expected number of felts
         // 8 metadata + 2*N*5 exit slots (1 sum + 4 account) + N*4 nullifiers
-        let expected_felts = 8 + num_exit_slots * 5 + n_leaf * 4;
+        let expected_felts = 8 + total_slots * 5 + n_leaf * 4;
         if cursor != expected_felts {
             bail!(
                 "AggregatedPI: cursor mismatch - consumed {} felts, expected {} (n_leaf={}, num_exit_slots={})",
@@ -545,7 +563,7 @@ impl PrivateBatchPublicInputs {
         }
 
         Ok(PrivateBatchPublicInputs {
-            num_unique_exits,
+            num_exit_slots,
             asset_id,
             volume_fee_bps,
             block_data,
@@ -702,16 +720,30 @@ mod tests {
     }
 
     #[test]
-    fn aggregated_public_inputs_parse_num_unique_exits() {
+    fn aggregated_public_inputs_parse_header() {
         let mut pis = vec![0u64; 8 + PUBLIC_INPUTS_FELTS_LEN];
-        pis[0] = 1; // num_unique_exits
+        pis[0] = 2; // num_exit_slots: structural constant 2*N for N = 1 leaf
         pis[7] = 42; // block_number
 
         let parsed = PrivateBatchPublicInputs::try_from_u64_slice(&pis).unwrap();
-        assert_eq!(parsed.num_unique_exits, 1);
+        assert_eq!(parsed.num_exit_slots, 2);
+        assert_eq!(parsed.num_exit_slots as usize, parsed.account_data.len());
         assert_eq!(parsed.block_data.block_number, 42);
         assert_eq!(parsed.account_data.len(), 2);
         assert_eq!(parsed.nullifiers.len(), 1);
+    }
+
+    /// The aggregation circuit provably writes the structural constant `2*N`
+    /// (total exit slots, two per leaf) at index 0; any other value means the
+    /// public inputs did not come from that circuit and the parser must not
+    /// hand the mismatched header on as truth (audit finding: aggregated
+    /// public input mislabels exit-slot count).
+    #[test]
+    fn aggregated_public_inputs_reject_header_slot_count_mismatch() {
+        let mut pis = vec![0u64; 8 + PUBLIC_INPUTS_FELTS_LEN];
+        pis[0] = 1; // one leaf means 2 exit slots; 1 is impossible
+        let err = PrivateBatchPublicInputs::try_from_u64_slice(&pis).unwrap_err();
+        assert!(err.to_string().contains("exit slot"), "got: {err}");
     }
 
     #[test]

--- a/wormhole/memprof/src/main.rs
+++ b/wormhole/memprof/src/main.rs
@@ -64,8 +64,12 @@ struct Args {
     #[arg(long, default_value_t = false)]
     release_after_each: bool,
 
-    /// Memory sampler poll period in milliseconds.
-    #[arg(long, default_value_t = 25)]
+    /// Memory sampler poll period in milliseconds. Bounded at parse time:
+    /// `0` would busy-loop the sampler thread, and an oversized period is
+    /// useless for profiling (the poll wait itself is interruptible, so
+    /// shutdown never blocks on it either way).
+    #[arg(long, default_value_t = 25,
+          value_parser = clap::value_parser!(u64).range(1..=crate::memory::MAX_SAMPLE_PERIOD_MS))]
     sample_period_ms: u64,
 
     /// If set, exits non-zero when overall peak exceeds this MB. CI guard.
@@ -226,6 +230,27 @@ mod tests {
             assert!(
                 Args::try_parse_from(["wormhole-memprof", "--rayon-threads", value]).is_ok(),
                 "--rayon-threads {value} must be accepted"
+            );
+        }
+    }
+
+    /// `--sample-period-ms 0` turns the sampler thread into a busy loop on
+    /// the process-memory read, and an absurdly large period parks the thread
+    /// in a sleep that shutdown must wait out; both must be rejected at
+    /// argument-parse time (audit finding: unbounded sampler interval).
+    #[test]
+    fn sample_period_out_of_range_is_rejected_at_parse_time() {
+        for value in ["0", "86400000"] {
+            assert!(
+                Args::try_parse_from(["wormhole-memprof", "--sample-period-ms", value]).is_err(),
+                "--sample-period-ms {value} must be rejected at parse time"
+            );
+        }
+        let max = crate::memory::MAX_SAMPLE_PERIOD_MS.to_string();
+        for value in ["1", "25", &max] {
+            assert!(
+                Args::try_parse_from(["wormhole-memprof", "--sample-period-ms", value]).is_ok(),
+                "--sample-period-ms {value} must be accepted"
             );
         }
     }

--- a/wormhole/memprof/src/memory.rs
+++ b/wormhole/memprof/src/memory.rs
@@ -4,8 +4,8 @@
 //! - Linux: `/proc/self/status:VmRSS`.
 //! - Other: returns `(0, 0)`.
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -52,23 +52,46 @@ pub fn release_memory() -> anyhow::Result<(u64, u64, u64)> {
     Ok((released_reported, before, after))
 }
 
+/// Upper bound for the sampler poll period. Sampling slower than once a
+/// minute cannot produce a useful peak profile, and bounding the period keeps
+/// the poll loop's wait short-lived relative to any run.
+pub const MAX_SAMPLE_PERIOD_MS: u64 = 60_000;
+
 /// A background thread that samples `phys_footprint` (or `RSS`) at a fixed
 /// interval and tracks the maximum observed value. Cheap enough to run with a
 /// 25-50ms period.
+#[derive(Debug)]
 pub struct PeakSampler {
     peak: Arc<AtomicU64>,
-    stop: Arc<AtomicBool>,
+    /// `true` once shutdown is requested; paired with the condvar so the
+    /// sampler's poll wait can be interrupted immediately on drop.
+    shutdown: Arc<(Mutex<bool>, Condvar)>,
     handle: Option<thread::JoinHandle<()>>,
 }
 
 impl PeakSampler {
-    pub fn start(period_ms: u64) -> Self {
+    /// Start the sampler thread polling every `period_ms` milliseconds.
+    ///
+    /// Rejects `period_ms == 0` (the poll wait would return immediately,
+    /// turning the sampler into a busy loop on the process-memory read) and
+    /// periods above [`MAX_SAMPLE_PERIOD_MS`] (useless for profiling). The
+    /// poll wait is condvar-based, so dropping the sampler interrupts it
+    /// immediately instead of blocking shutdown for up to a full period.
+    pub fn start(period_ms: u64) -> anyhow::Result<Self> {
+        if period_ms == 0 || period_ms > MAX_SAMPLE_PERIOD_MS {
+            anyhow::bail!(
+                "sample period must be between 1 and {} ms, got {}",
+                MAX_SAMPLE_PERIOD_MS,
+                period_ms
+            );
+        }
         let peak = Arc::new(AtomicU64::new(0));
-        let stop = Arc::new(AtomicBool::new(false));
+        let shutdown = Arc::new((Mutex::new(false), Condvar::new()));
         let peak_t = peak.clone();
-        let stop_t = stop.clone();
+        let shutdown_t = shutdown.clone();
         let handle = thread::spawn(move || {
-            while !stop_t.load(Ordering::Relaxed) {
+            let (stopped, cvar) = &*shutdown_t;
+            loop {
                 let rss = match process_memory() {
                     Ok((rss, _)) => rss,
                     Err(e) => {
@@ -88,14 +111,21 @@ impl PeakSampler {
                         Err(observed) => cur = observed,
                     }
                 }
-                thread::sleep(Duration::from_millis(period_ms));
+                // Wait out the poll period, waking immediately on shutdown.
+                let guard = stopped.lock().unwrap();
+                let (guard, _timeout) = cvar
+                    .wait_timeout_while(guard, Duration::from_millis(period_ms), |stop| !*stop)
+                    .unwrap();
+                if *guard {
+                    break;
+                }
             }
         });
-        Self {
+        Ok(Self {
             peak,
-            stop,
+            shutdown,
             handle: Some(handle),
-        }
+        })
     }
 
     /// Read current peak without resetting.
@@ -111,7 +141,9 @@ impl PeakSampler {
 
 impl Drop for PeakSampler {
     fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
+        let (stopped, cvar) = &*self.shutdown;
+        *stopped.lock().unwrap() = true;
+        cvar.notify_all();
         if let Some(h) = self.handle.take() {
             let _ = h.join();
         }
@@ -120,6 +152,40 @@ impl Drop for PeakSampler {
 
 pub fn fmt_mb(bytes: u64) -> String {
     format!("{:.1}", bytes as f64 / (1024.0 * 1024.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    /// Dropping the sampler must not block on the tail of a long poll sleep:
+    /// `Drop` joins the sampler thread, so a non-interruptible
+    /// `thread::sleep(period)` makes shutdown take up to a full period after
+    /// the work is done (audit finding: unbounded sampler interval).
+    #[test]
+    fn dropping_sampler_with_long_period_is_prompt() {
+        let t0 = Instant::now();
+        {
+            let _sampler = PeakSampler::start(10_000).unwrap();
+            thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            t0.elapsed() < Duration::from_secs(2),
+            "dropping the sampler blocked on its poll sleep ({}ms)",
+            t0.elapsed().as_millis()
+        );
+    }
+
+    /// A zero period would make the poll wait return immediately, turning the
+    /// sampler thread into a busy loop on the process-memory read.
+    #[test]
+    fn sampler_rejects_out_of_range_periods() {
+        let err = PeakSampler::start(0).unwrap_err();
+        assert!(err.to_string().contains("between 1 and"), "got: {err}");
+        let err = PeakSampler::start(MAX_SAMPLE_PERIOD_MS + 1).unwrap_err();
+        assert!(err.to_string().contains("between 1 and"), "got: {err}");
+    }
 }
 
 #[cfg(target_vendor = "apple")]

--- a/wormhole/memprof/src/report.rs
+++ b/wormhole/memprof/src/report.rs
@@ -27,7 +27,7 @@ pub struct PhaseReport {
 
 impl PhaseReport {
     pub fn new(sample_period_ms: u64) -> Result<Self> {
-        let sampler = PeakSampler::start(sample_period_ms);
+        let sampler = PeakSampler::start(sample_period_ms)?;
         let (start, _) = process_memory()?;
         let rows = vec![PhaseRow {
             label: "startup".to_string(),

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -119,14 +119,21 @@ fn private_batch_verifier() -> VerifierCircuitData<F, C, D> {
 /// from the header fields, so the proof is non-dummy (`test_inputs_0` uses the
 /// dummy sentinel `block_hash == 0`, which pools into the dummy bucket that
 /// `PublicBatchAggregator` refuses to aggregate).
-fn test_inputs_with_real_block() -> CircuitInputs {
+/// Replace the dummy-sentinel block hash (0) with the genuine hash of the
+/// inputs' header fields, making the resulting leaf proof non-dummy. Needed
+/// wherever a batch is aggregated: `PrivateBatchProver::commit` rejects
+/// all-dummy leaf batches (they settle nothing on-chain).
+fn with_real_block(mut inputs: CircuitInputs) -> CircuitInputs {
     use wormhole_circuit::block_header::header::HeaderInputs;
 
-    let mut inputs = CircuitInputs::test_inputs_0();
     inputs.public.block_hash = HeaderInputs::try_from(&inputs)
         .expect("header inputs from test inputs")
         .block_hash();
     inputs
+}
+
+fn test_inputs_with_real_block() -> CircuitInputs {
+    with_real_block(CircuitInputs::test_inputs_0())
 }
 
 /// Valid leaf inputs like `test_inputs_0` but for a non-native asset. The asset
@@ -149,7 +156,7 @@ fn test_inputs_with_asset(asset_id: u32) -> CircuitInputs {
 
 #[test]
 fn aggregate_single_proof() {
-    let proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
+    let proof = make_leaf_proof(&test_inputs_with_real_block());
 
     // A single proof in a 2-slot batch exercises dummy padding.
     let aggregated = make_private_batch_prover()
@@ -163,7 +170,7 @@ fn aggregate_single_proof() {
 #[test]
 fn aggregate_proofs_into_tree() {
     // All proofs must be from the SAME BLOCK for fixed-structure aggregation.
-    let inputs = CircuitInputs::test_inputs_0();
+    let inputs = test_inputs_with_real_block();
 
     let proof_0 = make_leaf_proof(&inputs);
     let proof_1 = make_leaf_proof(&inputs);
@@ -225,7 +232,7 @@ fn full_batch_of_same_nonzero_asset_aggregates() {
     // Sanity check for the fail-fast path: a FULL batch of same-asset proofs
     // needs no dummy padding, so a non-native asset is fine and the
     // compatibility preflight lets it through to real proving.
-    let inputs = test_inputs_with_asset(5);
+    let inputs = with_real_block(test_inputs_with_asset(5));
     let proof_0 = make_leaf_proof(&inputs);
     let proof_1 = make_leaf_proof(&inputs);
 
@@ -248,13 +255,13 @@ fn aggregate_proofs_from_separate_prover_instances_hex_serialized() {
 
     // Proof 1 from prover A
     let prover_a = WormholeProver::new(circuit_config());
-    let inputs_1 = CircuitInputs::test_inputs_0();
+    let inputs_1 = test_inputs_with_real_block();
     let proof_1 = prover_a.commit(&inputs_1).unwrap().prove().unwrap();
     let proof_1_hex = hex::encode(proof_1.to_bytes());
 
     // Proof 2 from prover B (same block)
     let prover_b = WormholeProver::new(circuit_config());
-    let inputs_2 = CircuitInputs::test_inputs_0();
+    let inputs_2 = test_inputs_with_real_block();
     let proof_2 = prover_b.commit(&inputs_2).unwrap().prove().unwrap();
     let proof_2_hex = hex::encode(proof_2.to_bytes());
 
@@ -372,7 +379,7 @@ fn private_batch_prover_ignores_prover_artifact() {
     }
 
     let aggregate_and_verify = |bins: &std::path::Path| {
-        let proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
+        let proof = make_leaf_proof(&test_inputs_with_real_block());
         let aggregated = PrivateBatchProver::new_from_binaries_dir(bins)
             .expect("prover must load without a trusted prover artifact")
             .aggregate(vec![proof])

--- a/wormhole/tests/src/prover/prover_tests.rs
+++ b/wormhole/tests/src/prover/prover_tests.rs
@@ -150,7 +150,7 @@ fn build_4ary_tree(leaves: &[Hash256]) -> (Hash256, Vec<Vec<Hash256>>) {
                 children[i] = *child;
             }
             // hash_node sorts children internally before hashing
-            next_level.push(hash_node(&children));
+            next_level.push(hash_node(&children).expect("test children are canonical"));
         }
 
         levels.push(next_level);
@@ -227,7 +227,8 @@ fn verify_proof_native(
     for (level_siblings, &position) in siblings.iter().zip(positions.iter()) {
         let sorted_children = insert_at_position(current_hash, level_siblings, position)
             .expect("test positions are always 0-3");
-        current_hash = hash_node_presorted(&sorted_children);
+        current_hash =
+            hash_node_presorted(&sorted_children).expect("test children are canonical");
     }
 
     current_hash == expected_root

--- a/wormhole/tests/src/prover/prover_tests.rs
+++ b/wormhole/tests/src/prover/prover_tests.rs
@@ -227,8 +227,7 @@ fn verify_proof_native(
     for (level_siblings, &position) in siblings.iter().zip(positions.iter()) {
         let sorted_children = insert_at_position(current_hash, level_siblings, position)
             .expect("test positions are always 0-3");
-        current_hash =
-            hash_node_presorted(&sorted_children).expect("test children are canonical");
+        current_hash = hash_node_presorted(&sorted_children).expect("test children are canonical");
     }
 
     current_hash == expected_root

--- a/wormhole/tests/tests/spec_differential.rs
+++ b/wormhole/tests/tests/spec_differential.rs
@@ -231,7 +231,7 @@ proptest! {
             bytes32_from_limbs(c3),
         ];
         // Chain/circuit node hash (presorted path does not sort), decoded to felts.
-        let actual = hash_to_felts(&hash_node_presorted(&children_bytes));
+        let actual = hash_to_felts(&hash_node_presorted(&children_bytes).unwrap());
 
         // Spec nodeHash: H over the concatenated child digests (4 × 4 = 16 felts).
         let mut preimage: Vec<F> = Vec::with_capacity(16);
@@ -259,7 +259,7 @@ proptest! {
         let sibs_b: [Hash256; 3] =
             [bytes32_from_limbs(s0), bytes32_from_limbs(s1), bytes32_from_limbs(s2)];
         let ordered = insert_at_position(cur_b, &sibs_b, pos).unwrap();
-        let actual = hash_to_felts(&hash_node_presorted(&ordered));
+        let actual = hash_to_felts(&hash_node_presorted(&ordered).unwrap());
 
         // Spec stepUp: the four children with `cur` at `pos`.
         let children = match pos {

--- a/wormhole/tests/tests/spec_differential.rs
+++ b/wormhole/tests/tests/spec_differential.rs
@@ -14,6 +14,9 @@
 //!     (`WormholeSpec.Aggregation.groupExits` / `RPrivateBatch_value_conservation`)
 //!   * the block-reference prefix scan (`referenceFromFirstReal`)
 //!   * dummy-nullifier replacement `DNull(u)=H(H(u))` (`WormholeSpec.Hash.dummyNull`)
+//!   * the nullifier-region sort order (`WormholeSpec.Aggregation.digestLt` /
+//!     `nullifiersSorted` ↔ the native `[u64; 4]` order the circuit tests pin
+//!     `sort_digests4` against)
 //!   * the block-header preimage order (`WormholeSpec.Leaf.headerPreimage`)
 //!
 //! The `hh`/`H` model is plonky2's `Poseidon2Hash`, the same hasher the spec's
@@ -386,6 +389,51 @@ proptest! {
         let spec_dummy = hh(&pre);
         prop_assert_eq!(circuit_dummy, spec_dummy);
         prop_assert_ne!(circuit_dummy, inner);
+    }
+
+    /// The nullifier-region sort order the spec models (`digestLt`, strict
+    /// lexicographic with limb 0 most significant) is the order the circuit
+    /// enforces: the circuit tests pin `sort_digests4` output against native
+    /// `<[u64; 4] as Ord>` sorting, and this test pins that native order to the
+    /// spec's `digestLt`, closing the circuit ↔ native ↔ spec chain. Also checks
+    /// the sorted result satisfies the spec's `nullifiersSorted` predicate
+    /// (pairwise `digestLE` on adjacent slots suffices: the order is total and
+    /// transitive).
+    #[test]
+    fn nullifier_sort_order_matches_spec(
+        digests in prop::collection::vec(prop::array::uniform4(0u64..GOLDILOCKS), 0..16),
+    ) {
+        /// Mirrors `WormholeSpec.Aggregation.digestLt` clause for clause.
+        fn digest_lt_spec(a: &[u64; 4], b: &[u64; 4]) -> bool {
+            a[0] < b[0]
+                || (a[0] == b[0]
+                    && (a[1] < b[1]
+                        || (a[1] == b[1]
+                            && (a[2] < b[2] || (a[2] == b[2] && a[3] < b[3])))))
+        }
+
+        // Native reference order (what the circuit tests sort expected regions by).
+        let mut native_sorted = digests.clone();
+        native_sorted.sort();
+
+        // Spec order.
+        let mut spec_sorted = digests.clone();
+        spec_sorted.sort_by(|a, b| {
+            if digest_lt_spec(a, b) {
+                std::cmp::Ordering::Less
+            } else if a == b {
+                std::cmp::Ordering::Equal
+            } else {
+                std::cmp::Ordering::Greater
+            }
+        });
+
+        prop_assert_eq!(&native_sorted, &spec_sorted);
+
+        // `nullifiersSorted`: adjacent pairs satisfy `digestLE` (lt or eq).
+        for w in native_sorted.windows(2) {
+            prop_assert!(digest_lt_spec(&w[0], &w[1]) || w[0] == w[1]);
+        }
     }
 
     /// Block-header preimage order (`HeaderInputs::block_hash` ↔ `headerPreimage`):

--- a/wormhole/verifier/Cargo.toml
+++ b/wormhole/verifier/Cargo.toml
@@ -13,8 +13,11 @@ qp-plonky2-verifier = { version = "=1.5.4", default-features = false }
 qp-wormhole-inputs = { version = "=3.1.0", path = "../inputs", default-features = false }
 tiny-keccak = { workspace = true }
 
+# Only used by the std-gated artifact reader (O_NONBLOCK open); optional and
+# std-gated so --no-default-features builds keep libc (and libc/std) out of
+# the dependency graph entirely.
 [target.'cfg(unix)'.dependencies]
-libc = "=0.2.186"
+libc = { version = "=0.2.186", default-features = false, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -23,6 +26,7 @@ criterion = { workspace = true }
 default = ["std"]
 std = [
 	"anyhow/std",
+	"dep:libc",
 	"qp-plonky2-verifier/std",
 	"qp-wormhole-inputs/std",
 ]

--- a/wormhole/verifier/Cargo.toml
+++ b/wormhole/verifier/Cargo.toml
@@ -13,6 +13,9 @@ qp-plonky2-verifier = { version = "=1.5.4", default-features = false }
 qp-wormhole-inputs = { version = "=3.1.0", path = "../inputs", default-features = false }
 tiny-keccak = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "=0.2.186"
+
 [dev-dependencies]
 criterion = { workspace = true }
 

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -111,12 +111,90 @@ const CANONICAL_LEAF_COMMON_KECCAK256: [u8; 32] = [
     0xb1, 0x82, 0x2e, 0xf0, 0x26, 0x37, 0xe8, 0xd8, 0x51, 0x2d, 0x8a, 0xbb, 0x79, 0x74, 0x80, 0xe3,
 ];
 
+/// Maximum size accepted for a serialized verifier artifact file.
+///
+/// The canonical leaf verifier/common artifacts are a few KB; 64 MiB (the same
+/// bound the aggregator applies to its artifacts) gives generous headroom
+/// while bounding the allocation an untrusted artifact path can force. Without
+/// a cap, an oversized or sparse file is read fully into memory BEFORE the
+/// keccak256 canonicality pin gets a chance to reject it.
+#[cfg(feature = "std")]
+pub const MAX_ARTIFACT_FILE_BYTES: u64 = 64 * 1024 * 1024;
+
 fn keccak256(input: &[u8]) -> [u8; 32] {
     let mut output = [0u8; 32];
     let mut hasher = Keccak::v256();
     hasher.update(input);
     hasher.finalize(&mut output);
     output
+}
+
+/// Read a verifier-artifact file, refusing anything larger than
+/// [`MAX_ARTIFACT_FILE_BYTES`] before allocating for its contents.
+///
+/// Only regular files are accepted. A FIFO, device node, or symlink to one
+/// planted at an artifact path would otherwise block `open` (a FIFO with no
+/// writer) or `read_to_end` (a stream that never reaches EOF) forever,
+/// independent of the size cap. On unix the open uses `O_NONBLOCK` so even
+/// the FIFO-open case cannot stall; the file type is then checked via `fstat`
+/// on the opened handle before any read. `O_NONBLOCK` has no effect on
+/// regular-file opens or reads.
+///
+/// The size is checked via `fstat` on the already-opened handle (no
+/// stat-then-open race), and the read itself is additionally capped with
+/// `Read::take` in case the file grows after the check.
+///
+/// This mirrors `read_artifact_file` in the aggregator crate; the verifier
+/// crate stays lean (no dependency on the prover-side crates), so the ~40
+/// lines are duplicated rather than shared. Keep the two in lockstep.
+#[cfg(feature = "std")]
+fn read_artifact_file(path: &Path) -> anyhow::Result<Vec<u8>> {
+    use anyhow::Context as _;
+    use std::io::Read as _;
+
+    let mut options = std::fs::File::options();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.custom_flags(libc::O_NONBLOCK);
+    }
+    let file = options
+        .open(path)
+        .with_context(|| format!("failed to open artifact file {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("failed to stat artifact file {}", path.display()))?;
+    if !metadata.file_type().is_file() {
+        return Err(anyhow!(
+            "artifact file {} is not a regular file; refusing to load it",
+            path.display()
+        ));
+    }
+    let claimed_len = metadata.len();
+    if claimed_len > MAX_ARTIFACT_FILE_BYTES {
+        return Err(anyhow!(
+            "artifact file {} is {} bytes, which exceeds the {} byte limit for \
+             verifier artifacts; refusing to load it",
+            path.display(),
+            claimed_len,
+            MAX_ARTIFACT_FILE_BYTES
+        ));
+    }
+
+    let mut bytes = Vec::with_capacity(claimed_len as usize);
+    file.take(MAX_ARTIFACT_FILE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("failed to read artifact file {}", path.display()))?;
+    if bytes.len() as u64 > MAX_ARTIFACT_FILE_BYTES {
+        return Err(anyhow!(
+            "artifact file {} grew past the {} byte limit for verifier artifacts \
+             while being read; refusing to load it",
+            path.display(),
+            MAX_ARTIFACT_FILE_BYTES
+        ));
+    }
+    Ok(bytes)
 }
 
 impl WormholeVerifier {
@@ -192,13 +270,19 @@ impl WormholeVerifier {
     }
 
     /// Creates a new [`WormholeVerifier`] from a verifier and common data files.
+    ///
+    /// Both files are read through [`read_artifact_file`], which rejects
+    /// non-regular files and anything larger than [`MAX_ARTIFACT_FILE_BYTES`]
+    /// before buffering, so an untrusted artifact path cannot stall or
+    /// memory-starve verifier startup. The keccak256 canonicality pin in
+    /// [`Self::new_from_bytes`] then rejects any non-canonical contents.
     #[cfg(feature = "std")]
     pub fn new_from_files(
         verifier_data_path: &Path,
         common_data_path: &Path,
     ) -> anyhow::Result<Self> {
-        let verifier_bytes = std::fs::read(verifier_data_path)?;
-        let common_bytes = std::fs::read(common_data_path)?;
+        let verifier_bytes = read_artifact_file(verifier_data_path)?;
+        let common_bytes = read_artifact_file(common_data_path)?;
 
         Self::new_from_bytes(&verifier_bytes, &common_bytes)
     }
@@ -221,5 +305,95 @@ impl WormholeVerifier {
     /// Returns an error if the proof is not valid.
     pub fn verify(&self, proof: ProofWithPublicInputs<F, C, D>) -> anyhow::Result<()> {
         self.verify_ref(&proof)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "qp-verifier-artifact-test-{}-{}",
+            tag,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// An oversized artifact file must be rejected by a size bound BEFORE its
+    /// contents are buffered, not after: `std::fs::read` would otherwise
+    /// allocate and read the whole file just so the keccak pin can reject it,
+    /// letting an attacker-planted sparse file memory-starve verifier startup
+    /// (audit finding: unbounded trusted file reads).
+    #[test]
+    fn new_from_files_rejects_oversized_artifact_before_reading() {
+        let dir = temp_dir("oversized");
+
+        let verifier_path = dir.join("verifier.bin");
+        let common_path = dir.join("common.bin");
+        // A sparse file claims an enormous length without costing disk space,
+        // exactly like an attacker-planted artifact would.
+        std::fs::File::create(&verifier_path)
+            .unwrap()
+            .set_len(MAX_ARTIFACT_FILE_BYTES + 1)
+            .unwrap();
+        std::fs::write(&common_path, b"irrelevant").unwrap();
+
+        let err = WormholeVerifier::new_from_files(&verifier_path, &common_path).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("exceeds the"),
+            "oversized artifact must be rejected by the size cap, got: {err:#}"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A FIFO planted at an artifact path must produce a prompt error, not a
+    /// hang: a blocking `File::open` on a FIFO with no writer stalls forever,
+    /// before any size or content check can run (audit finding: unbounded
+    /// trusted file reads).
+    #[cfg(unix)]
+    #[test]
+    fn new_from_files_rejects_fifo_without_blocking() {
+        use std::os::unix::ffi::OsStrExt as _;
+
+        let dir = temp_dir("fifo");
+
+        let fifo = dir.join("verifier.bin");
+        let c_path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+        assert_eq!(
+            unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) },
+            0,
+            "mkfifo failed"
+        );
+        let common_path = dir.join("common.bin");
+        std::fs::write(&common_path, b"irrelevant").unwrap();
+
+        // Run on a helper thread so a regression (blocking open or read)
+        // surfaces as a test failure instead of hanging the suite.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let fifo_for_thread = fifo.clone();
+        let common_for_thread = common_path.clone();
+        std::thread::spawn(move || {
+            let _ = tx.send(
+                WormholeVerifier::new_from_files(&fifo_for_thread, &common_for_thread).map(drop),
+            );
+        });
+
+        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+            Ok(result) => {
+                let err = result.unwrap_err();
+                assert!(
+                    format!("{err:#}").contains("not a regular file"),
+                    "got: {err:#}"
+                );
+            }
+            Err(_) => panic!("new_from_files blocked on a FIFO artifact path"),
+        }
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }


### PR DESCRIPTION
# Security review fixes (batch v12-5089)

This PR resolves eleven findings from the security review. Each finding was
first reproduced with a failing (red) test, then fixed, with the test kept as
a regression guard. One commit per finding.

## Circuit / protocol soundness

### Private-batch nullifier region emitted in enforced canonical order (`e188ef5`)

Exit slots and nullifiers were emitted positionally aligned in the aggregated
public inputs, so an observer could link each payout slot to the nullifier of
the leaf proof that produced it, eroding the privacy that shuffling and dummy
padding are meant to provide. The private-batch circuit now sorts the
nullifier region in-circuit with an odd-even transposition network before
registering it. The comparison gadget enforces canonical 32-bit limb
decomposition (`split_canonical_u32_halves`), so the sorted order is sound
even against a malicious prover — a prover cannot exploit non-canonical field
encodings to mis-order the output. `formal/SPEC.md` updated accordingly.

### `hash_bytes_compact` collision on unaligned input (`e012aa4`)

The compact 8-bytes-per-felt encoding zero-pads the final chunk, so inputs
differing only by trailing zeros within the last chunk hashed identically.
The function is now `pub(crate)` and rejects inputs whose length is not a
multiple of 8. All in-repo callers already pass fixed-size aligned input.

### Aggregated public input mislabeled exit-slot count (`3340488`)

`PrivateBatchPublicInputs` named the index-0 header felt `num_unique_exits`
and documented it as a deduplicated unique-exit-account count, but the
circuit writes the structural constant `2 * n_leaf` (total exit slots) there.
An integrator trusting the field would over-count payout accounts. The field
is renamed `num_exit_slots` with accurate docs, and both parsers now reject
public inputs whose header felt does not equal the length-derived `2*N`, so
a parsed struct can never contradict its own layout.

## Denial of service / resource exhaustion

### Merkle proof normalization did unbounded work (`aaaf723`)

`ZkMerkleProof::from_unsorted` (and its duplicate in the wormhole circuit
crate) allocated and iterated proportionally to attacker-controlled input
length. Both now return `Result` and reject sibling lists deeper than
`MAX_DEPTH` before doing any work.

### Aggregator artifact loading blocked on non-regular files (`2d0576b`)

`read_artifact_file` used a plain `File::open`, which blocks forever on a
FIFO with no writer, and read without a size cap. It now opens with
`O_NONBLOCK` on Unix, rejects non-regular files after `fstat`, checks the
claimed size against `MAX_ARTIFACT_FILE_BYTES` before allocating, and caps
the read with `Read::take`. `CircuitBinsConfig::load` is routed through the
same hardened reader.

### All-dummy batches accepted at the public-batch commit boundary (`23860e8`)

`PublicBatchProver::commit` accepted a batch in which every private-batch
proof was the all-dummy sentinel, burning a minutes-long proving window on a
proof the chain rejects. `ensure_private_batch_compatible` now bails when no
non-dummy reference proof exists. Benchmarks that previously committed
all-dummy batches were converted to build one real private-batch proof at
setup and reuse it.

### Verifier artifact reads were unbounded (`602ec87`)

`WormholeVerifier::new_from_files` buffered `verifier.bin` / `common.bin`
without limit and could block on non-regular files. It now uses a bounded,
non-blocking reader (same pattern as the aggregator's) with a 64 MiB cap
enforced before allocation and after read.

### memprof sampler period unbounded (`fe047cf`)

`--sample-period-ms` was an unconstrained `u64`: `0` busy-looped the sampler
thread and a huge value hung shutdown, because `PeakSampler::drop` joins the
thread after its full sleep. The flag is bounded at parse time
(1..=60000 ms), validated again in `PeakSampler::start`, and the bare sleep
is replaced with a condvar wait that `drop` interrupts immediately.

## Operational robustness

### Non-atomic private-batch artifact publication (`0bc0a97`)

`generate_private_batch_circuit_binaries` wrote its three artifacts with
sequential `fs::write` calls, so a crash mid-publish left a mixed old/new
set, and a verifier-only rerun left a stale `dummy_private_batch_proof.bin`
behind. Publication now goes through a shared `commit_artifact_set`: stage
everything to temp files, swap the whole set in with rollback on failure,
and atomically remove stale files.

### Artifact writes followed planted symlinks (`192c5a1`)

Leaf-circuit binary generation and `CircuitBinsConfig::save` used direct
`fs::write`, which follows a symlink planted at the destination path and
clobbers whatever it points to. Both now publish through
`commit_artifact_set`, whose create-new staging plus rename never follows a
pre-existing symlink.

### Dropped in-flight batch permanently wedged spends (`39a0d0a`)

`ProofPool` released a taken batch's nullifier reservations only via
`complete`/`reinsert`; a proving worker that panicked and dropped its
`TakenBatch` wedged those spends until the aggregator was rebuilt.
`TakenBatch` now carries a drop guard that deposits its nullifiers into a
shared orphan inbox, drained by the pool at the start of every operation.
Explicit hand-back disarms the guard and behaves exactly as before; the
on-chain double-spend boundary was never affected.

## Testing

- Every finding has a dedicated red-to-green regression test colocated with
  the fix (pool, parser, artifact-publication, sampler, gadget, and circuit
  tests).
- Full workspace builds clean (`cargo build --release --workspace
  --all-targets`); aggregator suite 85/85, inputs, circuit, verifier, and
  memprof suites all green in release mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes private-batch public-input layout (sorted nullifiers) and aggregation parsers/API names, which can break integrators; also touches ZK gadget soundness and security-sensitive artifact loading and proof-pool reservation logic.
> 
> **Overview**
> This PR batches **eleven security-review fixes**, each guarded by a regression test. The highest-impact protocol change is in **private-batch aggregation**: nullifiers are no longer emitted in leaf-slot order. They are **canonically sorted in-circuit** via new gadgets (`digest4_lt`, `sort_digests4`, canonical 32-bit limb splits) so exit slots cannot be correlated with specific nullifiers. `formal/SPEC.md` documents the new behavior.
> 
> **Parsing / hashing hardening:** `hash_bytes_compact` is crate-private and rejects non–8-byte-aligned input (fixes compact-encoding collisions). `PrivateBatchPublicInputs` renames `num_unique_exits` → **`num_exit_slots`** and parsers reject header values that do not equal `2 * n_leaf`. Merkle **`from_unsorted`** now returns `Result` and rejects depth `> MAX_DEPTH` before hashing.
> 
> **DoS and untrusted paths:** Aggregator and verifier **`read_artifact_file`** paths use `O_NONBLOCK`, require regular files, and cap reads at 64 MiB; config load uses the same reader. **`commit_artifact_set`** stages artifacts and swaps them atomically (leaf, private-batch, public-batch, `config.json`), avoiding mixed generations and symlink-follow writes. **`PublicBatchProver::commit`** rejects all-dummy batches; benchmarks build one real private-batch proof instead of all-dummy padding.
> 
> **Operational:** Dropped **`TakenBatch`** values release nullifier reservations via a drop guard (`reap_orphaned`). memprof bounds **`--sample-period-ms`** and uses a condvar so shutdown is not blocked by long sleeps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334048813de8141cfbc44a3cc68d1b8b1e71494a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->