### PR TITLE
Add --leaf-only mode to wormhole-memprof for leaf-side RSS profiling.

### DIFF
--- a/wormhole/memprof/README.md
+++ b/wormhole/memprof/README.md
@@ -34,6 +34,10 @@ cargo run -p wormhole-memprof --release -- \
 # Just the aggregation circuit data structure (no proving)
 cargo run -p wormhole-memprof --release -- --circuit-only
 
+# Just the leaf side: build leaf circuit + generate proofs, no aggregation.
+# Reports the max memory a leaf-proving-only client needs.
+cargo run -p wormhole-memprof --release -- --leaf-only --real-proofs 1
+
 # Skip leaf-proof generation; clones a dummy proof instead.
 # Useful to isolate aggregation cost from leaf proving cost.
 cargo run -p wormhole-memprof --release -- \
@@ -75,6 +79,7 @@ overall peak rss:      1498.3 MB
 | `--rayon-threads T` | Limit plonky2's parallel FFT pool. `0` = system default. |
 | `--skip-leaf-gen` | Use cloned dummy proofs; isolates aggregation cost. |
 | `--circuit-only` | Build agg circuit only, don't prove. |
+| `--leaf-only` | Stop after leaf-proof generation; measures the leaf side alone. |
 | `--release-after-each` | Call `malloc_zone_pressure_relief` between phases (Apple only). |
 | `--sample-period-ms P` | Memory sampler poll period in ms (default 25). |
 | `--peak-target-mb T` | Exit non-zero if overall peak > T MB (CI guard). |

--- a/wormhole/memprof/src/main.rs
+++ b/wormhole/memprof/src/main.rs
@@ -60,6 +60,13 @@ struct Args {
     #[arg(long, default_value_t = false)]
     circuit_only: bool,
 
+    /// Stop after leaf-proof generation; never touch the aggregator. Reports
+    /// the memory requirement of the leaf-proving side alone (circuit build +
+    /// proof generation). Conflicts with --skip-leaf-gen (nothing to measure)
+    /// and --circuit-only (which measures the aggregation circuit instead).
+    #[arg(long, default_value_t = false, conflicts_with_all = ["skip_leaf_gen", "circuit_only"])]
+    leaf_only: bool,
+
     /// Call malloc_zone_pressure_relief between phases (Apple only).
     #[arg(long, default_value_t = false)]
     release_after_each: bool,
@@ -186,6 +193,11 @@ fn main() -> Result<()> {
         }
     }
 
+    if args.leaf_only {
+        report.finish_and_print(args.peak_target_mb)?;
+        return Ok(());
+    }
+
     let _agg = workload::aggregate_fresh(
         &leaf_ctx,
         leaf_proofs,
@@ -251,6 +263,21 @@ mod tests {
             assert!(
                 Args::try_parse_from(["wormhole-memprof", "--sample-period-ms", value]).is_ok(),
                 "--sample-period-ms {value} must be accepted"
+            );
+        }
+    }
+
+    /// `--leaf-only` measures leaf proving, so combining it with flags that
+    /// skip leaf proving (`--skip-leaf-gen`) or measure the aggregation
+    /// circuit instead (`--circuit-only`) is contradictory and must be
+    /// rejected at parse time.
+    #[test]
+    fn leaf_only_conflicting_flags_are_rejected_at_parse_time() {
+        assert!(Args::try_parse_from(["wormhole-memprof", "--leaf-only"]).is_ok());
+        for conflicting in ["--skip-leaf-gen", "--circuit-only"] {
+            assert!(
+                Args::try_parse_from(["wormhole-memprof", "--leaf-only", conflicting]).is_err(),
+                "--leaf-only combined with {conflicting} must be rejected"
             );
         }
     }


### PR DESCRIPTION
## Summary

- Add `--leaf-only` to `wormhole-memprof` so a run stops after leaf circuit build + proof generation and never touches the aggregator.
- Reject contradictory flag combos at parse time (`--leaf-only` conflicts with `--skip-leaf-gen` and `--circuit-only`).
- Document the new knob and a usage example in `wormhole/memprof/README.md`.

## Motivation

We needed a clean peak-RSS number for **just leaf proofs** (no aggregation). The existing memprof path always continued into private-batch aggregation, which dominates memory (~GB) and obscures the leaf budget.

## Measured results (production leaf config)

Config: `zk=Disabled`, `num_wires=143`, `num_routed_wires=80`, `rate_bits=3`, `num_query_rounds=28`. Sampler period 1 ms.

| Run | Peak RSS |
|---|---|
| Build leaf circuit + 1 proof | ~23 MB |
| Build leaf circuit + 7 proofs (sequential) | ~25 MB |
| Single-threaded (`--rayon-threads 1`), 1 proof | ~19 MB |

Leaf proving alone fits comfortably in a **32 MB** budget; aggregation remains the memory bottleneck.

Reproduce:

```bash
cargo run -p wormhole-memprof --release -- --leaf-only --real-proofs 1 --sample-period-ms 1
```

## Test plan

- [x] `cargo test -p wormhole-memprof --release` (includes new parse-time conflict test)
- [x] Manual `--leaf-only` runs for 1 and 7 proofs; confirm report ends after `gen_leaf_proof[*]` with no agg phases
- [ ] Confirm `--leaf-only --skip-leaf-gen` and `--leaf-only --circuit-only` fail at CLI parse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the memprof CLI and docs; no production proving, aggregation, or verifier behavior.
> 
> **Overview**
> Adds **`--leaf-only`** to `wormhole-memprof` so a run finishes after leaf circuit build and proof generation and **never enters** private-batch aggregation. That isolates peak resident memory for leaf-only clients, which aggregation otherwise dominates (~GB).
> 
> The flag is wired with **clap `conflicts_with_all`** against `--skip-leaf-gen` and `--circuit-only`, and a parse-time test covers those combinations. **README** documents the knob and an example command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3294609446c01b41e861a90a270a06d9d426ef1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->