### PR TITLE
Entry-point caps, dummy exit invariant, and proof-pool redesign

### DIFF
--- a/common/src/circuit.rs
+++ b/common/src/circuit.rs
@@ -38,27 +38,67 @@ pub const MAX_STATE_ROOT_HEX_LEN: usize = 64;
 /// escape-inflated (6 bytes per decoded byte) but otherwise legal payloads.
 pub const MAX_TRANSFER_PROOF_JSON_BYTES: usize = 8 * 1024 * 1024;
 
-#[derive(Debug, Deserialize)]
+/// A parsed transfer-proof document.
+///
+/// This type deliberately does NOT implement `serde::Deserialize`: generic
+/// entry points (`serde_json::from_str`, `from_slice`, and especially the
+/// streaming `from_reader`) would bypass the raw-input cap that
+/// [`Self::from_json_str`] enforces, and the per-field visitor bounds alone
+/// cannot stop a streamed, escape-inflated string from being decoded into
+/// unbounded scratch storage first. All parsing must go through
+/// [`Self::from_json_str`].
+///
+/// ```compile_fail
+/// fn requires_deserialize<'de, T: serde::Deserialize<'de>>() {}
+/// requires_deserialize::<qp_zk_circuits_common::circuit::TransferProofJson>();
+/// ```
+#[derive(Debug)]
 pub struct TransferProofJson {
     pub transfer_count: u64,
-    #[serde(deserialize_with = "deserialize_bounded_state_root")]
-    pub state_root: String, // hex (no 0x)
-    #[serde(deserialize_with = "deserialize_bounded_storage_proof")]
+    pub state_root: String,         // hex (no 0x)
     pub storage_proof: Vec<String>, // hex-encoded nodes
-    #[serde(deserialize_with = "deserialize_bounded_indices")]
     pub indices: Vec<usize>,
+}
+
+/// Private deserialization target for [`TransferProofJson::from_json_str`].
+///
+/// The `Deserialize` impl lives on this non-public mirror so the only way to
+/// parse a [`TransferProofJson`] is through the raw-capped entry point; the
+/// per-field bounds below are defense in depth behind that cap, not a
+/// substitute for it.
+#[derive(Deserialize)]
+struct TransferProofJsonRaw {
+    transfer_count: u64,
+    #[serde(deserialize_with = "deserialize_bounded_state_root")]
+    state_root: String,
+    #[serde(deserialize_with = "deserialize_bounded_storage_proof")]
+    storage_proof: Vec<String>,
+    #[serde(deserialize_with = "deserialize_bounded_indices")]
+    indices: Vec<usize>,
+}
+
+impl From<TransferProofJsonRaw> for TransferProofJson {
+    fn from(raw: TransferProofJsonRaw) -> Self {
+        Self {
+            transfer_count: raw.transfer_count,
+            state_root: raw.state_root,
+            storage_proof: raw.storage_proof,
+            indices: raw.indices,
+        }
+    }
 }
 
 impl TransferProofJson {
     /// Parse untrusted transfer-proof JSON, bounding allocation up front.
     ///
-    /// This is the entry point services should use for attacker-supplied
-    /// payloads. The raw document length is checked against
-    /// [`MAX_TRANSFER_PROOF_JSON_BYTES`] BEFORE any parsing: the per-field
-    /// Serde bounds only observe string lengths after the deserializer has
-    /// decoded escaped content into scratch storage, so on their own they
-    /// cannot stop a single escape-inflated field from allocating and
-    /// scanning arbitrarily far past its cap before being rejected.
+    /// This is the ONLY parse path (the type does not implement
+    /// `Deserialize`; see the type-level docs). The raw document length is
+    /// checked against [`MAX_TRANSFER_PROOF_JSON_BYTES`] BEFORE any parsing:
+    /// the per-field Serde bounds only observe string lengths after the
+    /// deserializer has decoded escaped content into scratch storage, so on
+    /// their own they cannot stop a single escape-inflated field from
+    /// allocating and scanning arbitrarily far past its cap before being
+    /// rejected.
     pub fn from_json_str(json: &str) -> Result<Self, String> {
         if json.len() > MAX_TRANSFER_PROOF_JSON_BYTES {
             return Err(format!(
@@ -67,14 +107,16 @@ impl TransferProofJson {
                 json.len()
             ));
         }
-        serde_json::from_str(json).map_err(|e| format!("failed to parse transfer proof JSON: {e}"))
+        serde_json::from_str::<TransferProofJsonRaw>(json)
+            .map(Self::from)
+            .map_err(|e| format!("failed to parse transfer proof JSON: {e}"))
     }
 
     /// Validate the decoded transfer proof bounds.
     ///
-    /// `#[serde(deserialize_with)]` enforces the same caps on parsed documents
-    /// (though only after the deserializer has decoded each string — see
-    /// [`Self::from_json_str`] for the raw-input bound); this is a convenience
+    /// Parsed documents already satisfy these caps (the private
+    /// deserialization mirror enforces them per field, behind
+    /// [`Self::from_json_str`]'s raw-input bound); this is a convenience
     /// check for callers that construct the struct directly.
     pub fn validate(&self) -> Result<(), String> {
         if self.state_root.len() > MAX_STATE_ROOT_HEX_LEN {
@@ -119,8 +161,9 @@ impl TransferProofJson {
 ///
 /// NOTE: for escaped or streamed input the deserializer must decode the string
 /// into its own scratch storage before this visitor can observe the length, so
-/// this bound alone does not cap allocation. [`TransferProofJson::from_json_str`]
-/// bounds the raw document first; use it for untrusted payloads.
+/// this bound alone does not cap allocation. That is why these visitors are
+/// only reachable through [`TransferProofJson::from_json_str`], which bounds
+/// the raw document first.
 fn deserialize_bounded_state_root<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: Deserializer<'de>,
@@ -382,8 +425,8 @@ mod transfer_proof_json_tests {
             r#"{{"transfer_count":1,"state_root":"00","storage_proof":["{}"],"indices":[]}}"#,
             oversized
         );
-        let err = serde_json::from_str::<TransferProofJson>(&json).unwrap_err();
-        assert!(err.to_string().contains("storage_proof node exceeds"));
+        let err = TransferProofJson::from_json_str(&json).unwrap_err();
+        assert!(err.contains("storage_proof node exceeds"));
     }
 
     /// A single field written as JSON escape sequences forces serde_json to

--- a/common/src/circuit.rs
+++ b/common/src/circuit.rs
@@ -52,6 +52,21 @@ pub const MAX_TRANSFER_PROOF_JSON_BYTES: usize = 8 * 1024 * 1024;
 /// fn requires_deserialize<'de, T: serde::Deserialize<'de>>() {}
 /// requires_deserialize::<qp_zk_circuits_common::circuit::TransferProofJson>();
 /// ```
+///
+/// The passing companion below exercises the same fully qualified path (and
+/// the sanctioned parse route). A `compile_fail` test asserts only that
+/// *some* compile error occurs, so on its own it would keep passing — for
+/// the wrong reason — if the crate were renamed, the module moved, or serde
+/// stopped resolving in the doctest environment. Any of those now breaks
+/// this visible test instead of silently disarming the pin above.
+///
+/// ```
+/// use serde::Deserialize as _; // serde must resolve here for the pin to be meaningful
+/// let doc = qp_zk_circuits_common::circuit::TransferProofJson::from_json_str(
+///     r#"{"transfer_count":1,"state_root":"00","storage_proof":["00"],"indices":[0]}"#,
+/// ).unwrap();
+/// assert_eq!(doc.transfer_count, 1);
+/// ```
 #[derive(Debug)]
 pub struct TransferProofJson {
     pub transfer_count: u64,

--- a/formal/SPEC.md
+++ b/formal/SPEC.md
@@ -86,8 +86,8 @@ hermetic. Toolchain is pinned in `lean-toolchain` (Lean `v4.30`).
 | `nullifiersReplaced` `DNull(u)=H(H(u))`, held of the pre-sort list (`∃ raw, … ∧ Perm` in `RPrivateBatch`) | `hash_dummy_nullifier_pre_image` — `circuit_logic.rs` |
 | `nullifiersSorted` over `digestLt`/`digestLE` (region in ascending canonical order; position decorrelated from exit slots) | `sort_digests4` over selected nullifiers — `circuit_logic.rs`; gadget in `common/src/gadgets.rs` |
 | `isDummyPrivateBatch = blockHash=0` (weaker sentinel) | dummy detection at private-batch — `circuit_logic.rs` |
-| `groupExits` / `matchSum` (per-slot group sum + first-occurrence dedup) | exit-account grouping loop — `circuit_logic.rs:214–287` |
-| **thm** `RPrivateBatch_value_conservation`: `outputExitTotal = rawOutputTotal` | derived from the grouping primitive (was an assumed conjunct) |
+| `maskedChildPairs` → `groupExits` / `matchSum` (dummy slots masked to `(zero, 0)` at ingress; per-slot group sum + first-occurrence dedup) | dummy-mask selects + exit-account grouping loop — `circuit_logic.rs` |
+| **thm** `RPrivateBatch_value_conservation`: `outputExitTotal = inputExitTotal` (non-dummy total) | derived from the grouping primitive (was an assumed conjunct) |
 | **thm** `rawOutputTotal_lt_modulus`: total `< goldilocks` | explicit no-wraparound bound from 32-bit output range checks; Phase-2 field hypothesis (see note below) |
 | output layout (`PrivateBatchOutput`) | `aggregated_output` — `private_batch/circuit/constants.rs` |
 | `RPublicBatch` forwarding + consistency | `build_public_batch_constraints` — `public_batch/circuit/circuit_logic.rs` |
@@ -155,9 +155,13 @@ step is the Phase-4 preimage game, as for the other security theorems.
    `output_amount_2`, `volume_fee_bps` (all unconditional 32-bit), plus
    `block_number` in `BlockHeader::circuit_without_hash_binding`. `Rleaf` now asserts the full set.
 2. ~~Exit grouping/dedup.~~ **Done (conservation).** `RPrivateBatch` now pins the exact
-   in-circuit grouping (`groupExits`), and value conservation is the *derived*
-   theorem `RPrivateBatch_value_conservation` (with `rawOutputTotal_eq_inputExitTotal`
-   bridging to the non-dummy total under the dummy⟹zero-outputs guarantee).
+   in-circuit grouping (`groupExits` over the dummy-masked `maskedChildPairs`),
+   and value conservation is the *derived* theorem
+   `RPrivateBatch_value_conservation` — stated directly against the non-dummy
+   total `inputExitTotal`, with no compatibility hypothesis: the ingress mask
+   discharges dummy⟹zero-contribution structurally
+   (`rawOutputTotal_eq_inputExitTotal` remains as the leaf-side compatibility
+   statement for a full composition proof).
    Remaining: the full per-account *multiset* characterization (which account
    gets which sum) and `numExitSlots = 2·N` slot accounting (Phase 3).
    **Field caveat:** conservation is an exact `Nat` identity; over `ZMod p`
@@ -169,10 +173,15 @@ step is the Phase-4 preimage game, as for the other security theorems.
 3. **public-batch accounting.** `totalExitSlots` and aggregator-address binding semantics
    (Phase 3).
 4. **Dummy-notion compatibility.** Prove the leaf dummy (`blockHash=0 ∧ outs=0`)
-   and private-batch dummy (`blockHash=0`) interact safely (Phase 3).
+   and private-batch dummy (`blockHash=0`) interact safely (Phase 3). The exit
+   region is now independent of the gap (the ingress mask zeroes whatever a
+   `blockHash=0` child carries), narrowing the obligation to the nullifier and
+   metadata clauses.
 5. **`exit_account_1/2` are unconstrained at the leaf** — bound only at private-batch. The
    spec reflects this (no `Rleaf` clause references them); the binding obligation
-   lives in `RPrivateBatch`.
+   lives in `RPrivateBatch`, whose grouping masks dummy children's exits to the
+   canonical zero account (`maskedChildPairs`) so unconstrained dummy exit bytes
+   cannot mark padded slots in the aggregated output.
 6. **Game-based probabilistic accounting.** `Security.lean` proves the
    *deterministic* cores of one-time withdrawal and spend-path exclusivity as
    reductions to an `H` collision, clean under the `CollisionResistant` hypothesis.
@@ -224,7 +233,8 @@ step is the Phase-4 preimage game, as for the other security theorems.
 
 ## Intentionally-loose facts (must NOT be flagged as bugs)
 
-- Leaf exit accounts are free public inputs (above).
+- Leaf exit accounts are free public inputs (above); for dummy children the
+  private-batch wrapper masks them to zero in the output.
 - `asset_id` is constrained only via the Merkle leaf preimage, not a registry.
 - The two dummy notions differ by layer (above).
 - The `fake_leaf` test circuit does **not** implement C1–C5 and is not a

--- a/formal/SPEC.md
+++ b/formal/SPEC.md
@@ -88,7 +88,7 @@ hermetic. Toolchain is pinned in `lean-toolchain` (Lean `v4.30`).
 | `isDummyPrivateBatch = blockHash=0` (weaker sentinel) | dummy detection at private-batch — `circuit_logic.rs` |
 | `maskedChildPairs` → `groupExits` / `matchSum` (dummy slots masked to `(zero, 0)` at ingress; per-slot group sum + first-occurrence dedup) | dummy-mask selects + exit-account grouping loop — `circuit_logic.rs` |
 | **thm** `RPrivateBatch_value_conservation`: `outputExitTotal = inputExitTotal` (non-dummy total) | derived from the grouping primitive (was an assumed conjunct) |
-| **thm** `rawOutputTotal_lt_modulus`: total `< goldilocks` | explicit no-wraparound bound from 32-bit output range checks; Phase-2 field hypothesis (see note below) |
+| **thm** `rawOutputTotal_lt_modulus`: total `< goldilocks` (+ corollary `inputExitTotal_lt_modulus` for the masked total the circuit sums) | explicit no-wraparound bound from 32-bit output range checks; Phase-2 field hypothesis (see note below) |
 | output layout (`PrivateBatchOutput`) | `aggregated_output` — `private_batch/circuit/constants.rs` |
 | `RPublicBatch` forwarding + consistency | `build_public_batch_constraints` — `public_batch/circuit/circuit_logic.rs` |
 

--- a/formal/WormholeSpec/Aggregation.lean
+++ b/formal/WormholeSpec/Aggregation.lean
@@ -44,8 +44,9 @@
   while the total cannot wrap — i.e. under the explicit hypothesis
   `rawOutputTotal leaves < goldilocks`. That bound is *not* hand-waved: it is
   discharged below (`rawOutputTotal_lt_modulus`) from the leaf circuit's 32-bit
-  output range checks plus a batch-size bound (and it covers the masked
-  accumulator too, via `inputExitTotal_le_rawOutputTotal`), with an enormous margin
+  output range checks plus a batch-size bound — with the masked-accumulator form
+  the circuit actually needs stated as `inputExitTotal_lt_modulus` — and it has
+  an enormous margin
   (`n · 2³³ < p` holds for any `n < 2³¹`, versus realistic batches of a few
   dozen). Phase 2 must (a) carry `rawOutputTotal leaves < goldilocks` as a
   hypothesis on the field-level conservation statement, and (b) rework the
@@ -398,6 +399,18 @@ theorem rawOutputTotal_lt_modulus {leaves : List LeafPublic} {M : Felt}
     (hbatch : leaves.length * (2 * M) < goldilocks) :
     rawOutputTotal leaves < goldilocks :=
   Nat.lt_of_le_of_lt (rawOutputTotal_le_linear hM) hbatch
+
+/-- The no-wraparound bound stated directly for the *masked* (non-dummy) total —
+    what the in-circuit accumulator actually sums. This is the exact form the
+    Phase-2 field hypothesis needs for `inputExitTotal`, so callers get it
+    ready-made instead of chaining `inputExitTotal_le_rawOutputTotal` with
+    `rawOutputTotal_lt_modulus` by hand. -/
+theorem inputExitTotal_lt_modulus {leaves : List LeafPublic} {M : Felt}
+    (hM : ∀ p ∈ leaves, p.outputAmount1 ≤ M ∧ p.outputAmount2 ≤ M)
+    (hbatch : leaves.length * (2 * M) < goldilocks) :
+    inputExitTotal leaves < goldilocks :=
+  Nat.lt_of_le_of_lt (inputExitTotal_le_rawOutputTotal leaves)
+    (rawOutputTotal_lt_modulus hM hbatch)
 
 /-- Under the leaf↔private-batch compatibility guarantee (a private-batch dummy carries zero
     outputs), the raw total coincides with the non-dummy total. No longer needed for

--- a/formal/WormholeSpec/Aggregation.lean
+++ b/formal/WormholeSpec/Aggregation.lean
@@ -14,17 +14,26 @@
       output position no longer identifies the producing leaf slot, so payout
       slots cannot be linked to nullifiers positionally;
     * the exit *grouping/dedup* primitive (`groupExits`) that builds the `2N`
-      settled slots.
+      settled slots, fed the *dummy-masked* child pairs (`maskedChildPairs`):
+      the circuit masks each dummy slot's (exit account, amount) to `(0, 0)`
+      at ingress, because leaf exit accounts are unconstrained public inputs
+      and a poisoned padding template could otherwise mark padded slots with
+      attacker-chosen zero-amount exits (audit finding: incomplete dummy
+      sentinel).
 
   Value conservation is no longer asserted: `R_L0` now pins the exact in-circuit
-  grouping, and conservation (`outputExitTotal = rawOutputTotal`) is *derived* as
-  a theorem (`RPrivateBatch_value_conservation`).
+  grouping over the masked pairs, and conservation
+  (`outputExitTotal = inputExitTotal`, the non-dummy total) is *derived* as a
+  theorem (`RPrivateBatch_value_conservation`).
 
   NOTE the *weaker* private-batch dummy sentinel: at layer 0 a child is treated as a
   dummy when `block_hash == 0` alone (`isDummyPrivateBatch`), versus the leaf circuit's
-  `block_hash == 0 ∧ outputs == 0`. Their compatibility (dummy ⟹ zero outputs) is
-  the hypothesis of `rawOutputTotal_eq_inputExitTotal`, the obligation a full
-  leaf↔private-batch composition proof must discharge.
+  `block_hash == 0 ∧ outputs == 0`. The ingress mask makes the exit region
+  independent of that gap (a masked dummy contributes `(0, 0)` regardless of what
+  the leaf carried), so conservation no longer needs the leaf↔private-batch
+  compatibility hypothesis; `rawOutputTotal_eq_inputExitTotal` keeps the
+  compatibility statement (dummy ⟹ zero outputs) available for a full
+  composition proof.
 
   CONSERVATION OVER `Nat` VS `ZMod p` (a Phase-2 caveat)
   ------------------------------------------------------
@@ -35,7 +44,8 @@
   while the total cannot wrap — i.e. under the explicit hypothesis
   `rawOutputTotal leaves < goldilocks`. That bound is *not* hand-waved: it is
   discharged below (`rawOutputTotal_lt_modulus`) from the leaf circuit's 32-bit
-  output range checks plus a batch-size bound, with an enormous margin
+  output range checks plus a batch-size bound (and it covers the masked
+  accumulator too, via `inputExitTotal_le_rawOutputTotal`), with an enormous margin
   (`n · 2³³ < p` holds for any `n < 2³¹`, versus realistic batches of a few
   dozen). Phase 2 must (a) carry `rawOutputTotal leaves < goldilocks` as a
   hypothesis on the field-level conservation statement, and (b) rework the
@@ -71,27 +81,35 @@ abbrev isDummyPrivateBatch (p : LeafPublic) : Prop := p.blockHash = Digest.zero
 /-- Boolean "is a real (non-dummy) child", for use with `List.find?`. -/
 def isRealB (p : LeafPublic) : Bool := ! decide (isDummyPrivateBatch p)
 
-/-- Total of the two output amounts over *every* child. This is exactly what the
-    in-circuit exit accumulator sums — it does not gate on the dummy flag. -/
+/-- Total of the two output amounts over *every* child, dummies included
+    (un-masked). Used for the no-wraparound bounds and the leaf-compatibility
+    statement; the circuit's accumulator itself sums the *masked* pairs
+    (`maskedChildPairs`), whose total is `inputExitTotal`. -/
 def rawOutputTotal : List LeafPublic → Felt
   | [] => 0
   | p :: rest => (p.outputAmount1 + p.outputAmount2) + rawOutputTotal rest
 
-/-- Output total restricted to non-dummy children (the value entering the batch,
-    once the leaf guarantee "dummy ⟹ zero outputs" is taken into account). -/
+/-- Output total restricted to non-dummy children: the value entering the
+    batch, and exactly what the masked accumulator sums. -/
 def inputExitTotal : List LeafPublic → Felt
   | [] => 0
   | p :: rest =>
       (if isDummyPrivateBatch p then 0 else p.outputAmount1 + p.outputAmount2) + inputExitTotal rest
 
-/-- The flattened `(account, amount)` outputs of all children, two per child.
-    These are the `2N` slot inputs to the grouping in
-    `build_private_batch_constraints`. -/
-def childPairs : List LeafPublic → List (Digest × Felt)
+/-- The flattened `(account, amount)` outputs of all children, two per child,
+    with each dummy child's pairs masked to the canonical `(zero, 0)` — exactly
+    the slot inputs the circuit feeds the grouping after its ingress mask
+    (the `select(is_dummy_i, 0, …)` in `build_private_batch_constraints`).
+    The mask exists because leaf exit accounts are unconstrained public
+    inputs: a poisoned dummy padding template could otherwise mark padded
+    slots with attacker-chosen zero-amount exits (audit finding: incomplete
+    dummy sentinel). -/
+def maskedChildPairs : List LeafPublic → List (Digest × Felt)
   | [] => []
   | p :: rest =>
-      (p.exitAccount1, p.outputAmount1) ::
-      (p.exitAccount2, p.outputAmount2) :: childPairs rest
+      (if isDummyPrivateBatch p then (Digest.zero, 0) else (p.exitAccount1, p.outputAmount1)) ::
+      (if isDummyPrivateBatch p then (Digest.zero, 0) else (p.exitAccount2, p.outputAmount2)) ::
+      maskedChildPairs rest
 
 /-- Sum of the amounts whose account equals `k`. Mirrors the per-slot
     `select(exit_j = key, amount_j, 0)` accumulation across all slots. -/
@@ -204,10 +222,11 @@ def RPrivateBatch (ro : RandomOracle) (leaves : List LeafPublic) (us : List (Lis
   nullifiersSorted out.nullifiers ∧
   out.nullifiers.length = leaves.length ∧
   -- Primitive exit construction: the settled slots are *exactly* the in-circuit
-  -- group/dedup of every child's two (account, amount) outputs. Value
+  -- group/dedup of every child's two (account, amount) outputs, with dummy
+  -- children masked to `(zero, 0)` at ingress (see `maskedChildPairs`). Value
   -- conservation is a derived theorem (`RPrivateBatch_value_conservation`), not an
   -- assumed conjunct.
-  out.exitSlots = groupExits (childPairs leaves)
+  out.exitSlots = groupExits (maskedChildPairs leaves)
   -- TODO(Phase 3): `numExitSlots = 2 * leaves.length` slot accounting.
 
 -- ── Value conservation, derived from the grouping primitive ─────────────────
@@ -291,30 +310,64 @@ theorem groupAux_conserves :
           simp only [amtNotIn, if_neg hk]
         rw [hR]; simp only [Felt] at *; omega
 
-/-- `amtNotIn []` over the children's pairs is the raw output total. -/
-theorem amtNotIn_nil_childPairs (leaves : List LeafPublic) :
-    amtNotIn [] (childPairs leaves) = rawOutputTotal leaves := by
+/-- `amtNotIn []` over the masked pairs is the non-dummy output total. -/
+theorem amtNotIn_nil_maskedChildPairs (leaves : List LeafPublic) :
+    amtNotIn [] (maskedChildPairs leaves) = inputExitTotal leaves := by
   induction leaves with
   | nil => rfl
   | cons p rest ih =>
-      show p.outputAmount1 + (p.outputAmount2 + amtNotIn [] (childPairs rest))
-          = (p.outputAmount1 + p.outputAmount2) + rawOutputTotal rest
-      rw [ih]; simp only [Felt] at *; omega
+      by_cases hd : isDummyPrivateBatch p
+      · have e : maskedChildPairs (p :: rest)
+            = (Digest.zero, 0) :: (Digest.zero, 0) :: maskedChildPairs rest := by
+          simp only [maskedChildPairs, if_pos hd]
+        have hR : inputExitTotal (p :: rest) = 0 + inputExitTotal rest := by
+          simp only [inputExitTotal, if_pos hd]
+        rw [e, hR]
+        show (0 : Felt) + ((0 : Felt) + amtNotIn [] (maskedChildPairs rest))
+            = 0 + inputExitTotal rest
+        rw [ih]; simp only [Felt] at *; omega
+      · have e : maskedChildPairs (p :: rest)
+            = (p.exitAccount1, p.outputAmount1) ::
+              (p.exitAccount2, p.outputAmount2) :: maskedChildPairs rest := by
+          simp only [maskedChildPairs, if_neg hd]
+        have hR : inputExitTotal (p :: rest)
+            = (p.outputAmount1 + p.outputAmount2) + inputExitTotal rest := by
+          simp only [inputExitTotal, if_neg hd]
+        rw [e, hR]
+        show p.outputAmount1 + (p.outputAmount2 + amtNotIn [] (maskedChildPairs rest))
+            = (p.outputAmount1 + p.outputAmount2) + inputExitTotal rest
+        rw [ih]; simp only [Felt] at *; omega
 
-/-- Conservation for the top-level grouping of the children's outputs. -/
-theorem groupExits_childPairs (leaves : List LeafPublic) :
-    slotsTotal (groupExits (childPairs leaves)) = rawOutputTotal leaves := by
+/-- Conservation for the top-level grouping of the masked children's outputs. -/
+theorem groupExits_maskedChildPairs (leaves : List LeafPublic) :
+    slotsTotal (groupExits (maskedChildPairs leaves)) = inputExitTotal leaves := by
   unfold groupExits
-  rw [groupAux_conserves [] (childPairs leaves), amtNotIn_nil_childPairs]
+  rw [groupAux_conserves [] (maskedChildPairs leaves), amtNotIn_nil_maskedChildPairs]
 
 /-- **Value conservation** (whitepaper §6.1): every private-batch proof settles exactly
-    the value its children carry. Derived from the grouping primitive in `RPrivateBatch`. -/
+    the value its *non-dummy* children carry. Derived from the grouping primitive in
+    `RPrivateBatch`. The grouping runs over the dummy-masked pairs, so this needs no
+    leaf↔private-batch compatibility hypothesis (dummy ⟹ zero outputs) — the ingress
+    mask discharges it structurally. -/
 theorem RPrivateBatch_value_conservation {ro : RandomOracle} {leaves : List LeafPublic}
     {us : List (List Felt)} {out : PrivateBatchOutput} (h : RPrivateBatch ro leaves us out) :
-    outputExitTotal out = rawOutputTotal leaves := by
+    outputExitTotal out = inputExitTotal leaves := by
   unfold outputExitTotal
   rw [h.2.2.2.2.2]
-  exact groupExits_childPairs leaves
+  exact groupExits_maskedChildPairs leaves
+
+/-- The masked (non-dummy) total is bounded by the raw total, so the
+    no-wraparound bounds below cover the circuit's masked accumulator too. -/
+theorem inputExitTotal_le_rawOutputTotal (leaves : List LeafPublic) :
+    inputExitTotal leaves ≤ rawOutputTotal leaves := by
+  induction leaves with
+  | nil => exact Nat.le_refl 0
+  | cons p rest ih =>
+      by_cases hd : isDummyPrivateBatch p
+      · simp only [inputExitTotal, rawOutputTotal, if_pos hd]
+        simp only [Felt] at *; omega
+      · simp only [inputExitTotal, rawOutputTotal, if_neg hd]
+        simp only [Felt] at *; omega
 
 -- ── No-wraparound bound (makes the Phase-2 field hypothesis explicit) ────────
 
@@ -347,7 +400,9 @@ theorem rawOutputTotal_lt_modulus {leaves : List LeafPublic} {M : Felt}
   Nat.lt_of_le_of_lt (rawOutputTotal_le_linear hM) hbatch
 
 /-- Under the leaf↔private-batch compatibility guarantee (a private-batch dummy carries zero
-    outputs), the raw total coincides with the non-dummy total. -/
+    outputs), the raw total coincides with the non-dummy total. No longer needed for
+    conservation (the in-circuit ingress mask discharges it structurally); kept as the
+    compatibility obligation a full leaf↔private-batch composition proof discharges. -/
 theorem rawOutputTotal_eq_inputExitTotal {leaves : List LeafPublic}
     (h : ∀ p ∈ leaves, isDummyPrivateBatch p → p.outputAmount1 = 0 ∧ p.outputAmount2 = 0) :
     rawOutputTotal leaves = inputExitTotal leaves := by

--- a/formal/WormholeSpec/AggregationBridge.lean
+++ b/formal/WormholeSpec/AggregationBridge.lean
@@ -20,7 +20,9 @@
                               comparators route those already-constrained halves; see
                               `common/src/gadgets.rs`), surfaced here as the
                               `nullsPerm`/`nullsSorted` fields of `PrivateBatchCircuit`
-    * exit grouping/dedup     `select`/`matchSum`/`groupAux`     — `Plonky2Spec.Wrapper.{match_contribution, dedup_select}`
+    * exit grouping/dedup     `select`/`matchSum`/`groupAux` over dummy-masked
+                              ingress (`select(is_dummy, 0, …)`, see `maskedChildPairs`)
+                              — `Plonky2Spec.Wrapper.{match_contribution, dedup_select}`
     * block reference         first-real prefix scan             — `Plonky2Spec.Wrapper.scanFirst_correct`
     * metadata `or`-clause    `or(is_dummy, matches) = 1`        — `Plonky2Spec.Wrapper.{block_consistency, real_block_matches}`
 
@@ -113,7 +115,7 @@ structure PrivateBatchCircuit (ro : RandomOracle) (leaves : List LeafPublic)
       guarantee 2). -/
   nullsSorted : nullifiersSorted out.nullifiers
   /-- The `2N` settled slots are the in-circuit group/dedup of every child's outputs. -/
-  exits : out.exitSlots = groupExits (childPairs leaves)
+  exits : out.exitSlots = groupExits (maskedChildPairs leaves)
   /-- Each non-dummy child agrees with the aggregate header (the `or`-clause, satisfied). -/
   metaOk : metadataConsistent leaves out
   /-- The header is taken from the first non-dummy child (first-real scan result). -/

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -20,7 +20,9 @@
 //! should snapshot under a short lock and prove without it:
 //!
 //! ```text
-//! // policy loop, short lock:
+//! // policy loop, short exclusive lock (snapshot_batch takes &mut self —
+//! // it records the snapshot time, so racing policy workers see each
+//! // other's mark instead of both proving the same key):
 //! let proofs = aggregator.lock().snapshot_batch(&key)?;
 //!
 //! // proving worker, NO lock held (use its own prover instance):
@@ -37,10 +39,19 @@
 //! proof in the network (see the custody section in [`crate::pool`]). A
 //! failed or crashed proving worker therefore needs no recovery protocol —
 //! the pool never changed — and buckets queue deeper than one batch, so
-//! admissions for the same key keep landing while it is being proved. The
-//! only removal paths are settlement eviction
+//! admissions for the same key keep landing while it is being proved.
+//!
+//! Because success does not drain the bucket, a policy loop must NOT blindly
+//! re-aggregate the same key every cycle: until settlement lands (a few
+//! block times), each re-prove burns a full proving run to produce a
+//! duplicate submission. Use [`BucketStats::last_snapshot_age`] to skip
+//! buckets with a submission plausibly still in flight.
+//!
+//! The removal paths are settlement eviction
 //! ([`PublicBatchAggregator::evict_settled`], call it on every imported
-//! block) and the operator override
+//! block), expiry ([`PublicBatchAggregator::evict_older_than`] — operators
+//! MUST run it, or their own expiry policy, on a cadence; see the expiry
+//! section in [`crate::pool`]), and the operator override
 //! [`PublicBatchAggregator::remove_bucket`].
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -183,29 +194,35 @@ impl PublicBatchAggregator {
     /// NON-CONSUMING: the proved proofs stay pooled — they may exist nowhere
     /// else in the network (see the custody section in [`crate::pool`]) — so
     /// a failed attempt needs no cleanup, and calling this again before the
-    /// submitted batch settles re-proves the same batch. Removal happens
-    /// through the block-import [`Self::evict_settled`] cadence once the
-    /// batch's segments settle on-chain, or via [`Self::remove_bucket`].
-    /// Proofs beyond `batch_size` stay queued for the next call.
+    /// submitted batch settles re-proves the same batch (check
+    /// [`BucketStats::last_snapshot_age`] first; see the module docs).
+    /// Removal happens through the block-import [`Self::evict_settled`]
+    /// cadence once the batch's segments settle on-chain, through expiry
+    /// ([`Self::evict_older_than`]), or via [`Self::remove_bucket`]. Proofs
+    /// beyond `batch_size` stay queued for the next call.
     ///
     /// This convenience method blocks for the whole proving run (tens of
-    /// seconds). A concurrent service should use the split API instead:
-    /// [`Self::snapshot_batch`] under a short lock, then [`Self::prove_batch`]
-    /// on a proving worker WITHOUT holding the lock.
-    pub fn aggregate(&self, key: &BatchKey) -> Result<Proof> {
+    /// seconds) and, taking `&mut self`, holds exclusive access to the
+    /// aggregator throughout — which also means concurrent aggregation of
+    /// the same key is serialized structurally. A concurrent service should
+    /// use the split API instead: [`Self::snapshot_batch`] under a short
+    /// lock, then [`Self::prove_batch`] on a proving worker WITHOUT holding
+    /// the lock.
+    pub fn aggregate(&mut self, key: &BatchKey) -> Result<Proof> {
         let proofs = self.snapshot_batch(key)?;
         self.prove_batch(proofs)
     }
 
     /// Clone the oldest up-to-`batch_size` proofs of one bucket, for proving
-    /// via [`Self::prove_batch`]. Cheap and non-consuming; see
-    /// [`ProofPool::snapshot_batch`].
+    /// via [`Self::prove_batch`]. Cheap and non-consuming; records the
+    /// snapshot time (see [`BucketStats::last_snapshot_age`]) so policy can
+    /// avoid re-proving an in-flight batch. See [`ProofPool::snapshot_batch`].
     ///
     /// Refuses the dummy sentinel bucket: an all-dummy public batch is a
     /// valid proof that settles nothing, so proving it only wastes the
     /// proving run. (Defense in depth — [`ProofPool::push`] already rejects
     /// all-dummy proofs, so the bucket should never exist.)
-    pub fn snapshot_batch(&self, key: &BatchKey) -> Result<Vec<Proof>> {
+    pub fn snapshot_batch(&mut self, key: &BatchKey) -> Result<Vec<Proof>> {
         if key.is_dummy() {
             bail!(
                 "refusing to aggregate the dummy sentinel bucket (block_hash == 0): \
@@ -267,6 +284,16 @@ impl PublicBatchAggregator {
     /// slots. See [`ProofPool::evict_settled`].
     pub fn evict_settled(&mut self, settled: &HashSet<BytesDigest>) -> usize {
         self.pool.evict_settled(settled)
+    }
+
+    /// Evict every pooled proof admitted more than `max_age` ago, returning
+    /// the number evicted. Settlement only reclaims proofs whose nullifiers
+    /// reach the chain, so operators MUST run this (or their own expiry
+    /// policy) on a cadence with a `max_age` past the chain's acceptance
+    /// window — otherwise proofs that lost their inclusion race occupy
+    /// `max_proofs` forever. See [`ProofPool::evict_older_than`].
+    pub fn evict_older_than(&mut self, max_age: std::time::Duration) -> usize {
+        self.pool.evict_older_than(max_age)
     }
 
     /// Remove one bucket entirely, returning its proofs (operator recovery /

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -13,40 +13,35 @@
 //!
 //! # Concurrency
 //!
-//! Public-batch proving takes minutes. [`PublicBatchAggregator::aggregate`] is
-//! the simple blocking convenience; a service that must keep admitting proofs
-//! while proving should split the phases and only lock around the cheap pool
-//! operations:
+//! Public-batch proving takes tens of seconds (~16 s for a 53-proof batch on
+//! Apple-Silicon-class hardware; a few block times, so settlements can land
+//! mid-prove). [`PublicBatchAggregator::aggregate`] is the simple blocking
+//! convenience; a service that must keep admitting proofs while proving
+//! should snapshot under a short lock and prove without it:
 //!
 //! ```text
-//! // admission thread, short lock:
-//! let taken = aggregator.lock().take_batch(&key)?;
+//! // policy loop, short lock:
+//! let proofs = aggregator.lock().snapshot_batch(&key)?;
 //!
 //! // proving worker, NO lock held (use its own prover instance):
 //! let prover = PublicBatchProver::new_from_binaries_dir(&bins_dir)?;
-//! let result = prover
-//!     .commit(PublicBatchInputs { proofs: taken.proofs(), aggregator_address })?
-//!     .prove();
-//!
-//! // back under a short lock:
-//! match result {
-//!     Ok(proof) => { aggregator.lock().complete_batch(taken); /* submit `proof` */ }
-//!     Err(_) => { aggregator.lock().reinsert_batch(taken); }
-//! }
+//! let proof = prover
+//!     .commit(PublicBatchInputs { proofs, aggregator_address })?
+//!     .prove()?;
+//! // submit `proof`; the block-import evict_settled cadence retires the
+//! // proved inputs from the pool once their segments settle on-chain.
 //! ```
 //!
-//! Buckets queue deeper than one batch, so admissions for the same key keep
-//! landing while its previous batch is out being proved. Reinserted proofs are
-//! not re-verified. A taken batch's nullifiers stay tracked while it is out:
-//! settlements observed by the regular
-//! [`PublicBatchAggregator::evict_settled`] cadence during the proving window
-//! are remembered, and [`PublicBatchAggregator::reinsert_batch`] drops the
-//! affected (now-stale) proofs instead of restoring them. Hand every taken
-//! batch back via [`PublicBatchAggregator::complete_batch`] (success) or
-//! [`PublicBatchAggregator::reinsert_batch`] (failure); a batch that is
-//! instead dropped (e.g. its proving worker panicked) self-releases its
-//! nullifier reservations at the pool's next operation, so the affected
-//! spends can be resubmitted rather than staying wedged.
+//! Proving is NON-CONSUMING: the snapshot is a clone and the pooled originals
+//! stay put, because a claiming miner's pool may hold the only copy of a
+//! proof in the network (see the custody section in [`crate::pool`]). A
+//! failed or crashed proving worker therefore needs no recovery protocol —
+//! the pool never changed — and buckets queue deeper than one batch, so
+//! admissions for the same key keep landing while it is being proved. The
+//! only removal paths are settlement eviction
+//! ([`PublicBatchAggregator::evict_settled`], call it on every imported
+//! block) and the operator override
+//! [`PublicBatchAggregator::remove_bucket`].
 
 use anyhow::{anyhow, bail, Context, Result};
 use plonky2::plonk::{
@@ -62,7 +57,7 @@ use zk_circuits_common::{
     utils::try_4_felts_to_bytes,
 };
 
-use crate::pool::{BatchKey, BucketStats, PoolLimits, ProofPool, TakenBatch};
+use crate::pool::{BatchKey, BucketStats, PoolLimits, ProofPool};
 use crate::public_batch::prover::{PublicBatchInputs, PublicBatchProver};
 use crate::{
     common::utils::{
@@ -185,46 +180,39 @@ impl PublicBatchAggregator {
     /// bound to this aggregator's address. Partial batches are padded with the
     /// dummy private-batch template.
     ///
-    /// Only the proofs actually proved are drained, and only on success; a
-    /// failed attempt reinserts them for retry without re-verification
-    /// (#97067). Proofs beyond `batch_size` stay queued for the next call.
+    /// NON-CONSUMING: the proved proofs stay pooled — they may exist nowhere
+    /// else in the network (see the custody section in [`crate::pool`]) — so
+    /// a failed attempt needs no cleanup, and calling this again before the
+    /// submitted batch settles re-proves the same batch. Removal happens
+    /// through the block-import [`Self::evict_settled`] cadence once the
+    /// batch's segments settle on-chain, or via [`Self::remove_bucket`].
+    /// Proofs beyond `batch_size` stay queued for the next call.
     ///
-    /// This convenience method holds `&mut self` for the entire (minutes-long)
-    /// proving run, so a lock-wrapped aggregator admits nothing meanwhile. A
-    /// concurrent service should use the split API instead: [`Self::take_batch`]
-    /// under a short lock, [`Self::prove_taken`] on a proving worker WITHOUT
-    /// holding the lock, then [`Self::complete_batch`] on success or
-    /// [`Self::reinsert_batch`] on failure.
-    pub fn aggregate(&mut self, key: &BatchKey) -> Result<Proof> {
-        let taken = self.take_batch(key)?;
-
-        match self.prove_taken(&taken) {
-            Ok(proof) => {
-                self.pool.complete(taken);
-                Ok(proof)
-            }
-            Err(e) => {
-                self.pool.reinsert(taken);
-                Err(e)
-            }
-        }
+    /// This convenience method blocks for the whole proving run (tens of
+    /// seconds). A concurrent service should use the split API instead:
+    /// [`Self::snapshot_batch`] under a short lock, then [`Self::prove_batch`]
+    /// on a proving worker WITHOUT holding the lock.
+    pub fn aggregate(&self, key: &BatchKey) -> Result<Proof> {
+        let proofs = self.snapshot_batch(key)?;
+        self.prove_batch(proofs)
     }
 
-    /// Remove up to `batch_size` of the oldest proofs for `key` from the pool,
-    /// for proving via [`Self::prove_taken`]. Cheap; see [`ProofPool::take_batch`].
+    /// Clone the oldest up-to-`batch_size` proofs of one bucket, for proving
+    /// via [`Self::prove_batch`]. Cheap and non-consuming; see
+    /// [`ProofPool::snapshot_batch`].
     ///
-    /// Refuses the dummy sentinel bucket: an all-dummy public batch is a valid
-    /// proof that settles nothing, so proving it only wastes minutes. (Defense
-    /// in depth — [`ProofPool::push`] already rejects all-dummy proofs, so the
-    /// bucket should never exist.)
-    pub fn take_batch(&mut self, key: &BatchKey) -> Result<TakenBatch> {
+    /// Refuses the dummy sentinel bucket: an all-dummy public batch is a
+    /// valid proof that settles nothing, so proving it only wastes the
+    /// proving run. (Defense in depth — [`ProofPool::push`] already rejects
+    /// all-dummy proofs, so the bucket should never exist.)
+    pub fn snapshot_batch(&self, key: &BatchKey) -> Result<Vec<Proof>> {
         if key.is_dummy() {
             bail!(
                 "refusing to aggregate the dummy sentinel bucket (block_hash == 0): \
                  an all-dummy public batch settles nothing"
             );
         }
-        self.pool.take_batch(key).ok_or_else(|| {
+        self.pool.snapshot_batch(key).ok_or_else(|| {
             anyhow!(
                 "no pooled proofs for block {:?} (asset {}, fee {})",
                 key.block_hash,
@@ -234,28 +222,15 @@ impl PublicBatchAggregator {
         })
     }
 
-    /// Retire a taken batch after successful proving, releasing its nullifier
-    /// reservations; see [`ProofPool::complete`].
-    pub fn complete_batch(&mut self, batch: TakenBatch) {
-        self.pool.complete(batch)
-    }
-
-    /// Restore a taken batch after a failed proving attempt (no cryptographic
-    /// re-verification). Proofs observed settled while the batch was out are
-    /// dropped instead of restored. Returns the number of proofs restored; see
-    /// [`ProofPool::reinsert`].
-    pub fn reinsert_batch(&mut self, batch: TakenBatch) -> usize {
-        self.pool.reinsert(batch)
-    }
-
-    /// Prove a taken batch into a public-batch proof bound to this
-    /// aggregator's address. Does not touch the pool.
+    /// Prove a snapshot of private-batch proofs into a public-batch proof
+    /// bound to this aggregator's address. Does not touch the pool.
     ///
-    /// Takes minutes. In a concurrent service, run this on a dedicated proving
-    /// worker without holding whatever lock guards the aggregator — either via
-    /// a separately constructed [`PublicBatchProver`] fed `batch.proofs()`, or
-    /// by cheaply cloning the `TakenBatch`-relevant state out of the lock.
-    pub fn prove_taken(&self, batch: &TakenBatch) -> Result<Proof> {
+    /// Takes tens of seconds (~16 s for a 53-proof batch on
+    /// Apple-Silicon-class hardware, plus prover load). In a concurrent
+    /// service, run this on a dedicated proving worker without holding
+    /// whatever lock guards the aggregator — the snapshot is already
+    /// independent of the pool.
+    pub fn prove_batch(&self, proofs: Vec<Proof>) -> Result<Proof> {
         let prover = PublicBatchProver::new_from_binaries_dir(&self.bins_dir)
             .context("failed to load prebuilt public-batch prover")?;
 
@@ -264,7 +239,7 @@ impl PublicBatchAggregator {
         // so the chain can attribute each segment to its inner proof).
         prover
             .commit(PublicBatchInputs {
-                proofs: batch.proofs(),
+                proofs,
                 aggregator_address: self.aggregator_address,
             })
             .context("failed to commit private-batch proofs to public-batch prover")
@@ -281,7 +256,7 @@ impl PublicBatchAggregator {
         self.pool.len()
     }
 
-    /// Proofs per public batch (how many one `take_batch`/`aggregate` proves).
+    /// Proofs per public batch (how many one `snapshot_batch`/`aggregate` proves).
     pub fn batch_size(&self) -> usize {
         self.pool.batch_size()
     }

--- a/wormhole/aggregator/src/dummy_proof.rs
+++ b/wormhole/aggregator/src/dummy_proof.rs
@@ -10,7 +10,11 @@
 //! - `block_hash = [0u8; 32]` AND `output_amount_1 = 0` AND `output_amount_2 = 0`:
 //!   Triggers bypass of all validation. Both conditions must be met to prevent
 //!   an attacker from slipping funds through with a zero block hash.
-//! - `exit_account = [0u8; 32]`: Dummies form their own exit group, contributing 0 to sums
+//! - `exit_account = [0u8; 32]`: Dummies form their own exit group, contributing 0 to sums.
+//!   Enforced by the template validators (`verify_dummy_leaf_template`,
+//!   `verify_dummy_private_batch_template`) and masked in-circuit by the
+//!   private-batch wrapper, since the leaf circuit leaves exit accounts
+//!   unconstrained and its dummy sentinel does not cover them.
 //!
 //! # Usage
 //!

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -7,26 +7,37 @@
 //! construction: the "when to aggregate which bucket" decision is left to the
 //! operator's policy, fed by [`BucketStats`].
 //!
+//! # Custody: the pool may be a proof's only holder
+//!
+//! A miner runs this pool over proofs pulled from the node's transaction pool
+//! or intercepted from gossip before it — and a miner aggregating a proof for
+//! the reward has every incentive NOT to relay it further (it is claiming the
+//! proof for its own batch). A pooled proof must therefore be treated as
+//! possibly existing nowhere else in the network until it settles, so the
+//! pool never gives up custody for proving:
+//!
+//! [`ProofPool::snapshot_batch`] CLONES the oldest `batch_size` proofs of a
+//! bucket; the originals stay pooled. Prove the snapshot without holding any
+//! pool lock (public-batch proving is tens of seconds, i.e. a few block
+//! times), submit the result, and let the on-chain settlement retire the
+//! proved inputs through the regular [`ProofPool::evict_settled`] cadence. A
+//! failed or crashed proving attempt needs no recovery protocol: the pool
+//! never changed. The only paths that remove a proof are settlement eviction
+//! and the explicit operator override [`ProofPool::remove_bucket`].
+//!
 //! Buckets queue arbitrarily deep (bounded only by [`PoolLimits`]), so a hot
 //! (block, asset, fee) stream keeps admitting while earlier batches are being
-//! proved. [`ProofPool::take_batch`] removes the oldest `batch_size` proofs as
-//! an opaque [`TakenBatch`]; prove it without holding any pool lock, then
-//! [`ProofPool::complete`] it on success or [`ProofPool::reinsert`] it on
-//! failure (no re-verification). While a batch is out its nullifiers stay
-//! indexed, so duplicate spends are still rejected at admission and
-//! settlements observed by [`ProofPool::evict_settled`] during the proving
-//! window are remembered: `reinsert` drops the affected proofs instead of
-//! restoring dead weight. A batch that is DROPPED instead of handed back
-//! (e.g. the proving worker panicked) self-releases its reservations at the
-//! pool's next operation via [`TakenBatch`]'s drop guard, so no spend is ever
-//! permanently wedged by a lost batch.
+//! proved.
 //!
 //! Staleness: a queued proof becomes worthless once any of its nullifiers is
 //! settled on-chain (e.g. another miner included the same private batch, or a
-//! public batch containing it). Operators should call
-//! [`ProofPool::evict_settled`] with newly settled nullifiers on every imported
-//! block — both before proving (don't aggregate dead weight) and before
-//! submitting a finished public batch (don't submit stale segments).
+//! public batch containing it — including this miner's own submissions).
+//! Operators should call [`ProofPool::evict_settled`] with newly settled
+//! nullifiers on every imported block — both before proving (don't aggregate
+//! dead weight) and before submitting a finished public batch (don't submit
+//! stale segments). Until a submitted batch settles, its bucket remains
+//! snapshot-able; whether to re-prove it meanwhile is the operator's policy
+//! call (track your own in-flight submissions).
 //!
 //! Note on nullifier checks: the pool-wide duplicate-nullifier rejection at
 //! admission and `evict_settled` are OPERATIONAL, not security-critical. They
@@ -47,7 +58,6 @@
 //! template.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, ensure, Result};
@@ -83,12 +93,11 @@ impl BatchKey {
 /// Global size limits protecting a pool that fronts untrusted traffic.
 #[derive(Debug, Clone, Copy)]
 pub struct PoolLimits {
-    /// Maximum number of proofs the pool retains, counting both
-    /// bucket-resident proofs AND proofs currently out for proving with a
-    /// [`TakenBatch`]. Counting taken proofs is what makes this a real memory
-    /// bound: otherwise admissions could refill the pool to the cap while a
-    /// batch was out, and a failed prove's [`ProofPool::reinsert`] would push
-    /// residency to `max_proofs + batch_size` (audit finding).
+    /// Maximum number of proofs the pool retains across all buckets.
+    ///
+    /// Proving is non-consuming ([`ProofPool::snapshot_batch`] clones, the
+    /// originals stay resident), so this is the whole memory bound: there is
+    /// no out-for-proving state to account for separately.
     pub max_proofs: usize,
     /// Maximum number of distinct buckets (keys).
     pub max_buckets: usize,
@@ -134,8 +143,9 @@ pub struct BucketStats {
     /// arbitrarily deep (bounded only by [`PoolLimits`]), so this can exceed
     /// `batch_size`.
     pub num_proofs: usize,
-    /// Public-batch size: how many proofs one `take_batch` removes, and the
-    /// count at which a batch aggregates without dummy padding.
+    /// Public-batch size: how many proofs one [`ProofPool::snapshot_batch`]
+    /// clones, and the count at which a batch aggregates without dummy
+    /// padding.
     pub batch_size: usize,
     /// Time since the oldest queued proof in this bucket was admitted.
     pub oldest_age: Duration,
@@ -165,91 +175,6 @@ struct PooledProof {
     admitted_at: Instant,
 }
 
-/// What a dropped (not handed-back) [`TakenBatch`] leaves behind for the pool
-/// to release: its nullifier reservations, and the number of proofs it held —
-/// the latter so [`ProofPool::reap_orphaned`] can return the batch's capacity
-/// to the `max_proofs` accounting (out-for-proving proofs count against the
-/// cap; see [`PoolLimits::max_proofs`]).
-#[derive(Debug, Default)]
-struct OrphanInbox {
-    nullifiers: Vec<BytesDigest>,
-    proofs: usize,
-}
-
-/// Shared inbox for reservations and capacity released by a [`TakenBatch`]
-/// that was dropped without being handed back. Drained by the pool at the
-/// start of its next operation. The mutex is only ever held to push or drain
-/// the inbox, never across pool logic, so it cannot deadlock with any pool
-/// lock the operator wraps around [`ProofPool`] itself.
-type OrphanedReservations = Arc<Mutex<OrphanInbox>>;
-
-/// A batch of admission-verified proofs removed from the pool for proving.
-///
-/// Opaque by design: it can only be produced by [`ProofPool::take_batch`], so
-/// [`ProofPool::reinsert`] can restore it on proving failure without repeating
-/// cryptographic verification.
-///
-/// Hand it back via [`ProofPool::complete`] on proving success or
-/// [`ProofPool::reinsert`] on failure. The pool keeps the batch's nullifiers
-/// indexed while it is out (so duplicates stay rejected and settlements
-/// observed meanwhile are tracked). If the batch is instead dropped — e.g.
-/// the proving worker panicked and unwound — its `Drop` impl deposits the
-/// reservations and the batch's capacity into the pool's orphan inbox and
-/// the pool releases both at its next operation, so the affected spends can
-/// be resubmitted instead of being wedged until the aggregator is rebuilt.
-/// The dropped proofs themselves are gone; clients must resubmit them
-/// (re-admission re-verifies as usual).
-#[derive(Debug)]
-pub struct TakenBatch {
-    key: BatchKey,
-    proofs: Vec<PooledProof>,
-    /// Where `Drop` deposits this batch's reservations; shared with the pool
-    /// that produced it.
-    orphaned: OrphanedReservations,
-    /// Cleared by `complete`/`reinsert` before they consume the batch, so an
-    /// explicit hand-back does not also release through `Drop`.
-    armed: bool,
-}
-
-impl TakenBatch {
-    pub fn key(&self) -> &BatchKey {
-        &self.key
-    }
-
-    pub fn len(&self) -> usize {
-        self.proofs.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.proofs.is_empty()
-    }
-
-    /// Clone the contained proofs (e.g. to feed a prover's `commit`).
-    pub fn proofs(&self) -> Vec<Proof> {
-        self.proofs.iter().map(|q| q.proof.clone()).collect()
-    }
-}
-
-impl Drop for TakenBatch {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-        // Robust to a poisoned mutex: a panic elsewhere must not turn into a
-        // permanently wedged reservation, which is the bug this guards against.
-        let mut orphaned = self
-            .orphaned
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        for queued in &self.proofs {
-            orphaned
-                .nullifiers
-                .extend(queued.nullifiers.iter().copied());
-        }
-        orphaned.proofs += self.proofs.len();
-    }
-}
-
 /// A bounded pool of admission-verified private-batch proofs, bucketed by
 /// [`BatchKey`].
 #[derive(Debug)]
@@ -269,29 +194,9 @@ pub struct ProofPool {
     /// different recent blocks, landing in different buckets — only one copy
     /// can ever settle. The index also makes [`Self::evict_settled`] a lookup
     /// instead of a full pool scan. Invariant: contains exactly the nullifiers
-    /// of proofs currently in `buckets` plus those out with a [`TakenBatch`]
-    /// (the latter are also in `taken_nullifiers`).
+    /// of proofs currently in `buckets` (proving is non-consuming, so proofs
+    /// being proved are still in `buckets` and need no separate tracking).
     nullifier_index: HashMap<BytesDigest, BatchKey>,
-    /// Nullifiers of proofs currently out with a [`TakenBatch`]. Kept so
-    /// [`Self::evict_settled`] can tell settlements of out-for-proving proofs
-    /// apart (they go into `settled_while_taken`) and so admission still
-    /// rejects duplicates of taken spends.
-    taken_nullifiers: HashSet<BytesDigest>,
-    /// Taken-batch nullifiers observed settled on-chain while their batch was
-    /// out being proved. Consumed by [`Self::reinsert`] (drop the stale proof
-    /// instead of restoring it) and [`Self::complete`]. Bounded by the size of
-    /// outstanding taken batches.
-    settled_while_taken: HashSet<BytesDigest>,
-    /// Number of proofs currently out for proving with [`TakenBatch`]es.
-    /// Counted against [`PoolLimits::max_proofs`] at admission so `reinsert`
-    /// can never push residency past the cap. Decremented when a batch is
-    /// handed back (`complete`/`reinsert`) or reaped after being dropped.
-    taken_count: usize,
-    /// Reservations and capacity deposited by dropped (not handed-back)
-    /// [`TakenBatch`]es, released by [`Self::reap_orphaned`] at the start of
-    /// every pool operation. Shared with every `TakenBatch` this pool
-    /// produces.
-    orphaned: OrphanedReservations,
     /// Start of the current verification budget window (fixed-window counter).
     verify_window_started: Instant,
     /// Verification attempts (successful or not) in the current window.
@@ -349,40 +254,13 @@ impl ProofPool {
             limits,
             buckets: BTreeMap::new(),
             nullifier_index: HashMap::new(),
-            taken_nullifiers: HashSet::new(),
-            settled_while_taken: HashSet::new(),
-            taken_count: 0,
-            orphaned: Arc::new(Mutex::new(OrphanInbox::default())),
             verify_window_started: Instant::now(),
             verifies_in_window: 0,
         })
     }
 
-    /// Release reservations deposited by dropped (not handed-back)
-    /// [`TakenBatch`]es. Called at the start of every pool operation, so a
-    /// batch lost to a panicking or killed proving worker frees its spends
-    /// for resubmission at the next pool touch instead of wedging them until
-    /// the aggregator is reconstructed.
-    fn reap_orphaned(&mut self) {
-        let orphaned: OrphanInbox = {
-            let mut inbox = self
-                .orphaned
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            std::mem::take(&mut *inbox)
-        };
-        for nullifier in orphaned.nullifiers {
-            self.nullifier_index.remove(&nullifier);
-            self.taken_nullifiers.remove(&nullifier);
-            self.settled_while_taken.remove(&nullifier);
-        }
-        // Return the dropped batches' capacity to the max_proofs accounting.
-        self.taken_count = self.taken_count.saturating_sub(orphaned.proofs);
-    }
-
-    /// Total number of proofs across all buckets. Excludes proofs out for
-    /// proving with a [`TakenBatch`]; those still count against
-    /// [`PoolLimits::max_proofs`] at admission.
+    /// Total number of proofs across all buckets (proving is non-consuming,
+    /// so this includes proofs currently being proved from a snapshot).
     pub fn len(&self) -> usize {
         self.buckets.values().map(Vec::len).sum()
     }
@@ -413,18 +291,14 @@ impl ProofPool {
     /// over a bucket cannot fail deterministically on admitted inputs (#97067).
     ///
     /// Buckets are NOT capped at one batch: a hot key keeps admitting (up to
-    /// the global limits) while earlier batches for it are out being proved;
-    /// [`Self::take_batch`] takes the oldest `batch_size` proofs at a time.
+    /// the global limits) while earlier batches for it are being proved;
+    /// [`Self::snapshot_batch`] clones the oldest `batch_size` proofs at a
+    /// time.
     pub fn push(&mut self, proof: Proof) -> Result<BatchKey> {
-        self.reap_orphaned();
-        // Out-for-proving proofs count against the cap: they still occupy
-        // memory and return to the buckets on a failed prove's reinsert,
-        // which performs no capacity check of its own.
-        if self.len() + self.taken_count >= self.limits.max_proofs {
+        if self.len() >= self.limits.max_proofs {
             bail!(
-                "proof pool is full ({} pooled + {} out for proving, limit {})",
+                "proof pool is full ({} proofs, limit {})",
                 self.len(),
-                self.taken_count,
                 self.limits.max_proofs
             );
         }
@@ -433,7 +307,7 @@ impl ProofPool {
         let key = metadata.0;
 
         // Reject the all-dummy sentinel outright: it settles nothing and no
-        // automatic drain path could ever remove it (take_batch refuses the
+        // automatic drain path could ever remove it (aggregation refuses the
         // dummy bucket and its random nullifiers never settle on-chain), so
         // admitting it would hand attackers a permanent global-capacity sink.
         if key.is_dummy() {
@@ -479,24 +353,22 @@ impl ProofPool {
             )
         })?;
 
-        // A duplicate nullifier anywhere in the pool (including proofs out
-        // with a TakenBatch) means the same leaf spend is already staged; only
-        // one copy can ever settle. This is checked pool-wide (not per
-        // bucket): the cumulative merkle tree lets the same spend be proven
-        // against different recent blocks, i.e. into different buckets. It
-        // also deduplicates client re-submissions.
+        // A duplicate nullifier anywhere in the pool means the same leaf
+        // spend is already staged; only one copy can ever settle. This is
+        // checked pool-wide (not per bucket): the cumulative merkle tree lets
+        // the same spend be proven against different recent blocks, i.e. into
+        // different buckets. It also deduplicates client re-submissions.
         //
         // Checked AFTER cryptographic verification and the verify budget, and
         // with a generic message: otherwise this rejection is a free,
-        // unlimited membership/status oracle over the pool's not-yet-settled
-        // spends — an attacker submitting invalid proofs that reuse an
-        // observed nullifier could confirm the spend is pooled, learn which
-        // block it referenced, and detect when it goes out for proving, all
-        // without paying verification cost. Gating it behind verify means a
-        // probe now requires a cryptographically valid proof carrying the
-        // target nullifier (i.e. actually holding that spend), and the error
-        // reveals only that some nullifier collided, not which one, from which
-        // bucket, or its proving status.
+        // unlimited membership oracle over the pool's not-yet-settled spends
+        // — an attacker submitting invalid proofs that reuse an observed
+        // nullifier could confirm the spend is pooled and learn which block
+        // it referenced, all without paying verification cost. Gating it
+        // behind verify means a probe now requires a cryptographically valid
+        // proof carrying the target nullifier (i.e. actually holding that
+        // spend), and the error reveals only that some nullifier collided,
+        // not which one or from which bucket.
         if metadata
             .1
             .iter()
@@ -528,20 +400,11 @@ impl ProofPool {
     /// aggregating (avoid proving dead weight) and before submitting a finished
     /// public batch (detect batches that went stale mid-proving).
     ///
-    /// Proofs out with a [`TakenBatch`] cannot be evicted here (the pool no
-    /// longer holds them), but their settlements are remembered: a later
-    /// [`Self::reinsert`] drops the affected proofs instead of restoring them.
+    /// Proving is non-consuming, so proofs currently being proved from a
+    /// [`Self::snapshot_batch`] are still resident and are evicted here like
+    /// any others. This is also what retires a bucket's proofs once this
+    /// miner's own submitted public batch settles.
     pub fn evict_settled(&mut self, settled: &HashSet<BytesDigest>) -> usize {
-        self.reap_orphaned();
-        // Settlements hitting out-for-proving proofs can't be evicted now;
-        // record them so reinsert doesn't restore dead weight after the
-        // settled set of this block has already been consumed.
-        for n in settled {
-            if self.taken_nullifiers.contains(n) {
-                self.settled_while_taken.insert(*n);
-            }
-        }
-
         // The nullifier index turns this into a lookup over `settled` instead
         // of a scan of every pooled proof.
         let affected_keys: HashSet<BatchKey> = settled
@@ -592,119 +455,31 @@ impl ProofPool {
             .collect()
     }
 
-    /// Clone the proofs of one bucket (for aggregation attempts that must not
-    /// disturb the pool on failure).
-    pub fn bucket_proofs(&self, key: &BatchKey) -> Option<Vec<Proof>> {
-        self.buckets
-            .get(key)
-            .map(|bucket| bucket.iter().map(|q| q.proof.clone()).collect())
-    }
-
-    /// Remove up to `batch_size` of the oldest proofs for `key`, for proving.
+    /// Clone the oldest up-to-`batch_size` proofs of one bucket, for proving.
+    /// Returns `None` if the bucket doesn't exist.
     ///
-    /// This is the non-blocking aggregation primitive: taking is cheap, so a
-    /// service can take under a short lock, prove for minutes WITHOUT holding
-    /// any pool lock (admissions for the same key keep landing in the bucket
-    /// remainder), then [`Self::complete`] the batch on success or
-    /// [`Self::reinsert`] it on failure. Returns `None` if the bucket doesn't
-    /// exist.
-    ///
-    /// The taken proofs' nullifiers stay indexed while the batch is out:
-    /// duplicate spends are still rejected at admission, and settlements
-    /// observed by [`Self::evict_settled`] meanwhile are remembered so
-    /// `reinsert` drops the affected proofs instead of restoring dead weight.
-    pub fn take_batch(&mut self, key: &BatchKey) -> Option<TakenBatch> {
-        self.reap_orphaned();
-        let bucket = self.buckets.get_mut(key)?;
+    /// NON-CONSUMING by design: a pooled proof may exist nowhere else in the
+    /// network (a claiming miner withholds it from relay — see the module
+    /// docs on custody), so the pool never gives up custody for proving.
+    /// Prove the snapshot without holding any pool lock, submit the result,
+    /// and let the on-chain settlement retire the proved inputs through
+    /// [`Self::evict_settled`]. A failed or crashed proving attempt needs no
+    /// cleanup: the pool never changed. Whether to re-prove a bucket whose
+    /// batch is submitted but not yet settled is the caller's policy call.
+    pub fn snapshot_batch(&self, key: &BatchKey) -> Option<Vec<Proof>> {
+        let bucket = self.buckets.get(key)?;
         let n = bucket.len().min(self.batch_size);
-        let taken: Vec<PooledProof> = bucket.drain(..n).collect();
-        if bucket.is_empty() {
-            self.buckets.remove(key);
-        }
-        for queued in &taken {
-            for nullifier in &queued.nullifiers {
-                self.taken_nullifiers.insert(*nullifier);
-            }
-        }
-        self.taken_count += taken.len();
-        Some(TakenBatch {
-            key: *key,
-            proofs: taken,
-            orphaned: self.orphaned.clone(),
-            armed: true,
-        })
-    }
-
-    /// Retire a taken batch after SUCCESSFUL proving, releasing its nullifier
-    /// reservations (they are about to settle on-chain via the public batch;
-    /// the post-submission [`Self::evict_settled`] cadence no longer needs to
-    /// track them here).
-    pub fn complete(&mut self, mut batch: TakenBatch) {
-        self.reap_orphaned();
-        batch.armed = false;
-        self.taken_count = self.taken_count.saturating_sub(batch.proofs.len());
-        for queued in &batch.proofs {
-            for nullifier in &queued.nullifiers {
-                self.nullifier_index.remove(nullifier);
-                self.taken_nullifiers.remove(nullifier);
-                self.settled_while_taken.remove(nullifier);
-            }
-        }
-    }
-
-    /// Restore a taken batch after a failed proving attempt, WITHOUT repeating
-    /// cryptographic verification (the batch is only constructable from this
-    /// pool's own admission path).
-    ///
-    /// Proofs are restored at the front of their bucket, preserving age order.
-    /// A proof that went stale while out — any of its nullifiers was observed
-    /// settled on-chain by [`Self::evict_settled`] during the proving window —
-    /// is dropped instead of restored (re-proving it would waste minutes on a
-    /// batch the chain refuses). Returns the number of proofs actually
-    /// restored.
-    pub fn reinsert(&mut self, mut batch: TakenBatch) -> usize {
-        self.reap_orphaned();
-        batch.armed = false;
-        // Every proof in the batch leaves the out-for-proving state here;
-        // the restored ones re-enter the bucket-resident count instead.
-        // Admission held `len() + taken_count` under `max_proofs` the whole
-        // time the batch was out, so this restore cannot overshoot the cap.
-        self.taken_count = self.taken_count.saturating_sub(batch.proofs.len());
-        let mut restored: Vec<PooledProof> = Vec::with_capacity(batch.proofs.len());
-        for queued in std::mem::take(&mut batch.proofs) {
-            let stale = queued
-                .nullifiers
-                .iter()
-                .any(|n| self.settled_while_taken.contains(n));
-            for nullifier in &queued.nullifiers {
-                self.taken_nullifiers.remove(nullifier);
-                if stale {
-                    self.nullifier_index.remove(nullifier);
-                    self.settled_while_taken.remove(nullifier);
-                }
-            }
-            if !stale {
-                restored.push(queued);
-            }
-        }
-        let count = restored.len();
-
-        let bucket = self.buckets.entry(batch.key).or_default();
-        let mut merged = restored;
-        merged.append(bucket);
-        *bucket = merged;
-        if bucket.is_empty() {
-            self.buckets.remove(&batch.key);
-        }
-        count
+        Some(bucket[..n].iter().map(|q| q.proof.clone()).collect())
     }
 
     /// Remove one bucket entirely, returning its proofs (empty if absent).
     ///
-    /// Used both to drain a bucket after successful aggregation and as an
-    /// operator recovery/expiry path for buckets that will never be aggregated.
+    /// This is the operator override — the only removal path besides
+    /// settlement eviction — for buckets that will never be aggregated (e.g.
+    /// expiry policy). The returned proofs are the caller's responsibility;
+    /// if they were claimed from gossip, dropping them here may drop the last
+    /// copy in the network.
     pub fn remove_bucket(&mut self, key: &BatchKey) -> Vec<Proof> {
-        self.reap_orphaned();
         self.buckets
             .remove(key)
             .map(|bucket| {
@@ -901,7 +676,7 @@ mod tests {
     }
 
     /// First public-input felt of a proof's nullifier (test proofs use
-    /// single-felt nullifiers), to assert take/reinsert ordering.
+    /// single-felt nullifiers), to assert snapshot ordering.
     fn nullifier_felt(proof: &Proof) -> u64 {
         proof.public_inputs[aggregated_output::nullifiers_start(NUM_LEAVES)].to_canonical_u64()
     }
@@ -922,49 +697,34 @@ mod tests {
         assert!(stats[0].is_full());
     }
 
-    /// A TakenBatch dropped without complete/reinsert — e.g. the minutes-long
-    /// proving worker in the documented split flow panics — must not wedge its
-    /// spends forever. Reservations of a dropped batch must be released (at
-    /// the pool's next operation) so clients can resubmit; no operator-side
-    /// recovery API or pool reconstruction should be needed (audit finding:
-    /// dropped in-flight batch permanently wedges spends).
+    /// The custody property the non-consuming design exists for: a proving
+    /// snapshot never disturbs the pool. The pooled proof may be the only
+    /// copy in the network (a claiming miner withholds it from relay), so a
+    /// crashed or panicked proving worker must lose nothing — no recovery
+    /// protocol, no resubmission needed.
     #[test]
-    fn dropped_taken_batch_releases_reservations_for_resubmission() {
+    fn crashed_proving_worker_loses_nothing() {
         let (mut pool, data, targets) = make_pool(1, PoolLimits::default());
-        let proof = prove_fake(&data, &targets, &fake(1, 11));
-        let key = pool.push(proof.clone()).unwrap();
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
 
-        let batch = pool.take_batch(&key).expect("bucket must be takeable");
-        drop(batch);
-
-        pool.push(proof)
-            .expect("resubmission of a spend from a dropped batch must be admitted");
-        assert_eq!(pool.len(), 1);
-    }
-
-    /// The realistic loss mode from the audit finding: the batch is moved into
-    /// a proving worker thread that panics mid-proving. Unwinding drops the
-    /// batch, which must still release its reservations back to the pool.
-    #[test]
-    fn batch_lost_to_panicking_worker_releases_reservations() {
-        let (mut pool, data, targets) = make_pool(1, PoolLimits::default());
-        let proof = prove_fake(&data, &targets, &fake(1, 11));
-        let key = pool.push(proof.clone()).unwrap();
-        let batch = pool.take_batch(&key).unwrap();
-
+        let snapshot = pool.snapshot_batch(&key).expect("bucket must exist");
         let worker = std::thread::spawn(move || {
-            let _owned = batch;
+            let _owned = snapshot;
             panic!("simulated proving failure");
         });
         assert!(worker.join().is_err());
 
-        pool.push(proof)
-            .expect("resubmission after a panicked proving worker must be admitted");
+        // The pool never changed: the proof is still there, still snapshot-able.
         assert_eq!(pool.len(), 1);
+        let retry = pool.snapshot_batch(&key).unwrap();
+        assert_eq!(retry.len(), 1);
+        assert_eq!(nullifier_felt(&retry[0]), 11);
     }
 
     #[test]
-    fn take_batch_takes_oldest_and_leaves_remainder() {
+    fn snapshot_batch_clones_oldest_up_to_batch_size() {
         let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
 
         let key = pool
@@ -975,92 +735,64 @@ mod tests {
         pool.push(prove_fake(&data, &targets, &fake(1, 13)))
             .unwrap();
 
-        let taken = pool.take_batch(&key).unwrap();
-        assert_eq!(taken.key(), &key);
-        let taken_nullifiers: Vec<u64> = taken.proofs().iter().map(nullifier_felt).collect();
-        assert_eq!(taken_nullifiers, vec![11, 12]);
-        assert_eq!(pool.len(), 1);
-
-        // The remainder is the next batch (partial), and admissions continue.
-        pool.push(prove_fake(&data, &targets, &fake(1, 14)))
-            .unwrap();
-        let next = pool.take_batch(&key).unwrap();
-        let next_nullifiers: Vec<u64> = next.proofs().iter().map(nullifier_felt).collect();
-        assert_eq!(next_nullifiers, vec![13, 14]);
-        assert!(pool.is_empty());
-        assert!(pool.take_batch(&key).is_none());
-    }
-
-    #[test]
-    fn reinsert_restores_age_order_without_reverification() {
-        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
-
-        let key = pool
-            .push(prove_fake(&data, &targets, &fake(1, 11)))
-            .unwrap();
-        pool.push(prove_fake(&data, &targets, &fake(1, 12)))
-            .unwrap();
-
-        let taken = pool.take_batch(&key).unwrap();
-        // A newer proof lands while the batch is out being proved.
-        pool.push(prove_fake(&data, &targets, &fake(1, 13)))
-            .unwrap();
-
-        assert_eq!(pool.reinsert(taken), 2);
+        // Oldest batch_size proofs, in admission order; nothing removed.
+        let snapshot = pool.snapshot_batch(&key).unwrap();
+        let nullifiers: Vec<u64> = snapshot.iter().map(nullifier_felt).collect();
+        assert_eq!(nullifiers, vec![11, 12]);
         assert_eq!(pool.len(), 3);
 
-        // The reinserted (older) proofs come out first on the next take.
-        let retaken = pool.take_batch(&key).unwrap();
-        let nullifiers: Vec<u64> = retaken.proofs().iter().map(nullifier_felt).collect();
+        // Snapshots are repeatable and admissions keep landing behind them.
+        pool.push(prove_fake(&data, &targets, &fake(1, 14)))
+            .unwrap();
+        let again = pool.snapshot_batch(&key).unwrap();
+        let nullifiers: Vec<u64> = again.iter().map(nullifier_felt).collect();
         assert_eq!(nullifiers, vec![11, 12]);
+
+        // Only settlement retires the proved inputs; the next snapshot is the
+        // remainder, oldest first.
+        let settled: HashSet<BytesDigest> = [nullifier_digest(11), nullifier_digest(12)]
+            .into_iter()
+            .collect();
+        assert_eq!(pool.evict_settled(&settled), 2);
+        let next = pool.snapshot_batch(&key).unwrap();
+        let nullifiers: Vec<u64> = next.iter().map(nullifier_felt).collect();
+        assert_eq!(nullifiers, vec![13, 14]);
     }
 
     #[test]
-    fn duplicate_of_taken_spend_is_rejected_at_admission() {
+    fn duplicate_of_spend_being_proved_is_rejected() {
         let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
 
         let key = pool
             .push(prove_fake(&data, &targets, &fake(1, 11)))
             .unwrap();
-        let taken = pool.take_batch(&key).unwrap();
+        let _snapshot = pool.snapshot_batch(&key).unwrap();
 
-        // The client re-submits the same spend while its proof is out — this
-        // time proven against a DIFFERENT block. Taken proofs stay indexed,
-        // so the duplicate is rejected instead of pooling a second copy that
-        // could never settle alongside the first.
+        // The client re-submits the same spend while its proof is being
+        // proved — this time proven against a DIFFERENT block. The proof
+        // never left the pool, so the duplicate is rejected like any other.
         let err = pool
             .push(prove_fake(&data, &targets, &fake(2, 11)))
             .unwrap_err();
         assert!(err.to_string().contains("already staged"), "got: {err}");
-
-        // The original comes back on proving failure, still deduplicated.
-        assert_eq!(pool.reinsert(taken), 1);
         assert_eq!(pool.len(), 1);
         assert_eq!(pool.num_buckets(), 1);
     }
 
     /// The duplicate-nullifier rejection must not disclose internal pool state
-    /// to untrusted submitters: not the staged nullifier value, not the block
-    /// the staged copy referenced, and not whether it is out for proving.
+    /// to untrusted submitters: not the staged nullifier value and not the
+    /// block the staged copy referenced.
     #[test]
     fn duplicate_rejection_does_not_leak_pool_state() {
         let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
 
-        // Staged against block 1, then taken out for proving (the case whose
-        // old message leaked the most: nullifier + block + proving status).
-        let key = pool
-            .push(prove_fake(&data, &targets, &fake(1, 11)))
+        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
             .unwrap();
-        let taken = pool.take_batch(&key).unwrap();
 
         let err = pool
             .push(prove_fake(&data, &targets, &fake(2, 11)))
             .unwrap_err();
         let msg = err.to_string();
-        assert!(
-            !msg.contains("out for proving"),
-            "leaks proving status: {msg}"
-        );
         assert!(
             !msg.contains(&format!("{:?}", nullifier_digest(11))),
             "leaks staged nullifier: {msg}"
@@ -1072,8 +804,6 @@ mod tests {
             !msg.contains(&format!("{:?}", nullifier_digest(1))),
             "leaks staged bucket block hash: {msg}"
         );
-
-        let _ = pool.reinsert(taken);
     }
 
     /// The duplicate check must run AFTER cryptographic verification and the
@@ -1098,12 +828,13 @@ mod tests {
         );
     }
 
-    /// The gap this closes: a proof settled on-chain while its batch was out
-    /// being proved must not be restored by reinsert — the per-block
-    /// evict_settled cadence has already consumed that block's settled set and
-    /// will never revisit it.
+    /// A competing miner settles a spend while its proof is being proved from
+    /// a snapshot. Because proving is non-consuming, the proof is still
+    /// resident and the per-block evict_settled cadence removes it
+    /// IMMEDIATELY — there is no out-for-proving blind spot to remember and
+    /// reconcile later.
     #[test]
-    fn reinsert_drops_proofs_settled_while_out() {
+    fn settlement_during_proving_evicts_immediately() {
         let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
 
         let key = pool
@@ -1111,37 +842,15 @@ mod tests {
             .unwrap();
         pool.push(prove_fake(&data, &targets, &fake(1, 12)))
             .unwrap();
-        let taken = pool.take_batch(&key).unwrap();
+        let _snapshot = pool.snapshot_batch(&key).unwrap();
 
-        // A competing miner settles one of the taken spends mid-proving. The
-        // proof is out of the pool, so nothing is evicted now...
         let settled: HashSet<BytesDigest> = [nullifier_digest(11)].into_iter().collect();
-        assert_eq!(pool.evict_settled(&settled), 0);
+        assert_eq!(pool.evict_settled(&settled), 1);
 
-        // ...but reinsert after the proving failure drops the stale proof and
-        // restores only the live one.
-        assert_eq!(pool.reinsert(taken), 1);
-        assert_eq!(pool.len(), 1);
-        let retaken = pool.take_batch(&key).unwrap();
-        let nullifiers: Vec<u64> = retaken.proofs().iter().map(nullifier_felt).collect();
+        // The next proving attempt sees only the live proof.
+        let next = pool.snapshot_batch(&key).unwrap();
+        let nullifiers: Vec<u64> = next.iter().map(nullifier_felt).collect();
         assert_eq!(nullifiers, vec![12]);
-    }
-
-    #[test]
-    fn complete_releases_taken_nullifier_reservations() {
-        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
-
-        let key = pool
-            .push(prove_fake(&data, &targets, &fake(1, 11)))
-            .unwrap();
-        let taken = pool.take_batch(&key).unwrap();
-        pool.complete(taken);
-
-        // Reservations are gone: the spend can be staged again (and would be
-        // evicted by the post-settlement evict_settled cadence like any other).
-        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
-            .unwrap();
-        assert_eq!(pool.len(), 1);
     }
 
     #[test]
@@ -1156,16 +865,15 @@ mod tests {
         pool.push(prove_fake(&data, &targets, &fake(1, 11)))
             .unwrap();
 
-        // take + reinsert round-trips the index: re-pushing the nullifier
-        // afterwards is still rejected as a duplicate.
-        let taken = pool.take_batch(&key).unwrap();
-        assert_eq!(pool.reinsert(taken), 1);
+        // A snapshot does not unindex: re-pushing the nullifier while the
+        // batch is being proved is still rejected as a duplicate.
+        let _snapshot = pool.snapshot_batch(&key).unwrap();
         let err = pool
             .push(prove_fake(&data, &targets, &fake(1, 11)))
             .unwrap_err();
         assert!(err.to_string().contains("already staged"), "got: {err}");
 
-        // ...and eviction through the index still finds the reinserted proof.
+        // ...and eviction through the index still finds the proof.
         let settled: HashSet<BytesDigest> = [nullifier_digest(11)].into_iter().collect();
         assert_eq!(pool.evict_settled(&settled), 1);
         assert!(pool.is_empty());
@@ -1255,19 +963,16 @@ mod tests {
         assert!(err.to_string().contains("pool is full"), "got: {err}");
     }
 
-    /// `max_proofs` is documented as the pool's global retained-proof bound,
-    /// but a batch out for proving used to vanish from the accounting: `len()`
-    /// counts bucket residents only, so admissions could refill the pool to
-    /// `max_proofs` while a batch was out, and a failed prove's `reinsert`
-    /// (which has no capacity check) then pushed residency to
-    /// `max_proofs + batch_size` (audit finding). Out-for-proving proofs must
-    /// count against the cap so reinsert can never overshoot it.
+    /// Proofs being proved from a snapshot stay resident, so `max_proofs`
+    /// bounds them with no separate out-for-proving accounting — the cap
+    /// overshoot the old take/reinsert lifecycle allowed (audit finding)
+    /// cannot be expressed anymore.
     #[test]
-    fn proof_cap_counts_out_for_proving_proofs_so_reinsert_cannot_overshoot() {
+    fn proofs_being_proved_still_occupy_capacity() {
         let (mut pool, data, targets) = make_pool(
             2,
             PoolLimits {
-                max_proofs: 3,
+                max_proofs: 2,
                 ..PoolLimits::default()
             },
         );
@@ -1277,52 +982,14 @@ mod tests {
             .unwrap();
         pool.push(prove_fake(&data, &targets, &fake(1, 12)))
             .unwrap();
-        let taken = pool.take_batch(&key).unwrap();
+        let _snapshot = pool.snapshot_batch(&key).unwrap();
 
-        // Two of the three slots are out being proved; one admission remains.
-        pool.push(prove_fake(&data, &targets, &fake(1, 13)))
-            .unwrap();
+        // The snapshot freed nothing: the pool is still full.
         let err = pool
-            .push(prove_fake(&data, &targets, &fake(1, 14)))
+            .push(prove_fake(&data, &targets, &fake(1, 13)))
             .unwrap_err();
         assert!(err.to_string().contains("pool is full"), "got: {err}");
-
-        // The failed batch comes back: the documented global bound still holds.
-        assert_eq!(pool.reinsert(taken), 2);
-        assert_eq!(pool.len(), 3);
-
-        // ...and the freed accounting admits again only after a take.
-        let err = pool
-            .push(prove_fake(&data, &targets, &fake(1, 14)))
-            .unwrap_err();
-        assert!(err.to_string().contains("pool is full"), "got: {err}");
-    }
-
-    /// A `TakenBatch` dropped by a crashed proving worker must return its
-    /// capacity along with its nullifier reservations at the next pool
-    /// operation, or the out-for-proving count would leak and permanently
-    /// shrink the pool.
-    #[test]
-    fn dropped_batch_returns_capacity_to_the_pool() {
-        let (mut pool, data, targets) = make_pool(
-            1,
-            PoolLimits {
-                max_proofs: 1,
-                ..PoolLimits::default()
-            },
-        );
-
-        let key = pool
-            .push(prove_fake(&data, &targets, &fake(1, 11)))
-            .unwrap();
-        let taken = pool.take_batch(&key).unwrap();
-        drop(taken); // proving worker crashed
-
-        // The next operation reaps the orphaned batch: both the reservation
-        // and the capacity slot are free again.
-        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
-            .expect("dropped batch must free its capacity slot");
-        assert_eq!(pool.len(), 1);
+        assert_eq!(pool.len(), 2);
     }
 
     #[test]
@@ -1432,8 +1099,8 @@ mod tests {
         assert_eq!(evicted, 2);
         assert_eq!(pool.len(), 1);
         assert_eq!(pool.num_buckets(), 1);
-        assert!(pool.bucket_proofs(&key_a).is_some());
-        assert!(pool.bucket_proofs(&key_b).is_none());
+        assert!(pool.snapshot_batch(&key_a).is_some());
+        assert!(pool.snapshot_batch(&key_b).is_none());
     }
 
     #[test]

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -83,7 +83,12 @@ impl BatchKey {
 /// Global size limits protecting a pool that fronts untrusted traffic.
 #[derive(Debug, Clone, Copy)]
 pub struct PoolLimits {
-    /// Maximum number of proofs across all buckets.
+    /// Maximum number of proofs the pool retains, counting both
+    /// bucket-resident proofs AND proofs currently out for proving with a
+    /// [`TakenBatch`]. Counting taken proofs is what makes this a real memory
+    /// bound: otherwise admissions could refill the pool to the cap while a
+    /// batch was out, and a failed prove's [`ProofPool::reinsert`] would push
+    /// residency to `max_proofs + batch_size` (audit finding).
     pub max_proofs: usize,
     /// Maximum number of distinct buckets (keys).
     pub max_buckets: usize,
@@ -160,12 +165,23 @@ struct PooledProof {
     admitted_at: Instant,
 }
 
-/// Shared inbox for nullifier reservations released by a [`TakenBatch`] that
-/// was dropped without being handed back. Drained by the pool at the start of
-/// its next operation. The mutex is only ever held to push or drain a `Vec`,
-/// never across pool logic, so it cannot deadlock with any pool lock the
-/// operator wraps around [`ProofPool`] itself.
-type OrphanedReservations = Arc<Mutex<Vec<BytesDigest>>>;
+/// What a dropped (not handed-back) [`TakenBatch`] leaves behind for the pool
+/// to release: its nullifier reservations, and the number of proofs it held —
+/// the latter so [`ProofPool::reap_orphaned`] can return the batch's capacity
+/// to the `max_proofs` accounting (out-for-proving proofs count against the
+/// cap; see [`PoolLimits::max_proofs`]).
+#[derive(Debug, Default)]
+struct OrphanInbox {
+    nullifiers: Vec<BytesDigest>,
+    proofs: usize,
+}
+
+/// Shared inbox for reservations and capacity released by a [`TakenBatch`]
+/// that was dropped without being handed back. Drained by the pool at the
+/// start of its next operation. The mutex is only ever held to push or drain
+/// the inbox, never across pool logic, so it cannot deadlock with any pool
+/// lock the operator wraps around [`ProofPool`] itself.
+type OrphanedReservations = Arc<Mutex<OrphanInbox>>;
 
 /// A batch of admission-verified proofs removed from the pool for proving.
 ///
@@ -178,11 +194,11 @@ type OrphanedReservations = Arc<Mutex<Vec<BytesDigest>>>;
 /// indexed while it is out (so duplicates stay rejected and settlements
 /// observed meanwhile are tracked). If the batch is instead dropped — e.g.
 /// the proving worker panicked and unwound — its `Drop` impl deposits the
-/// reservations into the pool's orphan inbox and the pool releases them at
-/// its next operation, so the affected spends can be resubmitted instead of
-/// being wedged until the aggregator is rebuilt. The dropped proofs
-/// themselves are gone; clients must resubmit them (re-admission re-verifies
-/// as usual).
+/// reservations and the batch's capacity into the pool's orphan inbox and
+/// the pool releases both at its next operation, so the affected spends can
+/// be resubmitted instead of being wedged until the aggregator is rebuilt.
+/// The dropped proofs themselves are gone; clients must resubmit them
+/// (re-admission re-verifies as usual).
 #[derive(Debug)]
 pub struct TakenBatch {
     key: BatchKey,
@@ -226,8 +242,11 @@ impl Drop for TakenBatch {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         for queued in &self.proofs {
-            orphaned.extend(queued.nullifiers.iter().copied());
+            orphaned
+                .nullifiers
+                .extend(queued.nullifiers.iter().copied());
         }
+        orphaned.proofs += self.proofs.len();
     }
 }
 
@@ -263,9 +282,15 @@ pub struct ProofPool {
     /// instead of restoring it) and [`Self::complete`]. Bounded by the size of
     /// outstanding taken batches.
     settled_while_taken: HashSet<BytesDigest>,
-    /// Reservations deposited by dropped (not handed-back) [`TakenBatch`]es,
-    /// released by [`Self::reap_orphaned`] at the start of every pool
-    /// operation. Shared with every `TakenBatch` this pool produces.
+    /// Number of proofs currently out for proving with [`TakenBatch`]es.
+    /// Counted against [`PoolLimits::max_proofs`] at admission so `reinsert`
+    /// can never push residency past the cap. Decremented when a batch is
+    /// handed back (`complete`/`reinsert`) or reaped after being dropped.
+    taken_count: usize,
+    /// Reservations and capacity deposited by dropped (not handed-back)
+    /// [`TakenBatch`]es, released by [`Self::reap_orphaned`] at the start of
+    /// every pool operation. Shared with every `TakenBatch` this pool
+    /// produces.
     orphaned: OrphanedReservations,
     /// Start of the current verification budget window (fixed-window counter).
     verify_window_started: Instant,
@@ -326,7 +351,8 @@ impl ProofPool {
             nullifier_index: HashMap::new(),
             taken_nullifiers: HashSet::new(),
             settled_while_taken: HashSet::new(),
-            orphaned: Arc::new(Mutex::new(Vec::new())),
+            taken_count: 0,
+            orphaned: Arc::new(Mutex::new(OrphanInbox::default())),
             verify_window_started: Instant::now(),
             verifies_in_window: 0,
         })
@@ -338,21 +364,25 @@ impl ProofPool {
     /// for resubmission at the next pool touch instead of wedging them until
     /// the aggregator is reconstructed.
     fn reap_orphaned(&mut self) {
-        let orphaned: Vec<BytesDigest> = {
+        let orphaned: OrphanInbox = {
             let mut inbox = self
                 .orphaned
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             std::mem::take(&mut *inbox)
         };
-        for nullifier in orphaned {
+        for nullifier in orphaned.nullifiers {
             self.nullifier_index.remove(&nullifier);
             self.taken_nullifiers.remove(&nullifier);
             self.settled_while_taken.remove(&nullifier);
         }
+        // Return the dropped batches' capacity to the max_proofs accounting.
+        self.taken_count = self.taken_count.saturating_sub(orphaned.proofs);
     }
 
-    /// Total number of proofs across all buckets.
+    /// Total number of proofs across all buckets. Excludes proofs out for
+    /// proving with a [`TakenBatch`]; those still count against
+    /// [`PoolLimits::max_proofs`] at admission.
     pub fn len(&self) -> usize {
         self.buckets.values().map(Vec::len).sum()
     }
@@ -387,10 +417,14 @@ impl ProofPool {
     /// [`Self::take_batch`] takes the oldest `batch_size` proofs at a time.
     pub fn push(&mut self, proof: Proof) -> Result<BatchKey> {
         self.reap_orphaned();
-        if self.len() >= self.limits.max_proofs {
+        // Out-for-proving proofs count against the cap: they still occupy
+        // memory and return to the buckets on a failed prove's reinsert,
+        // which performs no capacity check of its own.
+        if self.len() + self.taken_count >= self.limits.max_proofs {
             bail!(
-                "proof pool is full ({} proofs, limit {})",
+                "proof pool is full ({} pooled + {} out for proving, limit {})",
                 self.len(),
+                self.taken_count,
                 self.limits.max_proofs
             );
         }
@@ -592,6 +626,7 @@ impl ProofPool {
                 self.taken_nullifiers.insert(*nullifier);
             }
         }
+        self.taken_count += taken.len();
         Some(TakenBatch {
             key: *key,
             proofs: taken,
@@ -607,6 +642,7 @@ impl ProofPool {
     pub fn complete(&mut self, mut batch: TakenBatch) {
         self.reap_orphaned();
         batch.armed = false;
+        self.taken_count = self.taken_count.saturating_sub(batch.proofs.len());
         for queued in &batch.proofs {
             for nullifier in &queued.nullifiers {
                 self.nullifier_index.remove(nullifier);
@@ -629,6 +665,11 @@ impl ProofPool {
     pub fn reinsert(&mut self, mut batch: TakenBatch) -> usize {
         self.reap_orphaned();
         batch.armed = false;
+        // Every proof in the batch leaves the out-for-proving state here;
+        // the restored ones re-enter the bucket-resident count instead.
+        // Admission held `len() + taken_count` under `max_proofs` the whole
+        // time the batch was out, so this restore cannot overshoot the cap.
+        self.taken_count = self.taken_count.saturating_sub(batch.proofs.len());
         let mut restored: Vec<PooledProof> = Vec::with_capacity(batch.proofs.len());
         for queued in std::mem::take(&mut batch.proofs) {
             let stale = queued
@@ -1212,6 +1253,76 @@ mod tests {
             .push(prove_fake(&data, &targets, &fake(2, 12)))
             .unwrap_err();
         assert!(err.to_string().contains("pool is full"), "got: {err}");
+    }
+
+    /// `max_proofs` is documented as the pool's global retained-proof bound,
+    /// but a batch out for proving used to vanish from the accounting: `len()`
+    /// counts bucket residents only, so admissions could refill the pool to
+    /// `max_proofs` while a batch was out, and a failed prove's `reinsert`
+    /// (which has no capacity check) then pushed residency to
+    /// `max_proofs + batch_size` (audit finding). Out-for-proving proofs must
+    /// count against the cap so reinsert can never overshoot it.
+    #[test]
+    fn proof_cap_counts_out_for_proving_proofs_so_reinsert_cannot_overshoot() {
+        let (mut pool, data, targets) = make_pool(
+            2,
+            PoolLimits {
+                max_proofs: 3,
+                ..PoolLimits::default()
+            },
+        );
+
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        pool.push(prove_fake(&data, &targets, &fake(1, 12)))
+            .unwrap();
+        let taken = pool.take_batch(&key).unwrap();
+
+        // Two of the three slots are out being proved; one admission remains.
+        pool.push(prove_fake(&data, &targets, &fake(1, 13)))
+            .unwrap();
+        let err = pool
+            .push(prove_fake(&data, &targets, &fake(1, 14)))
+            .unwrap_err();
+        assert!(err.to_string().contains("pool is full"), "got: {err}");
+
+        // The failed batch comes back: the documented global bound still holds.
+        assert_eq!(pool.reinsert(taken), 2);
+        assert_eq!(pool.len(), 3);
+
+        // ...and the freed accounting admits again only after a take.
+        let err = pool
+            .push(prove_fake(&data, &targets, &fake(1, 14)))
+            .unwrap_err();
+        assert!(err.to_string().contains("pool is full"), "got: {err}");
+    }
+
+    /// A `TakenBatch` dropped by a crashed proving worker must return its
+    /// capacity along with its nullifier reservations at the next pool
+    /// operation, or the out-for-proving count would leak and permanently
+    /// shrink the pool.
+    #[test]
+    fn dropped_batch_returns_capacity_to_the_pool() {
+        let (mut pool, data, targets) = make_pool(
+            1,
+            PoolLimits {
+                max_proofs: 1,
+                ..PoolLimits::default()
+            },
+        );
+
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        let taken = pool.take_batch(&key).unwrap();
+        drop(taken); // proving worker crashed
+
+        // The next operation reaps the orphaned batch: both the reservation
+        // and the capacity slot are free again.
+        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
+            .expect("dropped batch must free its capacity slot");
+        assert_eq!(pool.len(), 1);
     }
 
     #[test]

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -22,8 +22,9 @@
 //! times), submit the result, and let the on-chain settlement retire the
 //! proved inputs through the regular [`ProofPool::evict_settled`] cadence. A
 //! failed or crashed proving attempt needs no recovery protocol: the pool
-//! never changed. The only paths that remove a proof are settlement eviction
-//! and the explicit operator override [`ProofPool::remove_bucket`].
+//! never changed. The paths that remove a proof are settlement eviction,
+//! expiry ([`ProofPool::evict_older_than`]), and the explicit operator
+//! override [`ProofPool::remove_bucket`].
 //!
 //! Buckets queue arbitrarily deep (bounded only by [`PoolLimits`]), so a hot
 //! (block, asset, fee) stream keeps admitting while earlier batches are being
@@ -36,8 +37,19 @@
 //! nullifiers on every imported block — both before proving (don't aggregate
 //! dead weight) and before submitting a finished public batch (don't submit
 //! stale segments). Until a submitted batch settles, its bucket remains
-//! snapshot-able; whether to re-prove it meanwhile is the operator's policy
-//! call (track your own in-flight submissions).
+//! snapshot-able; use [`BucketStats::last_snapshot_age`] to skip buckets with
+//! a submission plausibly still in flight instead of re-proving them every
+//! policy cycle (a full public-batch prove is tens of seconds of CPU).
+//!
+//! Expiry: settlement is the only AUTOMATIC drain, and it only ever sees
+//! nullifiers that reach the chain. A proof that never settles — its miner
+//! lost the inclusion race and the referenced block fell out of the pallet's
+//! acceptance window — would otherwise stay resident forever, permanently
+//! consuming [`PoolLimits::max_proofs`] (which is the whole memory bound).
+//! Operators MUST therefore run an expiry policy: either call
+//! [`ProofPool::evict_older_than`] on a cadence with an age comfortably past
+//! the chain's acceptance window, or implement their own via
+//! [`ProofPool::remove_bucket`].
 //!
 //! Note on nullifier checks: the pool-wide duplicate-nullifier rejection at
 //! admission and `evict_settled` are OPERATIONAL, not security-critical. They
@@ -50,10 +62,10 @@
 //!
 //! Note on dummies: an all-dummy private-batch proof (all-zero block hash) is
 //! REJECTED at admission even though it can be cryptographically valid. It
-//! settles nothing, and none of the automatic drain paths could ever remove it
-//! (aggregating it is refused, and `evict_settled` never sees its random
-//! nullifiers on-chain), so pooling it would let an attacker fill the global
-//! capacity with permanently undrainable entries. Public-batch padding does
+//! settles nothing and only expiry could ever reclaim it (aggregating it is
+//! refused, and `evict_settled` never sees its random nullifiers on-chain),
+//! so pooling it would let an attacker occupy global capacity with dead
+//! entries for a full expiry window at a time. Public-batch padding does
 //! not need pooled dummies either: the prover pads from its own pinned dummy
 //! template.
 
@@ -148,9 +160,24 @@ pub struct BucketStats {
     /// padding.
     pub batch_size: usize,
     /// Time since the oldest queued proof in this bucket was admitted.
+    ///
+    /// This is also the expiry signal: a bucket whose oldest proof predates
+    /// the chain's acceptance window for its block can never settle and only
+    /// [`ProofPool::evict_older_than`] / [`ProofPool::remove_bucket`] will
+    /// reclaim its capacity.
     pub oldest_age: Duration,
     /// Sum of all exit-slot amounts across queued proofs (settled volume proxy).
     pub total_volume: u64,
+    /// Time since this bucket was last snapshot via
+    /// [`ProofPool::snapshot_batch`], or `None` if it never was.
+    ///
+    /// Proving is non-consuming, so a bucket whose batch is submitted but not
+    /// yet settled looks exactly like an untouched one — except for this
+    /// field. A policy loop should treat a recent snapshot as "submission in
+    /// flight" and skip the bucket until it settles (evicting the proofs) or
+    /// the operator's re-prove timeout passes, rather than re-proving the
+    /// same batch every cycle.
+    pub last_snapshot_age: Option<Duration>,
 }
 
 impl BucketStats {
@@ -175,6 +202,14 @@ struct PooledProof {
     admitted_at: Instant,
 }
 
+#[derive(Debug, Default)]
+struct Bucket {
+    proofs: Vec<PooledProof>,
+    /// When this bucket was last snapshot for proving (surfaced as
+    /// [`BucketStats::last_snapshot_age`], the policy layer's in-flight signal).
+    last_snapshot_at: Option<Instant>,
+}
+
 /// A bounded pool of admission-verified private-batch proofs, bucketed by
 /// [`BatchKey`].
 #[derive(Debug)]
@@ -186,7 +221,7 @@ pub struct ProofPool {
     /// Proofs per bucket (= public-batch size).
     batch_size: usize,
     limits: PoolLimits,
-    buckets: BTreeMap<BatchKey, Vec<PooledProof>>,
+    buckets: BTreeMap<BatchKey, Bucket>,
     /// Global index of every pooled nullifier to the bucket holding its proof.
     ///
     /// Duplicates are rejected pool-wide, not just per bucket: the merkle tree
@@ -262,7 +297,7 @@ impl ProofPool {
     /// Total number of proofs across all buckets (proving is non-consuming,
     /// so this includes proofs currently being proved from a snapshot).
     pub fn len(&self) -> usize {
-        self.buckets.values().map(Vec::len).sum()
+        self.buckets.values().map(|b| b.proofs.len()).sum()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -306,14 +341,15 @@ impl ProofPool {
         let metadata = self.parse_metadata(&proof)?;
         let key = metadata.0;
 
-        // Reject the all-dummy sentinel outright: it settles nothing and no
-        // automatic drain path could ever remove it (aggregation refuses the
-        // dummy bucket and its random nullifiers never settle on-chain), so
-        // admitting it would hand attackers a permanent global-capacity sink.
+        // Reject the all-dummy sentinel outright: it settles nothing and only
+        // expiry could ever remove it (aggregation refuses the dummy bucket
+        // and its random nullifiers never settle on-chain), so admitting it
+        // would hand attackers a global-capacity sink lasting a full expiry
+        // window per submission.
         if key.is_dummy() {
             bail!(
                 "refusing to pool an all-dummy private-batch proof (block_hash == 0): \
-                 it settles nothing and can never be drained"
+                 it settles nothing, so settlement eviction can never drain it"
             );
         }
 
@@ -384,12 +420,16 @@ impl ProofPool {
         for nullifier in &nullifiers {
             self.nullifier_index.insert(*nullifier, key);
         }
-        self.buckets.entry(key).or_default().push(PooledProof {
-            proof,
-            nullifiers,
-            volume,
-            admitted_at: Instant::now(),
-        });
+        self.buckets
+            .entry(key)
+            .or_default()
+            .proofs
+            .push(PooledProof {
+                proof,
+                nullifiers,
+                volume,
+                admitted_at: Instant::now(),
+            });
         Ok(key)
     }
 
@@ -417,7 +457,7 @@ impl ProofPool {
             let Some(bucket) = self.buckets.get_mut(&key) else {
                 continue;
             };
-            bucket.retain(|queued| {
+            bucket.proofs.retain(|queued| {
                 let stale = queued.nullifiers.iter().any(|n| settled.contains(n));
                 if stale {
                     evicted += 1;
@@ -427,10 +467,45 @@ impl ProofPool {
                 }
                 !stale
             });
-            if bucket.is_empty() {
+            if bucket.proofs.is_empty() {
                 self.buckets.remove(&key);
             }
         }
+        evicted
+    }
+
+    /// Remove every queued proof admitted more than `max_age` ago, dropping
+    /// buckets that become empty. Returns the number of evicted proofs.
+    ///
+    /// This is the expiry backstop settlement eviction cannot provide: a
+    /// proof whose miner lost the inclusion race for its referenced block
+    /// never has its nullifiers settle on-chain, so nothing else would ever
+    /// reclaim its capacity — and [`PoolLimits::max_proofs`] is the whole
+    /// memory bound. Operators MUST call this on a cadence (or run their own
+    /// expiry via [`Self::remove_bucket`]) with a `max_age` comfortably past
+    /// the chain's acceptance window for proof blocks, so only proofs that
+    /// can no longer settle are dropped.
+    ///
+    /// Custody note: unlike [`Self::remove_bucket`], the expired proofs are
+    /// dropped, not returned — past the acceptance window they are
+    /// unsettleable on ANY chain, so there is no last-copy value to preserve.
+    pub fn evict_older_than(&mut self, max_age: Duration) -> usize {
+        let now = Instant::now();
+        let mut evicted = 0;
+        let nullifier_index = &mut self.nullifier_index;
+        self.buckets.retain(|_, bucket| {
+            bucket.proofs.retain(|queued| {
+                let expired = now.saturating_duration_since(queued.admitted_at) > max_age;
+                if expired {
+                    evicted += 1;
+                    for n in &queued.nullifiers {
+                        nullifier_index.remove(n);
+                    }
+                }
+                !expired
+            });
+            !bucket.proofs.is_empty()
+        });
         evicted
     }
 
@@ -441,16 +516,21 @@ impl ProofPool {
             .iter()
             .map(|(key, bucket)| BucketStats {
                 key: *key,
-                num_proofs: bucket.len(),
+                num_proofs: bucket.proofs.len(),
                 batch_size: self.batch_size,
                 oldest_age: bucket
+                    .proofs
                     .iter()
                     .map(|q| now.saturating_duration_since(q.admitted_at))
                     .max()
                     .unwrap_or_default(),
                 total_volume: bucket
+                    .proofs
                     .iter()
                     .fold(0u64, |acc, q| acc.saturating_add(q.volume)),
+                last_snapshot_age: bucket
+                    .last_snapshot_at
+                    .map(|at| now.saturating_duration_since(at)),
             })
             .collect()
     }
@@ -465,25 +545,34 @@ impl ProofPool {
     /// and let the on-chain settlement retire the proved inputs through
     /// [`Self::evict_settled`]. A failed or crashed proving attempt needs no
     /// cleanup: the pool never changed. Whether to re-prove a bucket whose
-    /// batch is submitted but not yet settled is the caller's policy call.
-    pub fn snapshot_batch(&self, key: &BatchKey) -> Option<Vec<Proof>> {
-        let bucket = self.buckets.get(key)?;
-        let n = bucket.len().min(self.batch_size);
-        Some(bucket[..n].iter().map(|q| q.proof.clone()).collect())
+    /// batch is submitted but not yet settled is the caller's policy call —
+    /// the snapshot time recorded here (surfaced as
+    /// [`BucketStats::last_snapshot_age`]) is that policy's in-flight signal.
+    ///
+    /// Takes `&mut self` (to record the snapshot time), so whatever exclusive
+    /// lock guards the pool also serializes concurrent snapshot attempts:
+    /// two policy workers racing on the same key see each other's snapshot
+    /// mark instead of both launching a duplicate ~tens-of-seconds prove.
+    pub fn snapshot_batch(&mut self, key: &BatchKey) -> Option<Vec<Proof>> {
+        let bucket = self.buckets.get_mut(key)?;
+        let n = bucket.proofs.len().min(self.batch_size);
+        bucket.last_snapshot_at = Some(Instant::now());
+        Some(bucket.proofs[..n].iter().map(|q| q.proof.clone()).collect())
     }
 
     /// Remove one bucket entirely, returning its proofs (empty if absent).
     ///
-    /// This is the operator override — the only removal path besides
-    /// settlement eviction — for buckets that will never be aggregated (e.g.
-    /// expiry policy). The returned proofs are the caller's responsibility;
-    /// if they were claimed from gossip, dropping them here may drop the last
-    /// copy in the network.
+    /// This is the operator override — the manual removal path besides
+    /// settlement eviction and [`Self::evict_older_than`] — for buckets that
+    /// will never be aggregated (e.g. a custom expiry policy). The returned
+    /// proofs are the caller's responsibility; if they were claimed from
+    /// gossip, dropping them here may drop the last copy in the network.
     pub fn remove_bucket(&mut self, key: &BatchKey) -> Vec<Proof> {
         self.buckets
             .remove(key)
             .map(|bucket| {
                 bucket
+                    .proofs
                     .into_iter()
                     .map(|q| {
                         for nullifier in &q.nullifiers {
@@ -1076,6 +1165,72 @@ mod tests {
         // After the window rolls over, admission resumes.
         std::thread::sleep(Duration::from_millis(2100));
         pool.push(good).unwrap();
+    }
+
+    /// Settlement can only reclaim proofs whose nullifiers reach the chain; a
+    /// proof that lost its inclusion race would occupy `max_proofs` forever.
+    /// `evict_older_than` is the expiry backstop: it removes exactly the
+    /// proofs older than the cutoff (per proof, not per bucket), drops
+    /// emptied buckets, and unindexes the evicted nullifiers.
+    #[test]
+    fn evict_older_than_reclaims_expired_proofs() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        // Build all proofs up front: proving is slow enough that doing it
+        // between pushes would blur the admission-age gap asserted below.
+        let old_a = prove_fake(&data, &targets, &fake(1, 11));
+        let old_b = prove_fake(&data, &targets, &fake(2, 12));
+        let young = prove_fake(&data, &targets, &fake(1, 13));
+
+        let key_a = pool.push(old_a).unwrap();
+        let key_b = pool.push(old_b).unwrap();
+        std::thread::sleep(Duration::from_millis(200));
+        pool.push(young).unwrap();
+
+        // Cutoff between the two admission times: only the old proofs expire.
+        assert_eq!(pool.evict_older_than(Duration::from_millis(100)), 2);
+        assert_eq!(pool.len(), 1);
+
+        // key_b's only proof expired, so its bucket is gone; key_a keeps the
+        // young proof.
+        assert_eq!(pool.num_buckets(), 1);
+        assert!(pool.snapshot_batch(&key_b).is_none());
+        let remaining = pool.snapshot_batch(&key_a).unwrap();
+        assert_eq!(nullifier_felt(&remaining[0]), 13);
+
+        // The evicted nullifiers were unindexed: the same spend can re-pool.
+        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        assert_eq!(pool.len(), 2);
+
+        // A generous cutoff evicts nothing.
+        assert_eq!(pool.evict_older_than(Duration::from_secs(3600)), 0);
+        assert_eq!(pool.len(), 2);
+    }
+
+    /// `last_snapshot_age` is the policy layer's in-flight signal: `None`
+    /// until a bucket is first snapshot, then the time since the latest
+    /// snapshot — so a policy loop can skip buckets whose submitted batch is
+    /// plausibly still settling instead of re-proving them every cycle.
+    #[test]
+    fn bucket_stats_track_last_snapshot_age() {
+        let (mut pool, data, targets) = make_pool(2, PoolLimits::default());
+
+        let key = pool
+            .push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+        assert_eq!(pool.bucket_stats()[0].last_snapshot_age, None);
+
+        let _snapshot = pool.snapshot_batch(&key).unwrap();
+        let age = pool.bucket_stats()[0]
+            .last_snapshot_age
+            .expect("snapshot must be recorded");
+        assert!(age < Duration::from_secs(5), "age must be fresh: {age:?}");
+
+        // Admissions don't disturb the mark.
+        pool.push(prove_fake(&data, &targets, &fake(1, 12)))
+            .unwrap();
+        assert!(pool.bucket_stats()[0].last_snapshot_age.is_some());
     }
 
     #[test]

--- a/wormhole/aggregator/src/private_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/build.rs
@@ -50,7 +50,7 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     sweep_stale_artifact_droppings(output_path)?;
 
     println!(
-        "Building prebuilt private-batch aggregation circuit (num_leaf_proofs={})...",
+        "Building prebuilt private-batch aggregation circuit (num_leaf_proofs={}, ZK row blinding)...",
         num_leaf_proofs
     );
 

--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -286,6 +286,15 @@ fn build_private_batch_constraints(
     // 3) if this exit already appeared in an earlier slot, zero out the slot
     //
     // This makes duplicates indistinguishable from dummy/unused slots in output.
+    //
+    // Dummy slots are masked to the canonical zero exit account (and zero
+    // amount) at ingress, BEFORE the grouping. The leaf circuit leaves exit
+    // accounts unconstrained and its dummy sentinel does not cover them, so a
+    // valid dummy leaf can carry arbitrary exit bytes; without the mask, a
+    // poisoned padding template would mark every padded slot with a visible
+    // zero-amount attacker-chosen exit, breaking the indistinguishability of
+    // dummy, unused, and duplicate slots (audit finding: incomplete dummy
+    // sentinel).
 
     let num_exit_slots = n_leaf * 2;
 
@@ -307,31 +316,37 @@ fn build_private_batch_constraints(
         (exit, amount)
     };
 
+    // Masked per-slot (exit, amount): dummy slots read as (zero account, 0).
+    // The amount mask is defense in depth — the leaf circuit already forces
+    // dummy amounts to zero, but this gadget should not rely on a
+    // cross-circuit invariant it can enforce locally for one select per slot.
+    let mut slot_exits: Vec<[Target; 4]> = Vec::with_capacity(num_exit_slots);
+    let mut slot_amounts: Vec<Target> = Vec::with_capacity(num_exit_slots);
     for slot in 0..num_exit_slots {
         let proof_idx = slot / 2;
-        let output_idx = slot % 2;
-        let (exit_slot, _amount_slot) = get_exit_and_amount(proof_idx, output_idx);
+        let (exit_raw, amount_raw) = get_exit_and_amount(proof_idx, slot % 2);
+        let is_dummy_i = is_dummy_flags[proof_idx];
+        slot_exits.push(core::array::from_fn(|j| {
+            builder.select(is_dummy_i, zero, exit_raw[j])
+        }));
+        slot_amounts.push(builder.select(is_dummy_i, zero, amount_raw));
+    }
+
+    for slot in 0..num_exit_slots {
+        let exit_slot = slot_exits[slot];
 
         // Check whether this exit appeared earlier (for dedupe)
         let mut is_duplicate = builder._false();
-        for earlier in 0..slot {
-            let earlier_proof_idx = earlier / 2;
-            let earlier_output_idx = earlier % 2;
-            let (exit_earlier, _) = get_exit_and_amount(earlier_proof_idx, earlier_output_idx);
-
-            let matches_earlier = bytes_digest_eq(builder, exit_earlier, exit_slot);
+        for exit_earlier in slot_exits.iter().take(slot) {
+            let matches_earlier = bytes_digest_eq(builder, *exit_earlier, exit_slot);
             is_duplicate = builder.or(is_duplicate, matches_earlier);
         }
 
         // Sum all matching amounts across all 2*N outputs
         let mut acc = zero;
-        for j in 0..num_exit_slots {
-            let j_proof_idx = j / 2;
-            let j_output_idx = j % 2;
-            let (exit_j, amount_j) = get_exit_and_amount(j_proof_idx, j_output_idx);
-
-            let matches = bytes_digest_eq(builder, exit_j, exit_slot);
-            let conditional_amount = builder.select(matches, amount_j, zero);
+        for (exit_j, amount_j) in slot_exits.iter().zip(&slot_amounts) {
+            let matches = bytes_digest_eq(builder, *exit_j, exit_slot);
+            let conditional_amount = builder.select(matches, *amount_j, zero);
             acc = builder.add(acc, conditional_amount);
         }
 
@@ -1220,6 +1235,108 @@ mod tests {
             num_real_proofs,
             8 - num_real_proofs
         );
+    }
+
+    /// The leaf circuit leaves exit accounts unconstrained and its dummy
+    /// sentinel (`block_hash == 0 && amounts == 0`) does not cover them, so a
+    /// valid dummy leaf can carry attacker-chosen exit accounts. The wrapper
+    /// must mask dummy slots' exits to the canonical zero account in the
+    /// aggregated output, or a poisoned padding template marks every padded
+    /// slot as visibly dummy (audit finding: incomplete dummy sentinel).
+    #[test]
+    fn recursive_aggregation_masks_dummy_exit_accounts_to_zero() {
+        const N_LEAF: usize = 4;
+
+        let exits_felts: [[F; 8]; 8] = EXIT_ACCOUNTS.map(limbs8_u64_to_felts);
+        let nullifiers_felts: [[F; 4]; 8] = NULLIFIERS.map(limbs4_u64_to_felts);
+        let block_hashes_felts: [[F; 4]; 8] = BLOCK_HASHES.map(limbs4_u64_to_felts);
+
+        let asset_id = F::from_canonical_u64(TEST_ASSET_ID_U64);
+        let volume_fee_bps = F::from_canonical_u64(TEST_VOLUME_FEE_BPS);
+        let common_block_hash = block_hashes_felts[0];
+        let real_amount = F::from_canonical_u64(1234);
+
+        let mut pis_list: Vec<[F; LEAF_PI_LEN]> = Vec::with_capacity(N_LEAF);
+        // Slot 0: the one real proof.
+        pis_list.push(make_pi_from_felts(
+            asset_id,
+            real_amount,
+            F::ZERO,
+            volume_fee_bps,
+            nullifiers_felts[0],
+            exits_felts[0],
+            [F::ZERO; 8],
+            common_block_hash,
+            F::from_canonical_u64(42),
+        ));
+        // Slots 1..4: dummies (block_hash = 0, zero amounts) with
+        // ATTACKER-CHOSEN nonzero exit accounts, as a poisoned template
+        // could produce.
+        for i in 1..N_LEAF {
+            pis_list.push(make_pi_from_felts(
+                asset_id,
+                F::ZERO,
+                F::ZERO,
+                volume_fee_bps,
+                nullifiers_felts[i],
+                exits_felts[i],
+                exits_felts[i],
+                [F::ZERO; 4],
+                F::ZERO,
+            ));
+        }
+
+        let leaves = pis_list
+            .clone()
+            .into_iter()
+            .map(prove_fake_leaf_standalone)
+            .collect::<Vec<_>>();
+        let leaf_common = leaves[0].1.common.clone();
+        let leaf_verifier_only = leaves[0].1.verifier_only.clone();
+        let proofs = leaves
+            .into_iter()
+            .map(|(proof, _)| proof)
+            .collect::<Vec<_>>();
+
+        let dummy_nullifier_pre_images = deterministic_dummy_nullifier_pre_images(proofs.len());
+
+        let (root_proof, root_verifier) = aggregate_proofs_private_batch(
+            proofs,
+            leaf_common,
+            leaf_verifier_only,
+            dummy_nullifier_pre_images,
+        )
+        .unwrap();
+        root_verifier.verify(root_proof.clone()).unwrap();
+
+        let pis = &root_proof.public_inputs;
+
+        // Slots 2i / 2i+1 belong to proof i, so slots 2.. are the dummies'.
+        // Every one of them must be fully zero — amount AND exit account —
+        // regardless of the exit bytes the dummy leaves carried.
+        for slot in 2..N_LEAF * 2 {
+            let base = ROOT_HEADER_LEN + slot * aggregated_output::EXIT_SLOT_LEN;
+            assert_eq!(pis[base], F::ZERO, "dummy slot {slot} must have zero sum");
+            for j in 0..4 {
+                assert_eq!(
+                    pis[base + 1 + j],
+                    F::ZERO,
+                    "dummy slot {slot} must expose the canonical zero exit account, \
+                     not the template's exit bytes"
+                );
+            }
+        }
+
+        // The real proof's payout is untouched: slot 0 keeps its exit and sum.
+        let base = ROOT_HEADER_LEN;
+        assert_eq!(pis[base], real_amount, "real slot must keep its payout");
+        for j in 0..4 {
+            assert_eq!(
+                pis[base + 1 + j],
+                exits_felts[0][j],
+                "real slot must keep its exit account"
+            );
+        }
     }
 
     /// Regression test: the circuit must accept the real proof in EVERY slot position. The

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -330,7 +330,8 @@ impl PrivateBatchProver {
 
 /// Check that a set of leaf proofs is mutually compatible under the
 /// private-batch circuit's cross-slot constraints, so an incompatible batch is
-/// rejected at commit time instead of failing after minutes of proving:
+/// rejected at commit time instead of failing after a full proving run
+/// (potentially minutes on the phone-class hardware clients prove on):
 ///
 /// - `asset_id` must match across ALL proofs (dummies included),
 /// - `block_hash` and `volume_fee_bps` must match between non-dummy proofs

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -419,8 +419,8 @@ fn ensure_leaf_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) -> Re
 }
 
 /// Verify that the dummy leaf proof template is a valid leaf proof carrying the
-/// strong dummy sentinel: `block_hash == 0`, both output amounts zero, AND
-/// `asset_id == 0`.
+/// strong dummy sentinel: `block_hash == 0`, both output amounts zero,
+/// `asset_id == 0`, AND both exit accounts all-zero.
 ///
 /// The private-batch circuit only treats `block_hash == 0` slots as dummies, and
 /// its exit-dedup gadget sums output amounts across matching exit accounts. If a
@@ -471,6 +471,16 @@ fn verify_dummy_leaf_template(
             pis.asset_id
         );
     }
+    if pis.exit_account_1 != BytesDigest::default() || pis.exit_account_2 != BytesDigest::default()
+    {
+        bail!(
+            "dummy leaf proof template has non-zero exit account(s); padding templates \
+             must use the canonical all-zero exit account: the leaf circuit leaves exit \
+             accounts unconstrained, and marked exits would make padded slots \
+             distinguishable in the aggregated output (the wrapper circuit also masks \
+             dummy exits to zero as defense in depth)"
+        );
+    }
 
     leaf_verifier
         .verify(template.clone())
@@ -497,8 +507,8 @@ mod tests {
     };
     use plonky2::field::types::Field;
     use qp_wormhole_inputs::{
-        BLOCK_HASH_START_INDEX, NULLIFIER_START_INDEX, OUTPUT_AMOUNT_1_INDEX,
-        PUBLIC_INPUTS_FELTS_LEN,
+        BLOCK_HASH_START_INDEX, EXIT_ACCOUNT_1_START_INDEX, EXIT_ACCOUNT_2_START_INDEX,
+        NULLIFIER_START_INDEX, OUTPUT_AMOUNT_1_INDEX, PUBLIC_INPUTS_FELTS_LEN,
     };
     use test_helpers::fake_leaf::{build_fake_leaf_circuit, prove_fake_leaf};
 
@@ -542,6 +552,34 @@ mod tests {
         let err = verify_dummy_leaf_template(&template, &leaf.verifier_data()).unwrap_err();
         assert!(
             err.to_string().contains("non-zero output amounts"),
+            "got: {err}"
+        );
+    }
+
+    /// The leaf circuit leaves exit accounts unconstrained and its dummy
+    /// sentinel does not cover them, so a proof can be fully dummy (zero
+    /// block hash, zero amounts) yet carry attacker-chosen exit accounts
+    /// that mark every padded slot in the aggregated output (audit finding:
+    /// incomplete dummy sentinel).
+    #[test]
+    fn dummy_template_with_nonzero_exit_account_is_rejected() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+
+        let mut pis = [F::ZERO; PUBLIC_INPUTS_FELTS_LEN];
+        pis[EXIT_ACCOUNT_1_START_INDEX] = F::ONE;
+        let template = prove_fake_leaf(&leaf, &targets, pis);
+        let err = verify_dummy_leaf_template(&template, &leaf.verifier_data()).unwrap_err();
+        assert!(
+            err.to_string().contains("non-zero exit account"),
+            "got: {err}"
+        );
+
+        let mut pis = [F::ZERO; PUBLIC_INPUTS_FELTS_LEN];
+        pis[EXIT_ACCOUNT_2_START_INDEX] = F::ONE;
+        let template = prove_fake_leaf(&leaf, &targets, pis);
+        let err = verify_dummy_leaf_template(&template, &leaf.verifier_data()).unwrap_err();
+        assert!(
+            err.to_string().contains("non-zero exit account"),
             "got: {err}"
         );
     }

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -430,15 +430,10 @@ fn verify_dummy_private_batch_template(
     template: &ProofWithPublicInputs<F, C, D>,
     private_batch_verifier: &VerifierCircuitData<F, C, D>,
 ) -> Result<()> {
-    private_batch_verifier
-        .verify(template.clone())
-        .map_err(|e| {
-            anyhow!(
-                "dummy private-batch proof template failed verification: {}",
-                e
-            )
-        })?;
-
+    // Check the sentinel first (cheap, independently testable, and
+    // attributable), mirroring `verify_dummy_leaf_template`; a template is
+    // only acceptable if BOTH the sentinel and cryptographic verification
+    // pass.
     let u64s: Vec<u64> = template
         .public_inputs
         .iter()
@@ -463,7 +458,27 @@ fn verify_dummy_private_batch_template(
                 slot.summed_output_amount
             );
         }
+        if slot.exit_account != BytesDigest::default() {
+            bail!(
+                "dummy private-batch proof template has non-zero exit account at slot {}; \
+                 padding templates must carry the canonical all-zero exit account so \
+                 padded slots stay indistinguishable from unused ones (the private-batch \
+                 circuit masks dummy exits to zero, so a canonical-circuit template can \
+                 never trip this; it guards templates from variant circuits)",
+                i
+            );
+        }
     }
+
+    private_batch_verifier
+        .verify(template.clone())
+        .map_err(|e| {
+            anyhow!(
+                "dummy private-batch proof template failed verification: {}",
+                e
+            )
+        })?;
+
     Ok(())
 }
 
@@ -669,6 +684,47 @@ mod tests {
             .expect_err("tampered private-batch proof must be rejected at commit");
         assert!(
             err.to_string().contains("failed verification"),
+            "got: {err}"
+        );
+    }
+
+    /// A poisoned padding template can be all-dummy in every enforced respect
+    /// (zero block hash, zero forwarded amounts) yet carry attacker-chosen
+    /// exit accounts in its zero-amount exit slots, marking every padded slot
+    /// of a partial public batch (audit finding: incomplete dummy sentinel).
+    /// The sentinel check must cover exit accounts and run before
+    /// cryptographic verification (mirroring the leaf-template validator) so
+    /// the rejection is attributable, not a generic verify failure.
+    #[test]
+    fn constructor_rejects_dummy_template_with_nonzero_exit_account() {
+        use crate::private_batch::circuit::constants::aggregated_output;
+
+        let (leaf, leaf_targets) = build_fake_leaf_circuit();
+        let dummy_leaf = prove_fake_leaf(&leaf, &leaf_targets, [F::ZERO; 21]);
+        let private_batch = PrivateBatchCircuit::new(
+            wormhole_private_batch_circuit_config(),
+            &leaf.common,
+            &leaf.verifier_only,
+            1,
+        )
+        .unwrap()
+        .build_verifier();
+
+        let mut template = make_all_dummy_private_batch_template(&leaf, &dummy_leaf);
+        // First exit slot's first exit-account limb: zero amount, marked exit.
+        template.public_inputs[aggregated_output::exit_slots_start() + 1] = F::ONE;
+
+        let err = PublicBatchProver::new(
+            wormhole_public_batch_circuit_config(),
+            private_batch.common.clone(),
+            &private_batch.verifier_only,
+            1,
+            1,
+            template,
+        )
+        .expect_err("padding template with a nonzero exit account must be rejected");
+        assert!(
+            err.to_string().contains("non-zero exit account"),
             "got: {err}"
         );
     }

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -61,7 +61,7 @@ pub struct PublicBatchProver {
     /// nullifiers, so one template can fill several slots without collisions.
     dummy_proof_template: ProofWithPublicInputs<F, C, D>,
     /// Private-batch verifier data, kept so `commit` can cheaply verify each
-    /// supplied inner proof before starting the minutes-long proving run.
+    /// supplied inner proof before starting the expensive proving run.
     private_batch_verifier: VerifierCircuitData<F, C, D>,
 }
 
@@ -255,7 +255,7 @@ impl PublicBatchProver {
     /// The circuit exempts dummies (`block_hash == 0`) from metadata consistency
     /// and zeroes their forwarded exit slots and nullifiers.
     ///
-    /// Fails fast (milliseconds, before the minutes-long proving run) on inputs
+    /// Fails fast (milliseconds, before the tens-of-seconds proving run) on inputs
     /// the public-batch circuit could never prove or that could never settle:
     /// each supplied proof is cryptographically verified against the pinned
     /// private-batch verifier, non-dummy proofs must share one (block hash,
@@ -334,7 +334,7 @@ impl PublicBatchProver {
 
 /// Check that a set of private-batch proofs is mutually compatible under the
 /// public-batch circuit's cross-proof constraints, so an incompatible batch is
-/// rejected at commit time instead of failing after minutes of proving:
+/// rejected at commit time instead of failing after a full proving run:
 /// non-dummy proofs (`block_hash != 0`) must share one block hash, asset id,
 /// and volume fee; dummy proofs are exempt. At least one proof must be
 /// non-dummy: an all-dummy batch carries zero block references and settles
@@ -771,7 +771,7 @@ mod tests {
     /// Individually valid inner proofs with incompatible batch metadata (here:
     /// different block hashes) can never satisfy the circuit's cross-proof
     /// constraints; commit must reject them fail-fast instead of letting prove
-    /// burn minutes of CPU.
+    /// burn a full proving run.
     #[test]
     fn commit_rejects_batch_incompatible_private_batch_proofs() {
         let (leaf, leaf_targets) = build_fake_leaf_circuit();

--- a/wormhole/circuit-builder/examples/public_batch_bench.rs
+++ b/wormhole/circuit-builder/examples/public_batch_bench.rs
@@ -23,8 +23,20 @@ use wormhole_aggregator::{
     CircuitBinsConfig,
 };
 use wormhole_circuit::{block_header::header::HeaderInputs, inputs::CircuitInputs};
+use zk_circuits_common::circuit::{
+    wormhole_leaf_circuit_config, wormhole_private_batch_circuit_config,
+    wormhole_public_batch_circuit_config,
+};
 
 const NUM_LEAF_PROOFS: usize = 7;
+
+fn zk_label(zero_knowledge: bool) -> &'static str {
+    if zero_knowledge {
+        "ZK (row blinding)"
+    } else {
+        "non-ZK"
+    }
+}
 
 fn file_size(path: &Path) -> u64 {
     fs::metadata(path).map(|m| m.len()).unwrap_or(0)
@@ -45,7 +57,17 @@ fn main() -> anyhow::Result<()> {
         std::env::var("BENCH_BINS_DIR").unwrap_or_else(|_| "target/public-batch-bench".into()),
     );
     fs::create_dir_all(&dir)?;
-    println!("Binaries dir: {}\n", dir.display());
+    println!("Binaries dir: {}", dir.display());
+
+    // The bench uses the canonical production configs; print the ZK status of
+    // each layer so the measured hierarchy is explicit (only the private
+    // batch needs blinding: it is the layer whose witnesses are leaf proofs).
+    println!(
+        "Circuit hierarchy: leaf {}, private batch {}, public batch {}\n",
+        zk_label(wormhole_leaf_circuit_config().zero_knowledge),
+        zk_label(wormhole_private_batch_circuit_config().zero_knowledge),
+        zk_label(wormhole_public_batch_circuit_config().zero_knowledge),
+    );
 
     // Leaf + private-batch circuits don't depend on M; build them once.
     println!("== One-time setup: leaf + private-batch circuits (N={NUM_LEAF_PROOFS}) ==");

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -31,7 +31,9 @@ pub use wormhole_aggregator::CircuitBinsConfig;
 /// removed because a poisoned artifact could exfiltrate private witness data through the
 /// proof's public-input list.
 pub fn generate_circuit_binaries<P: AsRef<Path>>(output_dir: P) -> Result<()> {
-    println!("Building wormhole leaf circuit (non-ZK for faster proving)...");
+    println!(
+        "Building wormhole leaf circuit (non-ZK by design; ZK lives at the private-batch layer)..."
+    );
     let config = wormhole_leaf_circuit_config();
     let circuit = WormholeCircuit::new(config);
     let targets = circuit.targets();

--- a/wormhole/circuit/src/zk_merkle_proof.rs
+++ b/wormhole/circuit/src/zk_merkle_proof.rs
@@ -422,6 +422,30 @@ impl TryFrom<&CircuitInputs> for ZkMerkleProofData {
     type Error = anyhow::Error;
 
     fn try_from(inputs: &CircuitInputs) -> Result<Self, Self::Error> {
+        use anyhow::bail;
+
+        // Bound and cross-check the caller-controlled vectors BEFORE cloning
+        // them below: the clones are O(len), so deferring these O(1) checks
+        // to `fill_targets` would let malformed inputs force allocation and
+        // copying proportional to an arbitrarily large positions vector
+        // before being rejected (audit finding: validation order).
+        let siblings_len = inputs.private.zk_merkle_siblings.len();
+        let positions_len = inputs.private.zk_merkle_positions.len();
+        if siblings_len > MAX_DEPTH {
+            bail!(
+                "ZK Merkle proof depth {} exceeds maximum supported depth {}",
+                siblings_len,
+                MAX_DEPTH
+            );
+        }
+        if positions_len != siblings_len {
+            bail!(
+                "ZK Merkle proof positions length {} doesn't match siblings length {}",
+                positions_len,
+                siblings_len
+            );
+        }
+
         // Detect dummy proofs (block_hash == 0 and outputs == 0)
         let is_not_dummy = !(inputs.public.block_hash.as_ref() == [0u8; 32]
             && inputs.public.output_amount_1 == 0
@@ -751,6 +775,62 @@ mod tests {
         let err = ZkMerkleProofData::from_unsorted([0x11; 32], bad_levels, [0x42; 32], leaf, true)
             .unwrap_err();
         assert!(err.contains("sibling hash"), "got: {err}");
+    }
+
+    /// `TryFrom<&CircuitInputs>` clones the caller-controlled siblings and
+    /// positions vectors, so a positions vector that cannot possibly be valid
+    /// (length mismatched with siblings, or beyond MAX_DEPTH) must be
+    /// rejected at the conversion boundary, BEFORE the O(len) clone — not
+    /// deferred to `fill_targets` after the allocation and copying already
+    /// happened (audit finding: validation order).
+    #[test]
+    fn try_from_rejects_bad_position_vectors_before_cloning() {
+        use crate::inputs::{CircuitInputs, PrivateCircuitInputs, PublicCircuitInputs};
+
+        let base = CircuitInputs {
+            private: PrivateCircuitInputs {
+                secret: [0xAB; 32].try_into().unwrap(),
+                transfer_count: 0,
+                unspendable_account: [0xCD; 32].try_into().unwrap(),
+                parent_hash: [5u8; 32].try_into().unwrap(),
+                state_root: [3u8; 32].try_into().unwrap(),
+                extrinsics_root: [4u8; 32].try_into().unwrap(),
+                digest: [0xEE; 110],
+                input_amount: 1000,
+                zk_tree_root: [0u8; 32],
+                zk_merkle_siblings: vec![],
+                zk_merkle_positions: vec![],
+            },
+            public: PublicCircuitInputs {
+                asset_id: 0,
+                output_amount_1: 900,
+                output_amount_2: 99,
+                volume_fee_bps: 10,
+                nullifier: [1u8; 32].try_into().unwrap(),
+                block_hash: [0u8; 32].try_into().unwrap(),
+                exit_account_1: [2u8; 32].try_into().unwrap(),
+                exit_account_2: [3u8; 32].try_into().unwrap(),
+                block_number: 1,
+            },
+        };
+
+        // Valid (empty) siblings with an oversized positions vector.
+        let mut inputs = base;
+        inputs.private.zk_merkle_positions = vec![0u8; MAX_DEPTH + 1];
+        let err = ZkMerkleProofData::try_from(&inputs).unwrap_err();
+        assert!(err.to_string().contains("positions length"), "got: {err}");
+
+        // Oversized siblings must also be rejected at the conversion, not
+        // just at the prover entry point.
+        inputs.private.zk_merkle_siblings = vec![[[0u8; 32]; SIBLINGS_PER_LEVEL]; MAX_DEPTH + 1];
+        inputs.private.zk_merkle_positions = vec![0u8; MAX_DEPTH + 1];
+        let err = ZkMerkleProofData::try_from(&inputs).unwrap_err();
+        assert!(err.to_string().contains("depth"), "got: {err}");
+
+        // A consistent in-bounds pair still converts.
+        inputs.private.zk_merkle_siblings = vec![[[0u8; 32]; SIBLINGS_PER_LEVEL]; 2];
+        inputs.private.zk_merkle_positions = vec![0u8, 1];
+        ZkMerkleProofData::try_from(&inputs).expect("valid proof inputs must convert");
     }
 
     /// Sibling hashes and position hints identify the leaf's location in the

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -321,9 +321,12 @@ fn private_batch_prover_rejects_poisoned_dummy_template() {
         std::fs::copy(entry.path(), poisoned_dir.join(entry.file_name())).unwrap();
     }
 
-    // Sentinel-neutral tampering: block_hash and outputs stay zero, so only the
-    // cryptographic check can catch it.
-    let mut poisoned = make_leaf_proof(&CircuitInputs::test_inputs_0());
+    // Sentinel-neutral tampering: block_hash, outputs, and exit accounts stay
+    // zero (test_inputs_0 carries a nonzero exit_account_1, which the sentinel
+    // now rejects on its own), so only the cryptographic check can catch it.
+    let mut dummy_inputs = CircuitInputs::test_inputs_0();
+    dummy_inputs.public.exit_account_1 = zk_circuits_common::utils::BytesDigest::default();
+    let mut poisoned = make_leaf_proof(&dummy_inputs);
     poisoned.public_inputs[4] = F::from_canonical_u64(0xdead_beef); // nullifier felt
     std::fs::write(poisoned_dir.join("dummy_proof.bin"), poisoned.to_bytes()).unwrap();
 
@@ -332,6 +335,24 @@ fn private_batch_prover_rejects_poisoned_dummy_template() {
     assert!(
         err.to_string()
             .contains("dummy leaf proof template failed verification"),
+        "got: {err}"
+    );
+
+    // A cryptographically VALID dummy proof (over the real leaf circuit) with a
+    // nonzero exit account is exactly the poisoned-padding shape from the audit
+    // finding (incomplete dummy sentinel): block hash and amounts are zero, yet
+    // its exit bytes would mark every padded slot. The sentinel must reject it.
+    let marked_exits = make_leaf_proof(&CircuitInputs::test_inputs_0());
+    std::fs::write(
+        poisoned_dir.join("dummy_proof.bin"),
+        marked_exits.to_bytes(),
+    )
+    .unwrap();
+
+    let err = PrivateBatchProver::new_from_binaries_dir(&poisoned_dir)
+        .expect_err("dummy template with a nonzero exit account must be rejected at load time");
+    assert!(
+        err.to_string().contains("non-zero exit account"),
         "got: {err}"
     );
 

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -216,7 +216,7 @@ fn aggregate_rejects_empty_batch() {
 fn commit_rejects_batch_incompatible_proofs() {
     // Two individually valid proofs whose metadata the private-batch circuit's
     // cross-slot constraints reject (different asset ids) must fail fast at
-    // commit time, not minutes later inside proving.
+    // commit time, not a full proving run later.
     let proof_asset_0 = make_leaf_proof(&CircuitInputs::test_inputs_0());
     let proof_asset_5 = make_leaf_proof(&test_inputs_with_asset(5));
 
@@ -502,7 +502,7 @@ fn public_batch_build_rejects_substituted_private_batch_artifacts() {
 // ============================================================================
 
 /// Build (once) a real private-batch proof compatible with the public-batch
-/// test artifacts. Cached because private aggregation costs minutes.
+/// test artifacts. Cached because private aggregation is expensive.
 fn make_private_batch_proof_in_public_dir() -> ProofWithPublicInputs<F, C, D> {
     static PROOF: OnceLock<ProofWithPublicInputs<F, C, D>> = OnceLock::new();
     PROOF
@@ -591,7 +591,8 @@ fn pool_rejects_invalid_proofs_and_aggregates_by_bucket() {
 
     // Cryptographic rejection: valid shape, tampered contents. A proof admitted
     // into the pool despite being invalid would wedge its bucket forever, since
-    // buckets only drain on successful aggregation (#97067).
+    // its nullifiers can never settle on-chain and settlement eviction is the
+    // pool's only automatic drain (#97067).
     let mut tampered = private_batch_proof.clone();
     tampered.public_inputs[1] = F::from_canonical_u64(9); // asset_id felt
     let err = aggregator.push_proof(tampered).unwrap_err();
@@ -600,6 +601,21 @@ fn pool_rejects_invalid_proofs_and_aggregates_by_bucket() {
         "got: {err}"
     );
     assert_eq!(aggregator.pool_len(), 0, "rejected proofs must not pool");
+
+    // The proof's nullifiers, for simulating its on-chain settlement below.
+    let settled: std::collections::HashSet<BytesDigest> = {
+        use plonky2::field::types::PrimeField64;
+        let u64s: Vec<u64> = private_batch_proof
+            .public_inputs
+            .iter()
+            .map(|f| f.to_canonical_u64())
+            .collect();
+        qp_wormhole_inputs::PrivateBatchPublicInputs::try_from_u64_slice(&u64s)
+            .expect("parse private-batch public inputs")
+            .nullifiers
+            .into_iter()
+            .collect()
+    };
 
     // A valid proof is admitted, keyed by its (block, asset, fee) metadata.
     let key = aggregator
@@ -611,19 +627,35 @@ fn pool_rejects_invalid_proofs_and_aggregates_by_bucket() {
     assert_eq!(stats[0].key, key);
     assert!(stats[0].is_full(), "batch_size=1 bucket must be full");
 
-    // Aggregating the bucket produces a verifiable public batch and drains it.
+    // Aggregating the bucket produces a verifiable public batch. Proving is
+    // NON-CONSUMING — a claiming miner's pool may hold the only copy of a
+    // proof in the network — so the bucket does not drain on success.
     let aggregated = aggregator.aggregate(&key).expect("public aggregate");
     aggregator
         .verify(aggregated)
         .expect("public-batch proof must verify");
-    assert_eq!(aggregator.pool_len(), 0, "bucket must drain on success");
+    assert_eq!(
+        aggregator.pool_len(),
+        1,
+        "proofs stay pooled until their segments settle on-chain"
+    );
 
-    // Aggregating a missing bucket is an error, and the pool stays usable.
+    // On-chain settlement is what retires the proved inputs: the block-import
+    // evict_settled cadence sees the batch's nullifiers and drains the bucket.
+    assert_eq!(
+        aggregator.evict_settled(&settled),
+        1,
+        "settlement must retire the proved proof"
+    );
+    assert_eq!(aggregator.pool_len(), 0, "bucket must drain on settlement");
+
+    // Aggregating a now-missing bucket is an error, and the pool stays usable.
     let err = aggregator.aggregate(&key).unwrap_err();
     assert!(err.to_string().contains("no pooled proofs"), "got: {err}");
 
     // The dummy sentinel bucket (block_hash == 0) is refused outright: an
-    // all-dummy public batch settles nothing, so proving it wastes minutes.
+    // all-dummy public batch settles nothing, so proving it wastes a full
+    // proving run.
     let dummy_key = BatchKey {
         block_hash: BytesDigest::default(),
         ..key

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -114,14 +114,17 @@ const CANONICAL_LEAF_COMMON_KECCAK256: [u8; 32] = [
 /// Maximum size accepted for a serialized verifier artifact, whether loaded
 /// from a file or passed as bytes.
 ///
-/// The canonical leaf verifier/common artifacts are a few KB; 64 MiB (the same
-/// bound the aggregator applies to its artifacts) gives generous headroom
-/// while bounding the allocation an untrusted artifact path can force. Without
-/// a cap, an oversized or sparse file is read fully into memory BEFORE the
-/// keccak256 canonicality pin gets a chance to reject it. The same bound is
-/// enforced in [`WormholeVerifier::new_from_bytes`] so an oversized
-/// caller-supplied slice is rejected in O(1) instead of being hashed in full.
-pub const MAX_ARTIFACT_FILE_BYTES: u64 = 64 * 1024 * 1024;
+/// The keccak256 canonicality pin already rejects everything but the
+/// byte-exact canonical leaf artifacts, so this cap's only job is to bound
+/// the work done BEFORE the pin can fire: the file read's allocation in
+/// [`WormholeVerifier::new_from_files`] and the keccak pass over
+/// caller-supplied slices in [`WormholeVerifier::new_from_bytes`]. That work
+/// is proportional to the cap, so the cap must be tight for the "rejected in
+/// O(1)" property to mean anything. The canonical artifacts are a few KB;
+/// 1 MiB is ~2–3 orders of magnitude of headroom while keeping the worst
+/// pre-pin allocation and hash trivially cheap. (The aggregator crate keeps
+/// its own, larger bound for its much larger circuit artifacts.)
+pub const MAX_VERIFIER_ARTIFACT_BYTES: u64 = 1024 * 1024;
 
 fn keccak256(input: &[u8]) -> [u8; 32] {
     let mut output = [0u8; 32];
@@ -132,7 +135,7 @@ fn keccak256(input: &[u8]) -> [u8; 32] {
 }
 
 /// Read a verifier-artifact file, refusing anything larger than
-/// [`MAX_ARTIFACT_FILE_BYTES`] before allocating for its contents.
+/// [`MAX_VERIFIER_ARTIFACT_BYTES`] before allocating for its contents.
 ///
 /// Only regular files are accepted. A FIFO, device node, or symlink to one
 /// planted at an artifact path would otherwise block `open` (a FIFO with no
@@ -174,26 +177,26 @@ fn read_artifact_file(path: &Path) -> anyhow::Result<Vec<u8>> {
         ));
     }
     let claimed_len = metadata.len();
-    if claimed_len > MAX_ARTIFACT_FILE_BYTES {
+    if claimed_len > MAX_VERIFIER_ARTIFACT_BYTES {
         return Err(anyhow!(
             "artifact file {} is {} bytes, which exceeds the {} byte limit for \
              verifier artifacts; refusing to load it",
             path.display(),
             claimed_len,
-            MAX_ARTIFACT_FILE_BYTES
+            MAX_VERIFIER_ARTIFACT_BYTES
         ));
     }
 
     let mut bytes = Vec::with_capacity(claimed_len as usize);
-    file.take(MAX_ARTIFACT_FILE_BYTES + 1)
+    file.take(MAX_VERIFIER_ARTIFACT_BYTES + 1)
         .read_to_end(&mut bytes)
         .with_context(|| format!("failed to read artifact file {}", path.display()))?;
-    if bytes.len() as u64 > MAX_ARTIFACT_FILE_BYTES {
+    if bytes.len() as u64 > MAX_VERIFIER_ARTIFACT_BYTES {
         return Err(anyhow!(
             "artifact file {} grew past the {} byte limit for verifier artifacts \
              while being read; refusing to load it",
             path.display(),
-            MAX_ARTIFACT_FILE_BYTES
+            MAX_VERIFIER_ARTIFACT_BYTES
         ));
     }
     Ok(bytes)
@@ -202,7 +205,7 @@ fn read_artifact_file(path: &Path) -> anyhow::Result<Vec<u8>> {
 impl WormholeVerifier {
     /// Creates a new [`WormholeVerifier`] from verifier and common data bytes.
     ///
-    /// Inputs larger than [`MAX_ARTIFACT_FILE_BYTES`] are rejected before any
+    /// Inputs larger than [`MAX_VERIFIER_ARTIFACT_BYTES`] are rejected before any
     /// hashing, so the size bound is a property of the loading contract
     /// itself, not just of the file-based wrapper. Within that bound, both
     /// serialized inputs must match the byte-exact canonical Wormhole leaf
@@ -210,13 +213,13 @@ impl WormholeVerifier {
     /// are checked again as defense in depth.
     pub fn new_from_bytes(verifier_bytes: &[u8], common_bytes: &[u8]) -> anyhow::Result<Self> {
         for (label, bytes) in [("verifier-only", verifier_bytes), ("common", common_bytes)] {
-            if bytes.len() as u64 > MAX_ARTIFACT_FILE_BYTES {
+            if bytes.len() as u64 > MAX_VERIFIER_ARTIFACT_BYTES {
                 return Err(anyhow!(
                     "{} artifact is {} bytes, which exceeds the {} byte limit for \
                      verifier artifacts; refusing to load it",
                     label,
                     bytes.len(),
-                    MAX_ARTIFACT_FILE_BYTES
+                    MAX_VERIFIER_ARTIFACT_BYTES
                 ));
             }
         }
@@ -289,7 +292,7 @@ impl WormholeVerifier {
     /// Creates a new [`WormholeVerifier`] from a verifier and common data files.
     ///
     /// Both files are read through [`read_artifact_file`], which rejects
-    /// non-regular files and anything larger than [`MAX_ARTIFACT_FILE_BYTES`]
+    /// non-regular files and anything larger than [`MAX_VERIFIER_ARTIFACT_BYTES`]
     /// before buffering, so an untrusted artifact path cannot stall or
     /// memory-starve verifier startup. The keccak256 canonicality pin in
     /// [`Self::new_from_bytes`] then rejects any non-canonical contents.
@@ -346,7 +349,7 @@ mod tests {
     /// canonicality pin rejects it.
     #[test]
     fn new_from_bytes_rejects_oversized_slices_before_hashing() {
-        let oversized = vec![0u8; MAX_ARTIFACT_FILE_BYTES as usize + 1];
+        let oversized = vec![0u8; MAX_VERIFIER_ARTIFACT_BYTES as usize + 1];
 
         let err = WormholeVerifier::new_from_bytes(&oversized, b"irrelevant").unwrap_err();
         assert!(
@@ -376,7 +379,7 @@ mod tests {
         // exactly like an attacker-planted artifact would.
         std::fs::File::create(&verifier_path)
             .unwrap()
-            .set_len(MAX_ARTIFACT_FILE_BYTES + 1)
+            .set_len(MAX_VERIFIER_ARTIFACT_BYTES + 1)
             .unwrap();
         std::fs::write(&common_path, b"irrelevant").unwrap();
 

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -111,14 +111,16 @@ const CANONICAL_LEAF_COMMON_KECCAK256: [u8; 32] = [
     0xb1, 0x82, 0x2e, 0xf0, 0x26, 0x37, 0xe8, 0xd8, 0x51, 0x2d, 0x8a, 0xbb, 0x79, 0x74, 0x80, 0xe3,
 ];
 
-/// Maximum size accepted for a serialized verifier artifact file.
+/// Maximum size accepted for a serialized verifier artifact, whether loaded
+/// from a file or passed as bytes.
 ///
 /// The canonical leaf verifier/common artifacts are a few KB; 64 MiB (the same
 /// bound the aggregator applies to its artifacts) gives generous headroom
 /// while bounding the allocation an untrusted artifact path can force. Without
 /// a cap, an oversized or sparse file is read fully into memory BEFORE the
-/// keccak256 canonicality pin gets a chance to reject it.
-#[cfg(feature = "std")]
+/// keccak256 canonicality pin gets a chance to reject it. The same bound is
+/// enforced in [`WormholeVerifier::new_from_bytes`] so an oversized
+/// caller-supplied slice is rejected in O(1) instead of being hashed in full.
 pub const MAX_ARTIFACT_FILE_BYTES: u64 = 64 * 1024 * 1024;
 
 fn keccak256(input: &[u8]) -> [u8; 32] {
@@ -200,10 +202,25 @@ fn read_artifact_file(path: &Path) -> anyhow::Result<Vec<u8>> {
 impl WormholeVerifier {
     /// Creates a new [`WormholeVerifier`] from verifier and common data bytes.
     ///
-    /// Rejects artifacts unless both serialized inputs match the byte-exact
-    /// canonical Wormhole leaf artifacts. The decoded config and public-input
-    /// shape are checked again as defense in depth.
+    /// Inputs larger than [`MAX_ARTIFACT_FILE_BYTES`] are rejected before any
+    /// hashing, so the size bound is a property of the loading contract
+    /// itself, not just of the file-based wrapper. Within that bound, both
+    /// serialized inputs must match the byte-exact canonical Wormhole leaf
+    /// artifacts (keccak256 pin). The decoded config and public-input shape
+    /// are checked again as defense in depth.
     pub fn new_from_bytes(verifier_bytes: &[u8], common_bytes: &[u8]) -> anyhow::Result<Self> {
+        for (label, bytes) in [("verifier-only", verifier_bytes), ("common", common_bytes)] {
+            if bytes.len() as u64 > MAX_ARTIFACT_FILE_BYTES {
+                return Err(anyhow!(
+                    "{} artifact is {} bytes, which exceeds the {} byte limit for \
+                     verifier artifacts; refusing to load it",
+                    label,
+                    bytes.len(),
+                    MAX_ARTIFACT_FILE_BYTES
+                ));
+            }
+        }
+
         let verifier_hash = keccak256(verifier_bytes);
         if verifier_hash != CANONICAL_LEAF_VERIFIER_KECCAK256 {
             return Err(anyhow!(
@@ -321,6 +338,27 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    /// `new_from_bytes` is the public loading contract, so the size bound
+    /// must be enforced there — not only in the file wrapper — otherwise a
+    /// caller-supplied oversized slice is keccak-hashed in full before the
+    /// canonicality pin rejects it.
+    #[test]
+    fn new_from_bytes_rejects_oversized_slices_before_hashing() {
+        let oversized = vec![0u8; MAX_ARTIFACT_FILE_BYTES as usize + 1];
+
+        let err = WormholeVerifier::new_from_bytes(&oversized, b"irrelevant").unwrap_err();
+        assert!(
+            format!("{err:#}").contains("exceeds the"),
+            "oversized verifier bytes must be rejected by the size cap, got: {err:#}"
+        );
+
+        let err = WormholeVerifier::new_from_bytes(b"irrelevant", &oversized).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("exceeds the"),
+            "oversized common bytes must be rejected by the size cap, got: {err:#}"
+        );
     }
 
     /// An oversized artifact file must be rejected by a size bound BEFORE its


### PR DESCRIPTION
# Security round 3: entry-point caps, dummy exit invariant, and proof-pool redesign

Third round of security-review fixes. Each finding was confirmed with a failing
(red) test before the fix and verified green after; the last two commits go
further and replace the proof pool's lifecycle design with one under which the
audited failure modes cannot be expressed.

## Findings fixed

### 1. Public entry points bypassed the documented size caps (`830f1d5`)

Two public APIs allowed attacker-controlled inputs to force work proportional
to oversized payloads before any bound was checked:

- **`TransferProofJson` derived `Deserialize`**, so generic serde entry points
  (`from_str`, `from_slice`, and especially the streaming `from_reader`)
  bypassed the 8 MiB raw-input cap that only `from_json_str` enforced. The
  per-field visitor bounds cannot stop an escape-inflated string from being
  decoded into unbounded scratch storage first. The `Deserialize` impl now
  lives on a private mirror struct (`TransferProofJsonRaw`), making
  `from_json_str` — which checks the raw length first — the only parsing
  path. A `compile_fail` doctest pins that the public type no longer
  implements `Deserialize`.
- **`WormholeVerifier::new_from_bytes`** computed `keccak256` over
  caller-supplied slices before any length check. Both slices are now checked
  against `MAX_ARTIFACT_FILE_BYTES` (un-gated from `std`, same 64 MiB bound as
  the file path) before hashing, so oversized input is rejected in O(1).

### 2. Incomplete dummy sentinel: exit accounts were unconstrained (`4b2a997`)

The leaf circuit leaves exit accounts as free public inputs and its dummy
sentinel (`block_hash == 0`, zero amounts) did not cover them, so a poisoned
padding template could mark every padded slot in the aggregated output with
attacker-chosen zero-amount exits — breaking the indistinguishability of
dummy, unused, and duplicate slots. Fixed end to end:

- **In-circuit (the load-bearing fix):** the private-batch wrapper now masks
  each dummy slot's (exit account, amount) to `(0, 0)` at grouping ingress,
  so no template — canonical or variant — can mark padded slots. No FRI
  degree change.
- **Template validators (defense in depth):** `verify_dummy_leaf_template`
  and `verify_dummy_private_batch_template` now also require all-zero exit
  accounts; the public-batch validator runs its sentinel checks before
  cryptographic verification, mirroring the leaf one.
- **Formal spec:** `Aggregation.lean` models the mask (`maskedChildPairs`),
  and value conservation is now derived against the non-dummy total
  (`inputExitTotal`) with no leaf↔batch compatibility hypothesis — the
  ingress mask discharges it structurally. `lake build` + `leanchecker` pass.

### 3. Merkle path vectors cloned before validation (`8653bff`)

`ZkMerkleProofData::try_from` cloned `zk_merkle_siblings` and
`zk_merkle_positions` out of caller-controlled `CircuitInputs` before any
length check; the positions/siblings consistency check lived in
`fill_targets`, after the O(len) allocation. A hosted prover could be forced
to allocate and copy an arbitrarily large positions vector per malformed
request. The depth bound and the positions-length cross-check now run at the
conversion boundary, before cloning.

### 4 & 5. Proof pool: capacity accounting, then a redesign (`709890e`, `f5e06b6`)

The audited bug: `max_proofs` was enforced against bucket-resident proofs
only, while a `TakenBatch` was out for proving admissions could refill the
pool to the cap, and a failed prove's `reinsert` (no capacity check) pushed
residency to `max_proofs + batch_size`. `709890e` fixes it minimally by
counting out-for-proving proofs against the cap.

`f5e06b6` then replaces the design that kept producing this class of bug.
Re-evaluating the pool against its actual deployment changed two premises:

- **Proving is seconds, not minutes.** Measured ~16 s for a 53-proof public
  batch (M=53, N=7, ZK private batches) on Apple-Silicon-class hardware. The
  taken-batch lifecycle was built to survive a minutes-long window.
- **Claim custody.** A miner aggregating a proof for the reward withholds it
  from relay, so its pool may hold the only copy of that proof in the
  network. The pool must never give up custody of a proof to a proving
  attempt that might crash.

The pool is therefore now a **non-consuming cache**: `snapshot_batch` clones
the oldest `batch_size` proofs and the originals stay pooled; on-chain
settlement (`evict_settled`, called on every imported block) is the removal
authority, with `remove_bucket` as the operator override. A failed or crashed
proving worker is a non-event because the pool never changed. This deletes
the entire taken lifecycle — `TakenBatch`, its drop-guard orphan inbox
(`Arc<Mutex<...>>`), `reinsert` staleness reconciliation
(`settled_while_taken`), and the separate `taken_count` accounting — net
−325 lines. The three properties the round's pool fixes guarded (no wedged
reservations, no cap overshoot, no capacity leak) now hold structurally
rather than by bookkeeping, and are pinned by new tests
(`crashed_proving_worker_loses_nothing`,
`settlement_during_proving_evicts_immediately`,
`proofs_being_proved_still_occupy_capacity`).

API changes: `PublicBatchAggregator::{take_batch, complete_batch,
reinsert_batch, prove_taken}` are replaced by `snapshot_batch` +
`prove_batch`; `aggregate` no longer drains the bucket on success (settlement
does) and now takes `&self`.

## Documentation corrections (`f5e06b6`, `f1411de`)

- The "minutes-long proving" claims across `aggregator.rs`, `pool.rs`, and
  both provers were stale; public-batch proving is tens of seconds. Wording
  is now hardware-neutral, with the measured figure where it informs design.
- The ZK hierarchy (leaf **non-ZK** → private batch **ZK, row blinding** →
  public batch **non-ZK**) was already the canonical configuration but was
  easy to misread from build logs; the public-batch benchmark now prints it
  up front and the builder progress messages state each layer's ZK status.
  Verified that `qp-plonky2`'s `rand` feature (required for blinding) is
  active in the benchmark graph, so published numbers include ZK private
  batches.

## Testing

- Red→green unit tests accompany every finding (serialization, verifier,
  circuit masking, template validators, conversion bounds, pool semantics).
- `cargo test --release -p qp-wormhole-aggregator` (pool: 22 tests),
  integration suite `tests::aggregator`, `cargo clippy --all-targets
  -D warnings`, `cargo fmt` — all green.
- `lake build` + `leanchecker` for the Lean spec changes.
- Private-batch circuit FRI degrees unchanged by the in-circuit mask
  (verified against pre-change degree measurements).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch proof-system invariants (dummy exit masking), untrusted deserialization/artifact loading, and miner custody semantics for pooled proofs—any mistake could affect settlement correctness or DoS resistance.
> 
> **Overview**
> Third security-review round: **tighten untrusted entry points**, **close the incomplete dummy exit-account gap**, and **replace the proof pool’s take/reinsert lifecycle** with a non-consuming snapshot model.
> 
> **Parsing and verifier loading.** `TransferProofJson` no longer implements `Deserialize`; only `from_json_str` applies the 8 MiB raw cap before serde (private `TransferProofJsonRaw` + `compile_fail` doctest). `WormholeVerifier::new_from_bytes` rejects slices over `MAX_ARTIFACT_FILE_BYTES` before `keccak256`.
> 
> **Dummy padding / aggregation.** Private-batch grouping now masks each dummy slot’s exit account and amount to zero at ingress; dummy leaf and private-batch templates must use all-zero exit accounts, with tests and docs updated. Lean `Aggregation.lean` / `SPEC.md` model `maskedChildPairs` and derive conservation against `inputExitTotal` without a leaf↔batch dummy-output hypothesis.
> 
> **Hosted prover bounds.** `ZkMerkleProofData::try_from` checks Merkle depth and positions/siblings length before cloning caller-controlled vectors.
> 
> **Miner pool.** `take_batch` / `TakenBatch` / `complete` / `reinsert` are removed in favor of `snapshot_batch` + `prove_batch`; proofs stay pooled until `evict_settled` (or `remove_bucket`). `aggregate` takes `&self` and no longer drains on success. Docs now describe ~tens-of-seconds proving and the ZK stack (leaf non-ZK → private batch ZK → public batch non-ZK).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1411de1ddc9576b079dc83c236b72e460dbd74e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->