### PR TITLE
V12 e2e wormhole flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,6 @@ dependencies = [
  "criterion",
  "env_logger",
  "hex",
- "libc",
  "qp-plonky2",
  "qp-wormhole-circuit",
  "qp-wormhole-inputs",
@@ -1158,7 +1157,6 @@ version = "3.1.0"
 dependencies = [
  "anyhow",
  "criterion",
- "libc",
  "qp-plonky2-verifier",
  "qp-wormhole-inputs",
  "tiny-keccak",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,7 @@ dependencies = [
  "qp-plonky2",
  "qp-wormhole-inputs",
  "qp-zk-circuits-common",
+ "zeroize",
 ]
 
 [[package]]
@@ -1489,7 +1490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1918,6 +1919,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ qp-plonky2 = { version = "=1.5.4", default-features = false, features = ["std"] 
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
 serde = { version = "=1.0.228", default-features = false, features = ["derive"] }
 tiny-keccak = { version = "=2.0.2", default-features = false, features = ["keccak"] }
+zeroize = { version = "=1.8.2", default-features = false }
 
 [workspace.package]
 authors = ["Quantus Network"]

--- a/common/src/gadgets.rs
+++ b/common/src/gadgets.rs
@@ -350,7 +350,8 @@ mod tests {
         let data = b.build::<C>();
 
         let mut pw = PartialWitness::new();
-        pw.set_target(right_t, F::from_canonical_u64(right)).unwrap();
+        pw.set_target(right_t, F::from_canonical_u64(right))
+            .unwrap();
         let proof = data.prove(pw).unwrap();
         data.verify(proof.clone()).unwrap();
         proof.public_inputs[0].to_canonical_u64() == 1

--- a/common/src/gadgets.rs
+++ b/common/src/gadgets.rs
@@ -8,6 +8,12 @@ use plonky2::{
 
 fn assert_comparison_width(left: usize, n_log: usize) {
     assert!(n_log > 0, "comparison bit width must be greater than zero");
+    // Goldilocks elements are < 2^64. Widths above 64 have no unique meaning as
+    // integer comparisons over field targets; reject them up front.
+    assert!(
+        n_log <= 64,
+        "comparison bit width {n_log} exceeds 64 bits (Goldilocks field elements)"
+    );
 
     let exclusive_upper_bound = if n_log >= usize::BITS as usize {
         usize::MAX
@@ -25,7 +31,9 @@ fn assert_comparison_width(left: usize, n_log: usize) {
 /// or not `left < right`.
 ///
 /// `n_log` must be wide enough to represent `left`, and it also range-constrains `right` to
-/// `n_log` bits via `split_le`.
+/// `n_log` bits. Widths up to 63 use `split_le` (unique: `2^n_log < p`). Width 64 goes through
+/// [`split_canonical_u32_halves`] so the Goldilocks wraparound alias `x + p` cannot flip the
+/// comparison — a plain `split_le(right, 64)` would admit both decompositions.
 ///
 /// # Returns
 /// - `BoolTarget`: True if `left < right`, false otherwise.
@@ -36,6 +44,14 @@ pub fn is_const_less_than<F: RichField + Extendable<D>, const D: usize>(
     n_log: usize,
 ) -> BoolTarget {
     assert_comparison_width(left, n_log);
+
+    // 64-bit splits over Goldilocks are not unique: for small `x`, both `x` and
+    // `x + p` are valid 64-bit bit-patterns of the same field element. Compare
+    // via the canonical half-split so a malicious prover cannot witness the
+    // alias (e.g. decompose `right = 0` as `p`) and flip `left < right`.
+    if n_log == 64 {
+        return is_const_less_than_canonical_u64(builder, left as u64, right);
+    }
 
     let right_bits = builder.split_le(right, n_log);
     let left_bits: Vec<bool> = (0..n_log).map(|i| ((left >> i) & 1) != 0).collect();
@@ -58,6 +74,25 @@ pub fn is_const_less_than<F: RichField + Extendable<D>, const D: usize>(
     }
 
     lt
+}
+
+/// `left < right` for a 64-bit comparison, with `right` forced into its unique
+/// canonical 32-bit half decomposition (see [`split_canonical_u32_halves`]).
+fn is_const_less_than_canonical_u64<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    left: u64,
+    right: Target,
+) -> BoolTarget {
+    let (right_lo, right_hi) = split_canonical_u32_halves(builder, right);
+    let left_lo = builder.constant(F::from_canonical_u64(left & 0xFFFF_FFFF));
+    let left_hi = builder.constant(F::from_canonical_u64(left >> 32));
+
+    // left < right ⇔ left_hi < right_hi ∨ (left_hi = right_hi ∧ left_lo < right_lo)
+    let hi_lt = u32_lt(builder, left_hi, right_hi);
+    let lo_lt = u32_lt(builder, left_lo, right_lo);
+    let hi_eq = builder.is_equal(left_hi, right_hi);
+    let lo_lt_and_hi_eq = builder.and(hi_eq, lo_lt);
+    builder.or(hi_lt, lo_lt_and_hi_eq)
 }
 
 /// Enforce `target < upper_bound_exclusive`.
@@ -302,6 +337,86 @@ mod tests {
     use alloc::vec;
     use plonky2::field::types::{Field, PrimeField64};
     use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+    use plonky2::plonk::circuit_data::CircuitConfig;
+
+    /// Build `is_const_less_than(left, right, n_log)` as a public bool and prove it
+    /// for the given `right` value; return the proved boolean.
+    fn prove_const_lt(left: usize, right: u64, n_log: usize) -> bool {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut b = CircuitBuilder::<F, D>::new(config);
+        let right_t = b.add_virtual_target();
+        let lt = is_const_less_than(&mut b, left, right_t, n_log);
+        b.register_public_input(lt.target);
+        let data = b.build::<C>();
+
+        let mut pw = PartialWitness::new();
+        pw.set_target(right_t, F::from_canonical_u64(right)).unwrap();
+        let proof = data.prove(pw).unwrap();
+        data.verify(proof.clone()).unwrap();
+        proof.public_inputs[0].to_canonical_u64() == 1
+    }
+
+    /// Narrow widths (`n_log < 64`) keep the `split_le` bit-comparator path;
+    /// uniqueness is free because `2^n_log < p`.
+    #[test]
+    fn is_const_less_than_narrow_width_matches_native() {
+        assert!(!prove_const_lt(3, 3, 8));
+        assert!(prove_const_lt(3, 4, 8));
+        assert!(!prove_const_lt(0, 0, 1));
+        assert!(prove_const_lt(0, 1, 1));
+    }
+
+    /// The 64-bit path must go through the canonical half-split: a plain
+    /// `split_le(right, 64)` would let a prover decompose `right = 0` as the
+    /// 64-bit integer `p` and flip `0 < right` to true. These cases pin the
+    /// honest comparison, including against the wraparound-adjacent values
+    /// (`1`, `2^32 - 2`, `p - 1`) that sit next to the excluded alias region.
+    #[test]
+    fn is_const_less_than_u64_matches_native_and_rejects_zero_alias() {
+        const P: u64 = 0xFFFF_FFFF_0000_0001;
+        assert!(
+            !prove_const_lt(0, 0, 64),
+            "0 < 0 must be false; accepting bits-of-p for right=0 would flip this"
+        );
+        assert!(prove_const_lt(0, 1, 64));
+        assert!(!prove_const_lt(1, 1, 64));
+        assert!(prove_const_lt(1, 2, 64));
+        // Largest canonical field element (hi = 2^32 - 1, lo = 0 — the edge of
+        // the excluded wraparound region `hi == 2^32 - 1 && lo >= 1`).
+        assert!(prove_const_lt(0, P - 1, 64));
+        assert!(prove_const_lt((P - 2) as usize, P - 1, 64));
+        assert!(!prove_const_lt((P - 1) as usize, P - 1, 64));
+    }
+
+    /// Forcing `0 < right` while witnessing `right = 0` must be unsatisfiable.
+    /// Without the wraparound exclusion a malicious prover could satisfy this
+    /// by decomposing 0 as the 64-bit integer `p`.
+    #[test]
+    fn is_const_less_than_u64_cannot_prove_zero_less_than_zero() {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut b = CircuitBuilder::<F, D>::new(config);
+        let right_t = b.add_virtual_target();
+        let lt = is_const_less_than(&mut b, 0, right_t, 64);
+        let tru = b._true();
+        b.connect(lt.target, tru.target);
+        let data = b.build::<C>();
+
+        let mut pw = PartialWitness::new();
+        pw.set_target(right_t, F::ZERO).unwrap();
+        assert!(
+            data.prove(pw).is_err(),
+            "proving 0 < 0 via a 64-bit alias of zero must fail"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds 64 bits")]
+    fn is_const_less_than_rejects_width_above_64() {
+        let config = CircuitConfig::standard_recursion_config();
+        let mut b = CircuitBuilder::<F, D>::new(config);
+        let right_t = b.add_virtual_target();
+        let _ = is_const_less_than(&mut b, 0, right_t, 65);
+    }
 
     /// Gates added by `sort_digests4` over `n` virtual digests under the
     /// production private-batch circuit config.

--- a/wormhole/README.md
+++ b/wormhole/README.md
@@ -99,6 +99,16 @@ wormhole transactions.
    - all of the internal header fields (`parent_hash`, `block_number`, `state_root`, `extrinsics_root`, `digest`) are cryptographically bound to that real header via Poseidon2.
    - Because the same `state_root` is also used in the storage proof, this ties the storage proof, the header, and the public block commitment together.
 
+## Threat model (artifacts & trust boundaries)
+
+Circuit binaries are **CI-generated on a trusted build host**. The adversarial
+model for artifact *generation* and for loading attested bins directories is spelled
+out in [`THREAT_MODEL.md`](./THREAT_MODEL.md): local filesystem races on the
+builder (symlinks, staging TOCTOU, planted FIFOs, etc.) are **out of scope**;
+canonical verifier pinning, dummy-template checks, and untrusted client-proof
+admission remain **in scope**. Read that document before filing or triaging
+findings against `circuit-builder` or artifact I/O.
+
 ## Nullifiers and Double-Spend Prevention (Security Model)
 
 A recurring review question is where nullifier *collisions* (reuse of the same nullifier,

--- a/wormhole/THREAT_MODEL.md
+++ b/wormhole/THREAT_MODEL.md
@@ -1,0 +1,117 @@
+# Wormhole threat model (artifact generation & loading)
+
+This document states the **trust boundaries** for Wormhole circuit artifacts
+and aggregation. Review findings that assume a different boundary (especially
+a hostile local filesystem on the build host) are **out of scope** unless that
+assumption is explicitly adopted later.
+
+Related: [Nullifiers and double-spend prevention](./README.md#nullifiers-and-double-spend-prevention-security-model)
+(settlement is on-chain; aggregators are untrusted for spend uniqueness).
+
+---
+
+## Roles
+
+| Role | Trust |
+|---|---|
+| **CI / build host** running `qp-wormhole-circuit-builder` | **Trusted** for artifact *generation*. The host, its toolchain, the checkout, and the output parent directory during the build are not an adversarial environment. |
+| **Artifact directory after CI attestation** | **Trusted origin**. Nodes and operators load bins only from CI-produced (or equivalently attested) paths — not from arbitrary untrusted uploads. |
+| **Aggregator / miner operators** | **Untrusted for soundness**. They may omit, delay, or select proofs; they must not be able to mint value or forge verifying proofs. Operational DoS against a single miner is not a protocol-soundness bug. |
+| **Clients submitting proofs** | **Untrusted**. Proofs are attacker-controlled byte strings until cryptographic verification succeeds. |
+| **On-chain verifier / wormhole pallet** | **Trusted** for settlement rules (nullifier set, fee config, etc.). |
+
+---
+
+## Explicitly out of scope
+
+The following are **not** security requirements for the circuit-builder or for
+loading CI-attested artifact directories. They assume a **local adversary with
+write access to the build output parent (or the bins directory) concurrent
+with generation/loading** — incompatible with “CI-generated, trusted build
+host.”
+
+- Symlink planting / TOCTOU on staging or artifact pathnames during publish
+- FIFOs, device nodes, or sparse files planted at artifact names to hang or
+  inflate readers during a trusted build
+- Basename / path-escape attacks against a trusted builder writing into its
+  own output directory
+- Concurrent replacement of a staging directory mid-build by another local
+  process on the build host
+- Treating “cleanup of a moved-aside previous output failed” as equivalent to
+  “publish failed” for soundness (it is an operational concern only)
+
+Hardening that still exists in the tree for some of the above is
+**defense-in-depth / operator hygiene**, not part of the claimed adversarial
+model. It may be simplified or removed without changing the security story
+described here.
+
+---
+
+## Still in scope (do not regress)
+
+Even with a trusted build host, the following remain required:
+
+1. **No shipped prover binaries**  
+   Leaf / private-batch / public-batch provers rebuild proving key material
+   from source. A `prover.bin` could choose which witness wires become public
+   inputs and exfiltrate secrets through the proof.
+
+2. **Canonical verifier pinning at load time**  
+   Loaded `common.bin` / `verifier.bin` (and private-batch equivalents) must
+   match a rebuild of the expected circuit for the configured shape. This
+   catches **wrong version, wrong shape, or accidental mix-ups** — not only
+   malice. Prefer comparing raw artifact bytes to a canonical serialization
+   so untrusted-looking length fields are never deserialized blindly.
+
+3. **Dummy padding template validation**  
+   `dummy_proof.bin` / `dummy_private_batch_proof.bin` must carry the dummy
+   sentinel and verify, so padding cannot inject real exits/nullifiers into
+   partial batches.
+
+4. **Untrusted proof admission**  
+   Proofs from the network are verified (and rate-limited as needed) before
+   pool state or membership oracles are consulted. Aggregators remain
+   untrusted for nullifier uniqueness; the chain is the double-spend boundary.
+
+5. **Config / shape bounds**  
+   `num_leaf_proofs` and `num_private_batch_proofs` stay within
+   `1..=MAX_PROOF_COUNT` before circuit construction.
+
+---
+
+## Operational requirements (trusted path)
+
+To stay inside this model, deployments should:
+
+1. Build artifacts in CI (or an equivalently controlled builder) from a pinned
+   commit/toolchain.
+2. Distribute the artifact directory via an attested channel (release asset,
+   content-addressed store, image layer, etc.).
+3. Point provers/verifiers only at that attested path — do not accept
+   operator- or user-supplied bins directories as equivalent to CI output without
+   re-attestation.
+4. Treat a bins directory of unknown provenance as **untrusted input**: either
+   refuse it or re-run the builder and pin.
+
+If a deployment *does* load bins from untrusted hosts or shared writable
+directories, that is a **different threat model** and must be documented as
+such; the out-of-scope list above becomes in-scope again.
+
+---
+
+## Audit guidance
+
+When filing issues against `circuit-builder`, `commit_artifact_set`, staging
+renames, or artifact readers:
+
+| Finding class | Under this model |
+|---|---|
+| Local FS race / symlink / FIFO on the **build host during CI generation** | Out of scope — note the assumption, do not treat as a protocol defect |
+| Poisoned or mismatched bins loaded by a **prover/verifier** | In scope if it bypasses canonical pin, dummy checks, or ships prover-only data |
+| Invalid client proof affecting **pool membership oracles** or skipping verify | In scope |
+| Aggregator learning or omitting metadata | Usually operational / privacy of the miner, not minting — classify carefully |
+| Nullifier reuse accepted **on-chain** | In scope for the pallet (chain repo), not for circuits proving uniqueness |
+
+Point reviewers at this file and at the nullifier section of
+[`README.md`](./README.md) before classifying build-host filesystem issues as
+soundness bugs.

--- a/wormhole/THREAT_MODEL.md
+++ b/wormhole/THREAT_MODEL.md
@@ -40,10 +40,16 @@ host.”
 - Treating “cleanup of a moved-aside previous output failed” as equivalent to
   “publish failed” for soundness (it is an operational concern only)
 
-Hardening that still exists in the tree for some of the above is
-**defense-in-depth / operator hygiene**, not part of the claimed adversarial
-model. It may be simplified or removed without changing the security story
-described here.
+Those publisher/local-FS defenses have been **removed** from the builder and
+artifact I/O paths to match this model. What remains for operator hygiene:
+
+- Whole-directory staging in `generate_all_circuit_binaries` (avoids mixed
+  leaf / private-batch / public-batch generations on a failed mid-pipeline run)
+- Size caps on artifact reads before canonical pinning
+- Best-effort cleanup warnings after a successful directory swap
+
+Do not reintroduce symlink/FIFO/TOCTOU/basename hardening as “security
+requirements” without first changing this document.
 
 ---
 

--- a/wormhole/aggregator/Cargo.toml
+++ b/wormhole/aggregator/Cargo.toml
@@ -20,12 +20,6 @@ wormhole-circuit = { package = "qp-wormhole-circuit", version = "=3.1.0", path =
 wormhole-prover = { package = "qp-wormhole-prover", version = "=3.1.0", path = "../prover", default-features = false }
 zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common" }
 
-# Only used by the std-gated artifact reader (O_NONBLOCK open); optional and
-# std-gated so --no-default-features builds keep libc (and libc/std) out of
-# the dependency graph entirely.
-[target.'cfg(unix)'.dependencies]
-libc = { version = "=0.2.186", default-features = false, optional = true }
-
 [dev-dependencies]
 criterion = { workspace = true }
 env_logger = "=0.11.9"
@@ -38,7 +32,6 @@ no_zk = []
 profile = ["qp-plonky2/rand", "qp-plonky2/timing", "std"]
 std = [
 	"anyhow/std",
-	"dep:libc",
 	"qp-plonky2/std",
 	"wormhole-circuit/std",
 	"wormhole-prover/std",

--- a/wormhole/aggregator/README.md
+++ b/wormhole/aggregator/README.md
@@ -4,6 +4,10 @@ Aggregates multiple Wormhole ZK proofs into a single proof (tree aggregation).
 
 Takes a batch of leaf proofs from the Wormhole circuit and produces one aggregated proof via a configurable tree (branching factor and depth). Uses [qp-wormhole-circuit], [qp-wormhole-prover], and [qp-wormhole-verifier] under the hood.
 
+Artifact directories are assumed to come from **CI-attested builds** on a trusted
+host. Trust boundaries (what is in vs out of scope for audits) are in
+[`../THREAT_MODEL.md`](../THREAT_MODEL.md).
+
 ## License
 
 MIT

--- a/wormhole/aggregator/benches/aggregator.rs
+++ b/wormhole/aggregator/benches/aggregator.rs
@@ -145,7 +145,12 @@ macro_rules! prove_public_batch_benchmark {
                 );
 
             let proof = generate_real_private_batch_proof();
-            generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs).expect(
+            generate_public_batch_circuit_binaries(
+                BINS_DIR,
+                $num_private_batch_proofs,
+                PUBLIC_BATCH_INNER_NUM_LEAVES,
+            )
+            .expect(
                 "Failed to generate public_batch circuit binaries for public_batch benchmark",
             );
 
@@ -207,7 +212,12 @@ macro_rules! verify_public_batch_benchmark {
 
             let proof = generate_real_private_batch_proof();
 
-            generate_public_batch_circuit_binaries(BINS_DIR, $num_private_batch_proofs).expect(
+            generate_public_batch_circuit_binaries(
+                BINS_DIR,
+                $num_private_batch_proofs,
+                PUBLIC_BATCH_INNER_NUM_LEAVES,
+            )
+            .expect(
                 "Failed to generate public_batch circuit binaries for public_batch benchmark",
             );
 

--- a/wormhole/aggregator/benches/aggregator.rs
+++ b/wormhole/aggregator/benches/aggregator.rs
@@ -150,9 +150,7 @@ macro_rules! prove_public_batch_benchmark {
                 $num_private_batch_proofs,
                 PUBLIC_BATCH_INNER_NUM_LEAVES,
             )
-            .expect(
-                "Failed to generate public_batch circuit binaries for public_batch benchmark",
-            );
+            .expect("Failed to generate public_batch circuit binaries for public_batch benchmark");
 
             let config = CircuitBinsConfig::new(
                 PUBLIC_BATCH_INNER_NUM_LEAVES,
@@ -217,9 +215,7 @@ macro_rules! verify_public_batch_benchmark {
                 $num_private_batch_proofs,
                 PUBLIC_BATCH_INNER_NUM_LEAVES,
             )
-            .expect(
-                "Failed to generate public_batch circuit binaries for public_batch benchmark",
-            );
+            .expect("Failed to generate public_batch circuit binaries for public_batch benchmark");
 
             let config = CircuitBinsConfig::new(
                 PUBLIC_BATCH_INNER_NUM_LEAVES,

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -25,11 +25,9 @@
 //! // other's mark instead of both proving the same key):
 //! let proofs = aggregator.lock().snapshot_batch(&key)?;
 //!
-//! // proving worker, NO lock held (use its own prover instance):
-//! let prover = PublicBatchProver::new_from_binaries_dir(&bins_dir)?;
-//! let proof = prover
-//!     .commit(PublicBatchInputs { proofs, aggregator_address })?
-//!     .prove()?;
+//! // proving worker, NO lock held — prove from the aggregator's pinned
+//! // artifacts (never re-read the mutable bins_dir):
+//! let proof = aggregator.lock().prove_batch(proofs)?;
 //! // submit `proof`; the block-import evict_settled cadence retires the
 //! // proved inputs from the pool once their segments settle on-chain.
 //! ```
@@ -61,15 +59,17 @@ use plonky2::plonk::{
 };
 use qp_wormhole_inputs::{public_batch_pi::AGGREGATOR_ADDRESS_LEN, BytesDigest};
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use zk_circuits_common::{
-    circuit::{C, D, F},
+    circuit::{wormhole_public_batch_circuit_config, C, D, F},
     utils::try_4_felts_to_bytes,
 };
 
 use crate::pool::{BatchKey, BucketStats, PoolLimits, ProofPool};
-use crate::public_batch::prover::{PublicBatchInputs, PublicBatchProver};
+use crate::public_batch::prover::{
+    verify_dummy_private_batch_template, PublicBatchInputs, PublicBatchProver,
+};
 use crate::{
     common::utils::{
         canonical_leaf_verifier_data, canonical_public_batch_verifier_data,
@@ -128,14 +128,18 @@ fn load_public_batch_verifier_from_bins(
 // ============================================================================
 
 pub struct PublicBatchAggregator {
-    bins_dir: PathBuf,
     aggregator_address: BytesDigest,
     pool: ProofPool,
     /// Canonical-pinned public-batch verifier data, loaded once at construction.
     verifier: VerifierCircuitData<F, C, D>,
-    /// Canonical-pinned private-batch (inner) common data, kept for proof
-    /// deserialization by callers.
-    private_batch_common: CommonCircuitData<F, D>,
+    /// Canonical-pinned private-batch verifier, used to build the public-batch
+    /// prover on every [`Self::prove_batch`] without re-reading the artifact
+    /// directory (which is mutable after construction).
+    private_batch_verifier: VerifierCircuitData<F, C, D>,
+    /// Pinned dummy private-batch padding template, validated at construction.
+    dummy_proof_template: Proof,
+    num_leaf_proofs: usize,
+    num_private_batch_proofs: usize,
 }
 
 impl PublicBatchAggregator {
@@ -143,41 +147,57 @@ impl PublicBatchAggregator {
         Self::with_limits(bins_dir, aggregator_address, PoolLimits::default())
     }
 
+    /// Load and pin every artifact needed for pooling and proving.
+    ///
+    /// After construction the aggregator never reads `bins_dir` again: a
+    /// filesystem attacker (or a later artifact publish) cannot change the
+    /// circuit shape or dummy template under a proving call. Callers that
+    /// need to rotate artifacts must construct a new aggregator.
     pub fn with_limits<P: AsRef<Path>>(
         bins_dir: P,
         aggregator_address: BytesDigest,
         limits: PoolLimits,
     ) -> Result<Self> {
-        let bins_dir = bins_dir.as_ref().to_path_buf();
+        let bins_dir = bins_dir.as_ref();
 
-        let config = CircuitBinsConfig::load(&bins_dir)?;
+        let config = CircuitBinsConfig::load(bins_dir)?;
         let num_private_batch_proofs = config
             .num_private_batch_proofs
             .ok_or_else(|| anyhow!("config is missing num_private_batch_proofs. Please regenerate the binaries and set \"num_private_batch_proofs\""))?;
         let num_leaf_proofs = config.num_leaf_proofs;
 
-        let private_batch = load_private_batch_verifier_from_bins(&bins_dir, num_leaf_proofs)?;
+        let private_batch_verifier =
+            load_private_batch_verifier_from_bins(bins_dir, num_leaf_proofs)?;
         let verifier = load_public_batch_verifier_from_bins(
-            &bins_dir,
-            &private_batch,
+            bins_dir,
+            &private_batch_verifier,
             num_leaf_proofs,
             num_private_batch_proofs,
         )?;
 
-        let private_batch_common = private_batch.common.clone();
+        let dummy_proof_template = Proof::from_bytes(
+            read_bin(bins_dir, "dummy_private_batch_proof.bin")?,
+            &private_batch_verifier.common,
+        )
+        .map_err(|e| anyhow!("failed to deserialize dummy private-batch proof: {}", e))?;
+        verify_dummy_private_batch_template(&dummy_proof_template, &private_batch_verifier)
+            .context("dummy private-batch proof template failed validation at aggregator init")?;
+
         let pool = ProofPool::new(
-            private_batch,
+            private_batch_verifier.clone(),
             num_leaf_proofs,
             num_private_batch_proofs,
             limits,
         )?;
 
         Ok(Self {
-            bins_dir,
             aggregator_address,
             pool,
             verifier,
-            private_batch_common,
+            private_batch_verifier,
+            dummy_proof_template,
+            num_leaf_proofs,
+            num_private_batch_proofs,
         })
     }
 
@@ -242,25 +262,44 @@ impl PublicBatchAggregator {
     /// Prove a snapshot of private-batch proofs into a public-batch proof
     /// bound to this aggregator's address. Does not touch the pool.
     ///
+    /// Builds the public-batch prover from artifacts pinned at construction
+    /// (private-batch verifier, dummy template, batch sizes) — never from the
+    /// mutable `bins_dir` path. The returned proof is checked against the
+    /// pinned [`Self::verify`] before being handed back, so a divergent prover
+    /// build cannot silently return an unusable proof.
+    ///
     /// Takes tens of seconds (~16 s for a 53-proof batch on
     /// Apple-Silicon-class hardware, plus prover load). In a concurrent
     /// service, run this on a dedicated proving worker without holding
     /// whatever lock guards the aggregator — the snapshot is already
     /// independent of the pool.
     pub fn prove_batch(&self, proofs: Vec<Proof>) -> Result<Proof> {
-        let prover = PublicBatchProver::new_from_binaries_dir(&self.bins_dir)
-            .context("failed to load prebuilt public-batch prover")?;
+        let prover = PublicBatchProver::new(
+            wormhole_public_batch_circuit_config(),
+            self.private_batch_verifier.common.clone(),
+            &self.private_batch_verifier.verifier_only,
+            self.num_private_batch_proofs,
+            self.num_leaf_proofs,
+            self.dummy_proof_template.clone(),
+        )
+        .context("failed to build public-batch prover from pinned artifacts")?;
 
-        // Partial batches are fine: PublicBatchProver::commit pads with the dummy
-        // private-batch proof template (no shuffle - forwarding stays order-preserving
-        // so the chain can attribute each segment to its inner proof).
-        prover
+        // Partial batches are fine: PublicBatchProver::commit pads with the
+        // pinned dummy private-batch proof template (no shuffle — forwarding
+        // stays order-preserving so the chain can attribute each segment to
+        // its inner proof).
+        let proof = prover
             .commit(PublicBatchInputs {
                 proofs,
                 aggregator_address: self.aggregator_address,
             })
             .context("failed to commit private-batch proofs to public-batch prover")
-            .and_then(|committed| committed.prove().context("public-batch proving failed"))
+            .and_then(|committed| committed.prove().context("public-batch proving failed"))?;
+
+        self.verify(proof.clone()).context(
+            "proved public-batch proof rejected by the aggregator's pinned verifier",
+        )?;
+        Ok(proof)
     }
 
     /// Per-bucket statistics for the operator's "when to aggregate what" policy.
@@ -337,6 +376,6 @@ impl PublicBatchAggregator {
     /// Common circuit data of the private-batch (inner) circuit, e.g. for
     /// deserializing client proof submissions.
     pub fn private_batch_common(&self) -> &CommonCircuitData<F, D> {
-        &self.private_batch_common
+        &self.private_batch_verifier.common
     }
 }

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -22,15 +22,25 @@
 //! ```text
 //! // policy loop, short exclusive lock (snapshot_batch takes &mut self —
 //! // it records the snapshot time, so racing policy workers see each
-//! // other's mark instead of both proving the same key):
-//! let proofs = aggregator.lock().snapshot_batch(&key)?;
+//! // other's mark instead of both proving the same key). Capture the OWNED
+//! // proving context under the same short lock, then drop the guard:
+//! let (proofs, prover) = {
+//!     let mut guard = aggregator.lock();
+//!     (guard.snapshot_batch(&key)?, guard.proving_context())
+//! }; // guard dropped HERE — admission, eviction, and policy keep running
 //!
-//! // proving worker, NO lock held — prove from the aggregator's pinned
-//! // artifacts (never re-read the mutable bins_dir):
-//! let proof = aggregator.lock().prove_batch(proofs)?;
+//! // proving worker, NO lock held — the context owns clones of the
+//! // artifacts pinned at construction (never re-reads the mutable
+//! // bins_dir), so it can be moved to the worker outright:
+//! let proof = prover.prove_batch(proofs)?;
 //! // submit `proof`; the block-import evict_settled cadence retires the
 //! // proved inputs from the pool once their segments settle on-chain.
 //! ```
+//!
+//! Do NOT call [`PublicBatchAggregator::prove_batch`] through the lock
+//! (`aggregator.lock().prove_batch(proofs)`): it borrows the aggregator, so
+//! the temporary guard lives until proving returns, blocking every other
+//! aggregator user for the full proving window.
 //!
 //! Proving is NON-CONSUMING: the snapshot is a clone and the pooled originals
 //! stay put, because a claiming miner's pool may hold the only copy of a
@@ -128,8 +138,24 @@ fn load_public_batch_verifier_from_bins(
 // ============================================================================
 
 pub struct PublicBatchAggregator {
-    aggregator_address: BytesDigest,
     pool: ProofPool,
+    /// Everything proving needs, pinned at construction. Cloned out through
+    /// [`Self::proving_context`] so proving workers never hold the lock that
+    /// guards this aggregator.
+    proving: ProvingContext,
+}
+
+/// Owned proving context: every artifact [`prove_batch`](Self::prove_batch)
+/// needs, pinned at aggregator construction and detached from the pool.
+///
+/// Capture it under the same short lock as
+/// [`PublicBatchAggregator::snapshot_batch`], drop the guard, then move the
+/// context to a proving worker (see the module docs for the pattern). Cloning
+/// is cheap next to a proving run: two verifier keys and one dummy proof
+/// template, no pool data.
+#[derive(Clone)]
+pub struct ProvingContext {
+    aggregator_address: BytesDigest,
     /// Canonical-pinned public-batch verifier data, loaded once at construction.
     verifier: VerifierCircuitData<F, C, D>,
     /// Canonical-pinned private-batch verifier, used to build the public-batch
@@ -140,6 +166,77 @@ pub struct PublicBatchAggregator {
     dummy_proof_template: Proof,
     num_leaf_proofs: usize,
     num_private_batch_proofs: usize,
+}
+
+impl ProvingContext {
+    /// Prove a snapshot of private-batch proofs into a public-batch proof
+    /// bound to this aggregator's address. Independent of the pool and of the
+    /// aggregator it was cloned from.
+    ///
+    /// Builds the public-batch prover from artifacts pinned at aggregator
+    /// construction (private-batch verifier, dummy template, batch sizes) —
+    /// never from the mutable `bins_dir` path. The returned proof is checked
+    /// against the pinned [`Self::verify`] before being handed back, so a
+    /// divergent prover build cannot silently return an unusable proof.
+    ///
+    /// Takes tens of seconds (~16 s for a 53-proof batch on
+    /// Apple-Silicon-class hardware, plus prover load). Run it on a dedicated
+    /// proving worker without holding whatever lock guards the aggregator —
+    /// this context is owned, so nothing here needs the lock.
+    pub fn prove_batch(&self, proofs: Vec<Proof>) -> Result<Proof> {
+        let prover = PublicBatchProver::new(
+            wormhole_public_batch_circuit_config(),
+            self.private_batch_verifier.common.clone(),
+            &self.private_batch_verifier.verifier_only,
+            self.num_private_batch_proofs,
+            self.num_leaf_proofs,
+            self.dummy_proof_template.clone(),
+        )
+        .context("failed to build public-batch prover from pinned artifacts")?;
+
+        // Partial batches are fine: PublicBatchProver::commit pads with the
+        // pinned dummy private-batch proof template (no shuffle — forwarding
+        // stays order-preserving so the chain can attribute each segment to
+        // its inner proof).
+        let proof = prover
+            .commit(PublicBatchInputs {
+                proofs,
+                aggregator_address: self.aggregator_address,
+            })
+            .context("failed to commit private-batch proofs to public-batch prover")
+            .and_then(|committed| committed.prove().context("public-batch proving failed"))?;
+
+        self.verify(proof.clone())
+            .context("proved public-batch proof rejected by the aggregator's pinned verifier")?;
+        Ok(proof)
+    }
+
+    /// Verify an aggregated public-batch proof produced under this aggregator's
+    /// address.
+    pub fn verify(&self, proof: Proof) -> Result<()> {
+        // Bind the proof's exposed aggregator address to the configured one before
+        // accepting it: the public-batch circuit exposes the address as a public
+        // input, so without this check a valid proof produced under a different
+        // aggregator identity would be accepted here (#96981).
+        ensure_proof_public_input_len(
+            &proof,
+            self.verifier.common.num_public_inputs,
+            "public-batch proof",
+        )?;
+        let proof_aggregator_address =
+            try_4_felts_to_bytes(&proof.public_inputs[..AGGREGATOR_ADDRESS_LEN])
+                .context("failed to parse public-batch aggregator address from proof")?;
+        if proof_aggregator_address != self.aggregator_address {
+            bail!(
+                "public-batch proof aggregator address {:?} does not match configured aggregator address {:?}",
+                proof_aggregator_address,
+                self.aggregator_address
+            );
+        }
+        self.verifier
+            .verify(proof)
+            .map_err(|e| anyhow!("public-batch aggregated proof verification failed: {}", e))
+    }
 }
 
 impl PublicBatchAggregator {
@@ -191,13 +288,15 @@ impl PublicBatchAggregator {
         )?;
 
         Ok(Self {
-            aggregator_address,
             pool,
-            verifier,
-            private_batch_verifier,
-            dummy_proof_template,
-            num_leaf_proofs,
-            num_private_batch_proofs,
+            proving: ProvingContext {
+                aggregator_address,
+                verifier,
+                private_batch_verifier,
+                dummy_proof_template,
+                num_leaf_proofs,
+                num_private_batch_proofs,
+            },
         })
     }
 
@@ -259,46 +358,25 @@ impl PublicBatchAggregator {
         })
     }
 
+    /// Clone the owned proving context for a proving worker. Capture it under
+    /// the same short lock as [`Self::snapshot_batch`], drop the guard, then
+    /// call [`ProvingContext::prove_batch`] on the worker WITHOUT the lock
+    /// (see the module docs for the full pattern).
+    pub fn proving_context(&self) -> ProvingContext {
+        self.proving.clone()
+    }
+
     /// Prove a snapshot of private-batch proofs into a public-batch proof
     /// bound to this aggregator's address. Does not touch the pool.
     ///
-    /// Builds the public-batch prover from artifacts pinned at construction
-    /// (private-batch verifier, dummy template, batch sizes) — never from the
-    /// mutable `bins_dir` path. The returned proof is checked against the
-    /// pinned [`Self::verify`] before being handed back, so a divergent prover
-    /// build cannot silently return an unusable proof.
-    ///
-    /// Takes tens of seconds (~16 s for a 53-proof batch on
-    /// Apple-Silicon-class hardware, plus prover load). In a concurrent
-    /// service, run this on a dedicated proving worker without holding
-    /// whatever lock guards the aggregator — the snapshot is already
-    /// independent of the pool.
+    /// Blocking convenience that delegates to [`ProvingContext::prove_batch`]
+    /// on the pinned context. Because it borrows `&self`, a caller guarding
+    /// the aggregator with a mutex would keep the guard alive for the whole
+    /// tens-of-seconds proving run — a concurrent service must instead
+    /// capture [`Self::proving_context`] under the short lock and prove from
+    /// the owned context with the guard dropped.
     pub fn prove_batch(&self, proofs: Vec<Proof>) -> Result<Proof> {
-        let prover = PublicBatchProver::new(
-            wormhole_public_batch_circuit_config(),
-            self.private_batch_verifier.common.clone(),
-            &self.private_batch_verifier.verifier_only,
-            self.num_private_batch_proofs,
-            self.num_leaf_proofs,
-            self.dummy_proof_template.clone(),
-        )
-        .context("failed to build public-batch prover from pinned artifacts")?;
-
-        // Partial batches are fine: PublicBatchProver::commit pads with the
-        // pinned dummy private-batch proof template (no shuffle — forwarding
-        // stays order-preserving so the chain can attribute each segment to
-        // its inner proof).
-        let proof = prover
-            .commit(PublicBatchInputs {
-                proofs,
-                aggregator_address: self.aggregator_address,
-            })
-            .context("failed to commit private-batch proofs to public-batch prover")
-            .and_then(|committed| committed.prove().context("public-batch proving failed"))?;
-
-        self.verify(proof.clone())
-            .context("proved public-batch proof rejected by the aggregator's pinned verifier")?;
-        Ok(proof)
+        self.proving.prove_batch(proofs)
     }
 
     /// Per-bucket statistics for the operator's "when to aggregate what" policy.
@@ -341,40 +419,19 @@ impl PublicBatchAggregator {
     }
 
     /// Verify an aggregated public-batch proof produced under this aggregator's
-    /// address.
+    /// address. See [`ProvingContext::verify`].
     pub fn verify(&self, proof: Proof) -> Result<()> {
-        // Bind the proof's exposed aggregator address to the configured one before
-        // accepting it: the public-batch circuit exposes the address as a public
-        // input, so without this check a valid proof produced under a different
-        // aggregator identity would be accepted here (#96981).
-        ensure_proof_public_input_len(
-            &proof,
-            self.verifier.common.num_public_inputs,
-            "public-batch proof",
-        )?;
-        let proof_aggregator_address =
-            try_4_felts_to_bytes(&proof.public_inputs[..AGGREGATOR_ADDRESS_LEN])
-                .context("failed to parse public-batch aggregator address from proof")?;
-        if proof_aggregator_address != self.aggregator_address {
-            bail!(
-                "public-batch proof aggregator address {:?} does not match configured aggregator address {:?}",
-                proof_aggregator_address,
-                self.aggregator_address
-            );
-        }
-        self.verifier
-            .verify(proof)
-            .map_err(|e| anyhow!("public-batch aggregated proof verification failed: {}", e))
+        self.proving.verify(proof)
     }
 
     /// Common circuit data of the public-batch (output) circuit.
     pub fn public_batch_common(&self) -> &CommonCircuitData<F, D> {
-        &self.verifier.common
+        &self.proving.verifier.common
     }
 
     /// Common circuit data of the private-batch (inner) circuit, e.g. for
     /// deserializing client proof submissions.
     pub fn private_batch_common(&self) -> &CommonCircuitData<F, D> {
-        &self.private_batch_verifier.common
+        &self.proving.private_batch_verifier.common
     }
 }

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -296,9 +296,8 @@ impl PublicBatchAggregator {
             .context("failed to commit private-batch proofs to public-batch prover")
             .and_then(|committed| committed.prove().context("public-batch proving failed"))?;
 
-        self.verify(proof.clone()).context(
-            "proved public-batch proof rejected by the aggregator's pinned verifier",
-        )?;
+        self.verify(proof.clone())
+            .context("proved public-batch proof rejected by the aggregator's pinned verifier")?;
         Ok(proof)
     }
 

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -83,9 +83,8 @@ pub fn commit_artifact_set(
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => {
-                return Err(e).with_context(|| {
-                    format!("Failed to remove stale artifact {}", path.display())
-                })
+                return Err(e)
+                    .with_context(|| format!("Failed to remove stale artifact {}", path.display()))
             }
         }
     }
@@ -611,9 +610,8 @@ mod tests {
             poisoned[i..i + 8].copy_from_slice(&(usize::MAX / 16).to_le_bytes());
         }
         let leaf = canonical_leaf_verifier_data();
-        let err =
-            load_canonical_private_batch_verifier_data(&poisoned, &poisoned[..128], &leaf, 1)
-                .unwrap_err();
+        let err = load_canonical_private_batch_verifier_data(&poisoned, &poisoned[..128], &leaf, 1)
+            .unwrap_err();
         assert!(
             err.to_string().contains("does not match the canonical"),
             "poisoned common must fail the byte pin, got: {err}"
@@ -622,10 +620,8 @@ mod tests {
 
     #[test]
     fn commit_artifact_set_writes_and_removes_stale() {
-        let dir = std::env::temp_dir().join(format!(
-            "qp-artifact-write-test-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("qp-artifact-write-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
 
         commit_artifact_set(

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -359,6 +359,11 @@ pub fn sweep_stale_artifact_droppings(bins_dir: &std::path::Path) -> Result<usiz
 }
 
 /// Load verifier circuit data (common + verifier-only) from serialized bytes.
+///
+/// Prefer [`load_canonical_leaf_verifier_data`] /
+/// [`load_canonical_private_batch_verifier_data`] for untrusted artifacts: those
+/// pin by raw byte equality against a canonical rebuild and never ask Plonky2
+/// to deserialize attacker-controlled length fields.
 pub fn load_verifier_data_from_bytes(
     common_bytes: &[u8],
     verifier_only_bytes: &[u8],
@@ -379,28 +384,75 @@ pub fn load_verifier_data_from_bytes(
     })
 }
 
+/// Pin untrusted common/verifier-only artifact bytes to a canonical rebuild by
+/// raw equality. Never deserializes the untrusted side: Plonky2's
+/// `CommonCircuitData::from_bytes` reserves vector capacities from length
+/// fields in the artifact before those lengths are proven consistent with the
+/// file, so a capped-but-poisoned buffer can force large transient allocations
+/// (or allocator failure) before any canonical check runs.
+fn ensure_artifact_bytes_match_canonical(
+    common_bytes: &[u8],
+    verifier_only_bytes: &[u8],
+    canonical: &VerifierCircuitData<F, C, D>,
+    label: &str,
+) -> Result<()> {
+    let gate_serializer = DefaultGateSerializer;
+    let canonical_common = canonical
+        .common
+        .to_bytes(&gate_serializer)
+        .map_err(|e| anyhow!("failed to serialize canonical {} common data: {}", label, e))?;
+    if common_bytes != canonical_common.as_slice() {
+        bail!(
+            "loaded {} common circuit data does not match the canonical circuit",
+            label
+        );
+    }
+
+    let canonical_vo = canonical.verifier_only.to_bytes().map_err(|e| {
+        anyhow!(
+            "failed to serialize canonical {} verifier-only data: {}",
+            label,
+            e
+        )
+    })?;
+    if verifier_only_bytes != canonical_vo.as_slice() {
+        bail!(
+            "loaded {} verifier-only data does not match the canonical circuit",
+            label
+        );
+    }
+    Ok(())
+}
+
 /// Load leaf verifier data and reject anything that is not the canonical Wormhole leaf circuit.
 pub fn load_canonical_leaf_verifier_data(
     common_bytes: &[u8],
     verifier_only_bytes: &[u8],
 ) -> Result<VerifierCircuitData<F, C, D>> {
-    let loaded = load_verifier_data_from_bytes(common_bytes, verifier_only_bytes, "leaf")?;
-    ensure_verifier_data_matches_canonical(&loaded, &canonical_leaf_verifier_data(), "leaf")?;
-    Ok(loaded)
+    let canonical = canonical_leaf_verifier_data();
+    ensure_artifact_bytes_match_canonical(common_bytes, verifier_only_bytes, &canonical, "leaf")?;
+    Ok(canonical)
 }
 
 /// Load private-batch verifier data pinned to the canonical private-batch circuit for
 /// `num_leaf_proofs`. `leaf` must be canonical leaf verifier data (loaded pinned or rebuilt).
+///
+/// The untrusted artifact bytes are compared to the canonical serialization
+/// without deserializing them — see [`ensure_artifact_bytes_match_canonical`].
 pub fn load_canonical_private_batch_verifier_data(
     common_bytes: &[u8],
     verifier_only_bytes: &[u8],
     leaf: &VerifierCircuitData<F, C, D>,
     num_leaf_proofs: usize,
 ) -> Result<VerifierCircuitData<F, C, D>> {
-    let loaded = load_verifier_data_from_bytes(common_bytes, verifier_only_bytes, "private_batch")?;
     let canonical = canonical_private_batch_verifier_data(leaf, num_leaf_proofs)?;
-    ensure_verifier_data_matches_canonical(&loaded, &canonical, "private_batch")?;
-    Ok(loaded)
+    ensure_artifact_bytes_match_canonical(
+        common_bytes,
+        verifier_only_bytes,
+        &canonical,
+        "private_batch",
+    )?;
+    Ok(canonical)
 }
 
 pub fn ensure_common_matches_canonical(
@@ -815,6 +867,36 @@ mod tests {
     fn private_batch_num_leaves_from_padded_pi_len_rejects_malformed_lengths() {
         let err = private_batch_num_leaves_from_padded_pi_len(9).unwrap_err();
         assert!(err.to_string().contains("malformed"));
+    }
+
+    /// Pinning must compare raw artifact bytes to a canonical rebuild and never
+    /// feed untrusted common data into `CommonCircuitData::from_bytes`. That
+    /// deserializer reserves vector capacities from length fields in the
+    /// artifact; a small buffer of enormous little-endian usizes would
+    /// previously force large `try_reserve` calls (or allocator failure)
+    /// before the canonical check could reject it (audit finding).
+    #[test]
+    fn load_canonical_private_batch_rejects_poisoned_common_by_byte_pin() {
+        use super::{
+            canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
+        };
+
+        let mut poisoned = vec![0u8; 4096];
+        for i in (0..poisoned.len()).step_by(8) {
+            poisoned[i..i + 8].copy_from_slice(&(usize::MAX / 16).to_le_bytes());
+        }
+        let leaf = canonical_leaf_verifier_data();
+        let err = load_canonical_private_batch_verifier_data(
+            &poisoned,
+            &poisoned[..128],
+            &leaf,
+            1,
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("does not match the canonical"),
+            "poisoned common must fail the byte pin, got: {err}"
+        );
     }
 
     #[test]

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -98,6 +98,39 @@ pub fn read_artifact_file(path: &std::path::Path) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
+/// Reject any artifact name that is not a single basename confined under
+/// `bins_dir`.
+///
+/// `commit_artifact_set` builds staging, backup, and final paths with
+/// `bins_dir.join(name)` (and `bins_dir.join(format!(".{name}.…"))`). A name
+/// carrying directory components, `..`, or an absolute path would therefore
+/// resolve outside `bins_dir`. This is an allowlist — the name must already
+/// be exactly one normal path component — not a scrubber that tries to strip
+/// hostile fragments.
+#[cfg(feature = "std")]
+fn ensure_artifact_basename(name: &str) -> Result<()> {
+    use std::path::Path;
+
+    let path = Path::new(name);
+    let Some(file_name) = path.file_name() else {
+        bail!("artifact name {name:?} is not a valid basename");
+    };
+    // Equality holds iff `name` is a single component: `file_name()` strips
+    // parents / trailing separators, so `../x`, `a/b`, `/abs`, `.`, and `..`
+    // all fail. Platform separators (`\` on Windows) are handled by Path.
+    if path.as_os_str() != file_name {
+        bail!(
+            "artifact name {name:?} must be a single filename with no directory components"
+        );
+    }
+    // NUL can truncate C-style path APIs on some platforms; refuse it even
+    // though it is not a Path separator.
+    if name.contains('\0') {
+        bail!("artifact name must not contain NUL");
+    }
+    Ok(())
+}
+
 /// Publish a matched set of artifact files into `bins_dir` all-or-nothing,
 /// optionally removing stale files that are no longer part of the set.
 ///
@@ -132,7 +165,9 @@ pub fn read_artifact_file(path: &std::path::Path) -> Result<Vec<u8>> {
 /// Because staging opens with create-new semantics and publication renames
 /// over the final name, a symlink pre-planted at an artifact filename is
 /// replaced as an entry rather than followed, so a write can never be
-/// redirected onto the symlink's target. Public so `circuit-builder` can
+/// redirected onto the symlink's target. Artifact names (both published and
+/// `remove_stale`) must be basenames with no directory components, so path
+/// construction cannot escape `bins_dir`. Public so `circuit-builder` can
 /// publish the leaf artifact set through the same path.
 #[cfg(feature = "std")]
 pub fn commit_artifact_set(
@@ -142,6 +177,16 @@ pub fn commit_artifact_set(
 ) -> Result<()> {
     use std::fs;
     use std::io::Write as _;
+
+    // Validate before any filesystem work so a hostile name cannot stage,
+    // move aside, or delete outside `bins_dir`.
+    for name in files
+        .iter()
+        .map(|(name, _)| *name)
+        .chain(remove_stale.iter().copied())
+    {
+        ensure_artifact_basename(name)?;
+    }
 
     let unique = format!("{}-{:016x}", std::process::id(), rand::random::<u64>());
     let tmp_path = |name: &str| bins_dir.join(format!(".{name}.tmp-{unique}"));
@@ -761,12 +806,110 @@ pub fn private_batch_num_leaves_from_padded_pi_len(pi_len: usize) -> Result<usiz
 #[cfg(test)]
 mod tests {
     use super::private_batch_num_leaves_from_padded_pi_len;
-    use super::{read_artifact_file, sweep_stale_artifact_droppings, MAX_ARTIFACT_FILE_BYTES};
+    use super::{
+        commit_artifact_set, ensure_artifact_basename, read_artifact_file,
+        sweep_stale_artifact_droppings, MAX_ARTIFACT_FILE_BYTES,
+    };
 
     #[test]
     fn private_batch_num_leaves_from_padded_pi_len_rejects_malformed_lengths() {
         let err = private_batch_num_leaves_from_padded_pi_len(9).unwrap_err();
         assert!(err.to_string().contains("malformed"));
+    }
+
+    #[test]
+    fn ensure_artifact_basename_accepts_plain_filenames() {
+        for name in ["common.bin", "config.json", "dummy_private_batch_proof.bin", "a"] {
+            ensure_artifact_basename(name).unwrap_or_else(|e| {
+                panic!("expected {name:?} to be accepted, got: {e}");
+            });
+        }
+    }
+
+    /// Audit finding: unvalidated artifact names let `bins_dir.join(name)`
+    /// (and the `.{name}.tmp-…` staging form) escape the artifact directory.
+    /// Only a single normal path component is allowed.
+    #[test]
+    fn ensure_artifact_basename_rejects_directory_components() {
+        for name in [
+            "",
+            ".",
+            "..",
+            "../common.bin",
+            "foo/bar",
+            "foo/../bar",
+            "/etc/passwd",
+            "./common.bin",
+            "common.bin/",
+            "a\0b",
+        ] {
+            let err = ensure_artifact_basename(name).expect_err(&format!(
+                "expected {name:?} to be rejected"
+            ));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("basename")
+                    || msg.contains("directory components")
+                    || msg.contains("NUL"),
+                "unexpected error for {name:?}: {msg}"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn ensure_artifact_basename_rejects_windows_separators() {
+        let err = ensure_artifact_basename("foo\\bar").unwrap_err();
+        assert!(
+            err.to_string().contains("directory components"),
+            "got: {err}"
+        );
+    }
+
+    /// A hostile name in either `files` or `remove_stale` must fail before any
+    /// path under / beside `bins_dir` is touched.
+    #[test]
+    fn commit_artifact_set_rejects_non_basename_names_before_touching_disk() {
+        let dir = std::env::temp_dir().join(format!(
+            "qp-artifact-basename-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Outside-target marker: must remain untouched if validation works.
+        let outside = std::env::temp_dir().join(format!(
+            "qp-artifact-basename-victim-{}",
+            std::process::id()
+        ));
+        std::fs::write(&outside, b"untouched").unwrap();
+
+        let err = commit_artifact_set(
+            &dir,
+            &[("../qp-artifact-basename-victim-should-not-exist", b"x".to_vec())],
+            &[],
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("directory components")
+                || err.to_string().contains("basename"),
+            "got: {err}"
+        );
+
+        let err = commit_artifact_set(&dir, &[("ok.bin", b"x".to_vec())], &["../outside"])
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("directory components")
+                || err.to_string().contains("basename"),
+            "got: {err}"
+        );
+
+        assert_eq!(std::fs::read(&outside).unwrap(), b"untouched");
+        // Nothing staged or published inside bins_dir either.
+        assert!(std::fs::read_dir(&dir).unwrap().next().is_none());
+
+        let _ = std::fs::remove_file(&outside);
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     /// The sweep must remove exactly the `.<name>.tmp-<pid>-<rand>` /

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -26,52 +26,18 @@ use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 
 /// Maximum size accepted for any serialized circuit-artifact file.
 ///
-/// The largest legitimate artifact is a serialized recursive proof (hundreds
-/// of KB); common/verifier data is smaller still. 64 MiB gives generous
-/// headroom for config variations while bounding the allocation an untrusted
-/// artifact directory can force: without a cap, a single oversized or sparse
-/// `*.bin` file is read fully into memory BEFORE canonical validation gets a
-/// chance to reject it, letting an attacker-chosen directory crash or memory-
-/// starve the loading process.
+/// Bounds the allocation before canonical pinning can reject a wrong or
+/// oversized file. Artifact directories are assumed to come from attested CI
+/// builds ([`crate`]-level threat model in `wormhole/THREAT_MODEL.md`); this
+/// is a cheap sanity bound, not a local-filesystem adversary defense.
 pub const MAX_ARTIFACT_FILE_BYTES: u64 = 64 * 1024 * 1024;
 
 /// Read a circuit-artifact file, refusing anything larger than
 /// [`MAX_ARTIFACT_FILE_BYTES`] before allocating for its contents.
-///
-/// Only regular files are accepted. A FIFO, device node, or symlink to one
-/// planted at an artifact path would otherwise block `open` (a FIFO with no
-/// writer) or `read_to_end` (a stream that never reaches EOF) forever,
-/// independent of the size cap below. On unix the open uses `O_NONBLOCK` so
-/// even the FIFO-open case cannot stall; the file type is then checked via
-/// `fstat` on the opened handle before any read. `O_NONBLOCK` has no effect
-/// on regular-file opens or reads.
-///
-/// The size is checked via `fstat` on the already-opened handle (no
-/// stat-then-open race), and the read itself is additionally capped with
-/// `Read::take` in case the file grows after the check.
 #[cfg(feature = "std")]
 pub fn read_artifact_file(path: &std::path::Path) -> Result<Vec<u8>> {
-    use std::io::Read as _;
-
-    let mut options = std::fs::File::options();
-    options.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        options.custom_flags(libc::O_NONBLOCK);
-    }
-    let file = options
-        .open(path)
-        .with_context(|| format!("failed to open artifact file {}", path.display()))?;
-    let metadata = file
-        .metadata()
+    let metadata = std::fs::metadata(path)
         .with_context(|| format!("failed to stat artifact file {}", path.display()))?;
-    if !metadata.file_type().is_file() {
-        bail!(
-            "artifact file {} is not a regular file; refusing to load it",
-            path.display()
-        );
-    }
     let claimed_len = metadata.len();
     if claimed_len > MAX_ARTIFACT_FILE_BYTES {
         bail!(
@@ -82,93 +48,20 @@ pub fn read_artifact_file(path: &std::path::Path) -> Result<Vec<u8>> {
             MAX_ARTIFACT_FILE_BYTES
         );
     }
-
-    let mut bytes = Vec::with_capacity(claimed_len as usize);
-    file.take(MAX_ARTIFACT_FILE_BYTES + 1)
-        .read_to_end(&mut bytes)
-        .with_context(|| format!("failed to read artifact file {}", path.display()))?;
-    if bytes.len() as u64 > MAX_ARTIFACT_FILE_BYTES {
-        bail!(
-            "artifact file {} grew past the {} byte limit for circuit artifacts \
-             while being read; refusing to load it",
-            path.display(),
-            MAX_ARTIFACT_FILE_BYTES
-        );
-    }
-    Ok(bytes)
+    std::fs::read(path).with_context(|| format!("failed to read artifact file {}", path.display()))
 }
 
-/// Reject any artifact name that is not a single basename confined under
-/// `bins_dir`.
+/// Write a matched set of artifact files into `bins_dir`, optionally removing
+/// stale names that are no longer part of the set.
 ///
-/// `commit_artifact_set` builds staging, backup, and final paths with
-/// `bins_dir.join(name)` (and `bins_dir.join(format!(".{name}.…"))`). A name
-/// carrying directory components, `..`, or an absolute path would therefore
-/// resolve outside `bins_dir`. This is an allowlist — the name must already
-/// be exactly one normal path component — not a scrubber that tries to strip
-/// hostile fragments.
-#[cfg(feature = "std")]
-fn ensure_artifact_basename(name: &str) -> Result<()> {
-    use std::path::Path;
-
-    let path = Path::new(name);
-    let Some(file_name) = path.file_name() else {
-        bail!("artifact name {name:?} is not a valid basename");
-    };
-    // Equality holds iff `name` is a single component: `file_name()` strips
-    // parents / trailing separators, so `../x`, `a/b`, `/abs`, `.`, and `..`
-    // all fail. Platform separators (`\` on Windows) are handled by Path.
-    if path.as_os_str() != file_name {
-        bail!(
-            "artifact name {name:?} must be a single filename with no directory components"
-        );
-    }
-    // NUL can truncate C-style path APIs on some platforms; refuse it even
-    // though it is not a Path separator.
-    if name.contains('\0') {
-        bail!("artifact name must not contain NUL");
-    }
-    Ok(())
-}
-
-/// Publish a matched set of artifact files into `bins_dir` all-or-nothing,
-/// optionally removing stale files that are no longer part of the set.
+/// Under the trusted-CI threat model (`wormhole/THREAT_MODEL.md`), generation
+/// runs on a trusted host — typically into a private staging directory that
+/// [`qp_wormhole_circuit_builder::generate_all_circuit_binaries`] swaps in
+/// wholesale. Per-file atomic publish / symlink TOCTOU hardening is therefore
+/// unnecessary here; prefer `generate_all_circuit_binaries` for production
+/// regenerates so a failed stage never mixes generations in the live output.
 ///
-/// Artifact files are consumed as matched sets (loaders pin them against a
-/// canonical circuit rebuild and verify templates against the loaded verifier
-/// data), so a directory holding a fresh file from one generation beside a
-/// stale file from another is rejected until regenerated. Naive in-place
-/// writes create exactly that state whenever a re-run fails between files.
-///
-/// Instead, every file is first staged under a fresh unpredictable temp name
-/// in the same directory (exclusive create, so a pre-planted entry or symlink
-/// is never adopted), and only after all stages succeed are the previous
-/// artifacts (including any `remove_stale` entries) moved aside and the
-/// staged files renamed into place. Any HANDLED failure rolls the moved-aside
-/// originals back, so an error return always leaves either the complete
-/// previous set or the complete new set — never a mix. The unwritten window
-/// shrinks from the whole multi-minute build-and-write to the instants
-/// between renames of already-complete files.
-///
-/// A hard crash (SIGKILL, power loss) inside that window is NOT rolled back:
-/// dying between the move-aside loop and the rename-in loop leaves the
-/// directory with no live artifacts plus orphaned `.<name>.old-<pid>-<rand>`
-/// (and possibly `.<name>.tmp-<pid>-<rand>`) entries. That state is
-/// fail-closed — loaders see missing artifacts, never a mixed generation —
-/// but it needs regeneration to recover. The builder entry points call
-/// [`sweep_stale_artifact_droppings`] before regenerating so those orphans do
-/// not accumulate. For whole-directory consistency across all stages, the
-/// staging-directory swap in `circuit-builder`'s
-/// `generate_all_circuit_binaries` remains the only true whole-set atomic
-/// primitive.
-///
-/// Because staging opens with create-new semantics and publication renames
-/// over the final name, a symlink pre-planted at an artifact filename is
-/// replaced as an entry rather than followed, so a write can never be
-/// redirected onto the symlink's target. Artifact names (both published and
-/// `remove_stale`) must be basenames with no directory components, so path
-/// construction cannot escape `bins_dir`. Public so `circuit-builder` can
-/// publish the leaf artifact set through the same path.
+/// Kept as `commit_artifact_set` for call-site stability.
 #[cfg(feature = "std")]
 pub fn commit_artifact_set(
     bins_dir: &std::path::Path,
@@ -176,186 +69,27 @@ pub fn commit_artifact_set(
     remove_stale: &[&str],
 ) -> Result<()> {
     use std::fs;
-    use std::io::Write as _;
 
-    // Validate before any filesystem work so a hostile name cannot stage,
-    // move aside, or delete outside `bins_dir`.
-    for name in files
-        .iter()
-        .map(|(name, _)| *name)
-        .chain(remove_stale.iter().copied())
-    {
-        ensure_artifact_basename(name)?;
+    fs::create_dir_all(bins_dir)
+        .with_context(|| format!("Failed to create artifact dir {}", bins_dir.display()))?;
+    for (name, bytes) in files {
+        let path = bins_dir.join(name);
+        fs::write(&path, bytes)
+            .with_context(|| format!("Failed to write artifact {}", path.display()))?;
     }
-
-    let unique = format!("{}-{:016x}", std::process::id(), rand::random::<u64>());
-    let tmp_path = |name: &str| bins_dir.join(format!(".{name}.tmp-{unique}"));
-    let old_path = |name: &str| bins_dir.join(format!(".{name}.old-{unique}"));
-    let all_names = || {
-        files
-            .iter()
-            .map(|(name, _)| *name)
-            .chain(remove_stale.iter().copied())
-    };
-
-    // Phase 1: stage every file. Any failure here leaves the originals untouched.
-    for (i, (name, bytes)) in files.iter().enumerate() {
-        let path = tmp_path(name);
-        let staged = fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)
-            .and_then(|mut f| f.write_all(bytes));
-        if let Err(e) = staged {
-            for (name, _) in &files[..=i] {
-                let _ = fs::remove_file(tmp_path(name));
-            }
-            return Err(e).with_context(|| format!("Failed to stage {}", path.display()));
-        }
-    }
-
-    // Phase 2: move previous artifacts (and stale files) aside, then swap the
-    // staged set in.
-    let mut moved_aside: Vec<&str> = Vec::new();
-    let mut swapped: Vec<&str> = Vec::new();
-    let swap_result = (|| -> Result<()> {
-        for name in all_names() {
-            match fs::rename(bins_dir.join(name), old_path(name)) {
-                Ok(()) => moved_aside.push(name),
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                Err(e) => {
-                    return Err(e).with_context(|| {
-                        format!(
-                            "Failed to move previous {} aside",
-                            bins_dir.join(name).display()
-                        )
-                    })
-                }
+    for name in remove_stale {
+        let path = bins_dir.join(name);
+        match fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("Failed to remove stale artifact {}", path.display())
+                })
             }
         }
-        for (name, _) in files {
-            fs::rename(tmp_path(name), bins_dir.join(name)).with_context(|| {
-                format!(
-                    "Failed to move staged artifact into place at {}",
-                    bins_dir.join(name).display()
-                )
-            })?;
-            swapped.push(name);
-        }
-        Ok(())
-    })();
-
-    match swap_result {
-        Ok(()) => {
-            // The new set is committed; the moved-aside copies (and moved-aside
-            // stale files) are redundant.
-            for name in moved_aside {
-                let old = old_path(name);
-                if fs::remove_file(&old).is_err() {
-                    let _ = fs::remove_dir_all(&old);
-                }
-            }
-            Ok(())
-        }
-        Err(e) => {
-            // Restore the previous set: renaming the old copy back atomically
-            // overwrites any already-swapped new file; names that had no old
-            // copy get their new file removed instead.
-            for name in all_names() {
-                let final_path = bins_dir.join(name);
-                if moved_aside.contains(&name) {
-                    if fs::rename(old_path(name), &final_path).is_err() {
-                        // A blocking entry (e.g. an already-swapped file under
-                        // a directory-shaped old copy) must not strand the
-                        // rollback in a mixed state.
-                        let _ = fs::remove_file(&final_path);
-                        let _ = fs::rename(old_path(name), &final_path);
-                    }
-                } else if swapped.contains(&name) {
-                    let _ = fs::remove_file(&final_path);
-                }
-                let _ = fs::remove_file(tmp_path(name));
-            }
-            Err(e)
-        }
     }
-}
-
-/// Remove orphaned `commit_artifact_set` droppings from `bins_dir`.
-///
-/// A publish hard-killed mid-swap (SIGKILL, power loss) leaves behind
-/// `.<name>.tmp-<pid>-<rand>` staged files and/or `.<name>.old-<pid>-<rand>`
-/// moved-aside originals that no later run adopts (the random suffix is fresh
-/// per call). This sweep deletes exactly those patterns: a leading dot, a
-/// `.tmp-`/`.old-` marker, and the `<pid>-<16 hex>` suffix `commit_artifact_set`
-/// generates. Unrelated dotfiles are left alone.
-///
-/// Only called from the builder entry points, immediately before
-/// regeneration: on the read/prove paths a sweep could race a concurrent
-/// publisher and delete its in-flight staging files, but a builder is about
-/// to replace the whole set anyway. Returns the number of entries removed.
-#[cfg(feature = "std")]
-pub fn sweep_stale_artifact_droppings(bins_dir: &std::path::Path) -> Result<usize> {
-    use std::fs;
-
-    fn is_dropping(name: &str) -> bool {
-        if !name.starts_with('.') {
-            return false;
-        }
-        let Some(idx) = name.rfind(".tmp-").or_else(|| name.rfind(".old-")) else {
-            return false;
-        };
-        // Suffix shape from commit_artifact_set: "<pid>-<16 lowercase hex>".
-        let suffix = &name[idx + ".tmp-".len()..];
-        let Some((pid, rand)) = suffix.split_once('-') else {
-            return false;
-        };
-        !pid.is_empty()
-            && pid.bytes().all(|b| b.is_ascii_digit())
-            && rand.len() == 16
-            && rand.bytes().all(|b| b.is_ascii_hexdigit())
-    }
-
-    let entries = match fs::read_dir(bins_dir) {
-        Ok(entries) => entries,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
-        Err(e) => return Err(e).with_context(|| format!("Failed to list {}", bins_dir.display())),
-    };
-
-    let mut removed = 0usize;
-    for entry in entries {
-        let entry = entry?;
-        let name = entry.file_name();
-        let Some(name) = name.to_str() else { continue };
-        if !is_dropping(name) {
-            continue;
-        }
-        let path = entry.path();
-        // Moved-aside entries can be directory-shaped (a planted directory
-        // that a previous publish moved aside), so fall back accordingly.
-        let dir_fallback = match fs::remove_file(&path) {
-            Ok(()) => Ok(()),
-            Err(_) => fs::remove_dir_all(&path),
-        };
-        if !path.exists() {
-            removed += 1;
-        } else if let Err(e) = dir_fallback {
-            // Don't fail the rebuild over an unremovable dropping, but don't
-            // let the accumulation this sweep exists to prevent silently
-            // resume either.
-            eprintln!(
-                "warning: failed to remove orphaned artifact dropping {}: {e}",
-                path.display()
-            );
-        }
-    }
-    if removed > 0 {
-        println!(
-            "Removed {removed} orphaned staging/backup entries from {} (leftovers of an interrupted artifact publish)",
-            bins_dir.display()
-        );
-    }
-    Ok(removed)
+    Ok(())
 }
 
 /// Load verifier circuit data (common + verifier-only) from serialized bytes.
@@ -858,10 +592,7 @@ pub fn private_batch_num_leaves_from_padded_pi_len(pi_len: usize) -> Result<usiz
 #[cfg(test)]
 mod tests {
     use super::private_batch_num_leaves_from_padded_pi_len;
-    use super::{
-        commit_artifact_set, ensure_artifact_basename, read_artifact_file,
-        sweep_stale_artifact_droppings, MAX_ARTIFACT_FILE_BYTES,
-    };
+    use super::{commit_artifact_set, read_artifact_file, MAX_ARTIFACT_FILE_BYTES};
 
     #[test]
     fn private_batch_num_leaves_from_padded_pi_len_rejects_malformed_lengths() {
@@ -870,29 +601,19 @@ mod tests {
     }
 
     /// Pinning must compare raw artifact bytes to a canonical rebuild and never
-    /// feed untrusted common data into `CommonCircuitData::from_bytes`. That
-    /// deserializer reserves vector capacities from length fields in the
-    /// artifact; a small buffer of enormous little-endian usizes would
-    /// previously force large `try_reserve` calls (or allocator failure)
-    /// before the canonical check could reject it (audit finding).
+    /// feed untrusted common data into `CommonCircuitData::from_bytes`.
     #[test]
     fn load_canonical_private_batch_rejects_poisoned_common_by_byte_pin() {
-        use super::{
-            canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
-        };
+        use super::{canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data};
 
         let mut poisoned = vec![0u8; 4096];
         for i in (0..poisoned.len()).step_by(8) {
             poisoned[i..i + 8].copy_from_slice(&(usize::MAX / 16).to_le_bytes());
         }
         let leaf = canonical_leaf_verifier_data();
-        let err = load_canonical_private_batch_verifier_data(
-            &poisoned,
-            &poisoned[..128],
-            &leaf,
-            1,
-        )
-        .unwrap_err();
+        let err =
+            load_canonical_private_batch_verifier_data(&poisoned, &poisoned[..128], &leaf, 1)
+                .unwrap_err();
         assert!(
             err.to_string().contains("does not match the canonical"),
             "poisoned common must fail the byte pin, got: {err}"
@@ -900,175 +621,26 @@ mod tests {
     }
 
     #[test]
-    fn ensure_artifact_basename_accepts_plain_filenames() {
-        for name in ["common.bin", "config.json", "dummy_private_batch_proof.bin", "a"] {
-            ensure_artifact_basename(name).unwrap_or_else(|e| {
-                panic!("expected {name:?} to be accepted, got: {e}");
-            });
-        }
-    }
-
-    /// Audit finding: unvalidated artifact names let `bins_dir.join(name)`
-    /// (and the `.{name}.tmp-…` staging form) escape the artifact directory.
-    /// Only a single normal path component is allowed.
-    #[test]
-    fn ensure_artifact_basename_rejects_directory_components() {
-        for name in [
-            "",
-            ".",
-            "..",
-            "../common.bin",
-            "foo/bar",
-            "foo/../bar",
-            "/etc/passwd",
-            "./common.bin",
-            "common.bin/",
-            "a\0b",
-        ] {
-            let err = ensure_artifact_basename(name).expect_err(&format!(
-                "expected {name:?} to be rejected"
-            ));
-            let msg = err.to_string();
-            assert!(
-                msg.contains("basename")
-                    || msg.contains("directory components")
-                    || msg.contains("NUL"),
-                "unexpected error for {name:?}: {msg}"
-            );
-        }
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn ensure_artifact_basename_rejects_windows_separators() {
-        let err = ensure_artifact_basename("foo\\bar").unwrap_err();
-        assert!(
-            err.to_string().contains("directory components"),
-            "got: {err}"
-        );
-    }
-
-    /// A hostile name in either `files` or `remove_stale` must fail before any
-    /// path under / beside `bins_dir` is touched.
-    #[test]
-    fn commit_artifact_set_rejects_non_basename_names_before_touching_disk() {
+    fn commit_artifact_set_writes_and_removes_stale() {
         let dir = std::env::temp_dir().join(format!(
-            "qp-artifact-basename-test-{}",
+            "qp-artifact-write-test-{}",
             std::process::id()
         ));
         let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
 
-        // Outside-target marker: must remain untouched if validation works.
-        let outside = std::env::temp_dir().join(format!(
-            "qp-artifact-basename-victim-{}",
-            std::process::id()
-        ));
-        std::fs::write(&outside, b"untouched").unwrap();
-
-        let err = commit_artifact_set(
+        commit_artifact_set(
             &dir,
-            &[("../qp-artifact-basename-victim-should-not-exist", b"x".to_vec())],
+            &[("a.bin", b"one".to_vec()), ("b.bin", b"two".to_vec())],
             &[],
         )
-        .unwrap_err();
-        assert!(
-            err.to_string().contains("directory components")
-                || err.to_string().contains("basename"),
-            "got: {err}"
-        );
+        .unwrap();
+        assert_eq!(std::fs::read(dir.join("a.bin")).unwrap(), b"one");
+        assert_eq!(std::fs::read(dir.join("b.bin")).unwrap(), b"two");
 
-        let err = commit_artifact_set(&dir, &[("ok.bin", b"x".to_vec())], &["../outside"])
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("directory components")
-                || err.to_string().contains("basename"),
-            "got: {err}"
-        );
+        commit_artifact_set(&dir, &[("a.bin", b"new".to_vec())], &["b.bin"]).unwrap();
+        assert_eq!(std::fs::read(dir.join("a.bin")).unwrap(), b"new");
+        assert!(!dir.join("b.bin").exists());
 
-        assert_eq!(std::fs::read(&outside).unwrap(), b"untouched");
-        // Nothing staged or published inside bins_dir either.
-        assert!(std::fs::read_dir(&dir).unwrap().next().is_none());
-
-        let _ = std::fs::remove_file(&outside);
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    /// The sweep must remove exactly the `.<name>.tmp-<pid>-<rand>` /
-    /// `.<name>.old-<pid>-<rand>` patterns `commit_artifact_set` generates —
-    /// including directory-shaped moved-aside entries — and leave everything
-    /// else (live artifacts, unrelated dotfiles, near-miss names) alone.
-    #[test]
-    fn sweep_removes_publish_droppings_and_nothing_else() {
-        let dir = std::env::temp_dir().join(format!("qp-sweep-test-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        // Droppings: staged file, moved-aside file, directory-shaped
-        // moved-aside entry (a planted directory a publish moved aside).
-        std::fs::write(dir.join(".common.bin.tmp-42-00112233445566ff"), b"x").unwrap();
-        std::fs::write(dir.join(".verifier.bin.old-42-00112233445566ff"), b"x").unwrap();
-        std::fs::create_dir(dir.join(".config.json.old-42-aabbccddeeff0011")).unwrap();
-
-        // Survivors: live artifact, unrelated dotfiles, near-miss suffixes.
-        std::fs::write(dir.join("common.bin"), b"live").unwrap();
-        std::fs::write(dir.join(".gitignore"), b"*.log").unwrap();
-        std::fs::write(dir.join(".config.json.old-backup"), b"manual backup").unwrap();
-        std::fs::write(dir.join(".x.tmp-notapid-00112233445566ff"), b"x").unwrap();
-        std::fs::write(dir.join(".x.tmp-42-shorthex"), b"x").unwrap();
-        std::fs::write(dir.join("common.bin.tmp-42-00112233445566ff"), b"no dot").unwrap();
-
-        let removed = sweep_stale_artifact_droppings(&dir).unwrap();
-        assert_eq!(removed, 3, "exactly the three droppings must be removed");
-
-        let mut names: Vec<String> = std::fs::read_dir(&dir)
-            .unwrap()
-            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
-            .collect();
-        names.sort();
-        assert_eq!(
-            names,
-            vec![
-                ".config.json.old-backup".to_string(),
-                ".gitignore".to_string(),
-                ".x.tmp-42-shorthex".to_string(),
-                ".x.tmp-notapid-00112233445566ff".to_string(),
-                "common.bin".to_string(),
-                "common.bin.tmp-42-00112233445566ff".to_string(),
-            ]
-        );
-
-        // A missing directory is a no-op, not an error (fresh builder runs).
-        std::fs::remove_dir_all(&dir).unwrap();
-        assert_eq!(sweep_stale_artifact_droppings(&dir).unwrap(), 0);
-    }
-
-    /// An unremovable dropping must not fail the sweep, and must not be
-    /// counted as removed (it is reported on stderr, not silently skipped —
-    /// the warning itself is not capturable in-process, so this asserts the
-    /// count and survival).
-    #[test]
-    #[cfg(unix)]
-    fn sweep_survives_unremovable_dropping_without_counting_it() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = std::env::temp_dir().join(format!("qp-sweep-stuck-test-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        // A directory-shaped dropping whose contents cannot be unlinked:
-        // remove_file fails (it is a directory) and remove_dir_all fails
-        // (no write permission on the directory itself).
-        let stuck = dir.join(".common.bin.old-42-00112233445566ff");
-        std::fs::create_dir(&stuck).unwrap();
-        std::fs::write(stuck.join("inner"), b"x").unwrap();
-        std::fs::set_permissions(&stuck, std::fs::Permissions::from_mode(0o555)).unwrap();
-
-        let removed = sweep_stale_artifact_droppings(&dir).unwrap();
-        assert_eq!(removed, 0, "a still-present entry must not be counted");
-        assert!(stuck.exists());
-
-        std::fs::set_permissions(&stuck, std::fs::Permissions::from_mode(0o755)).unwrap();
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
@@ -1083,8 +655,6 @@ mod tests {
         std::fs::write(&normal, b"artifact bytes").unwrap();
         assert_eq!(read_artifact_file(&normal).unwrap(), b"artifact bytes");
 
-        // A sparse file costs no disk but still claims an oversized length,
-        // exactly like an attacker-planted artifact would.
         let oversized = dir.join("oversized.bin");
         std::fs::File::create(&oversized)
             .unwrap()
@@ -1092,49 +662,6 @@ mod tests {
             .unwrap();
         let err = read_artifact_file(&oversized).unwrap_err();
         assert!(err.to_string().contains("exceeds the"), "got: {err}");
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    /// A FIFO planted at an expected `*.bin` path must produce a prompt
-    /// invalid-artifact error, not a hang: a blocking `File::open` on a FIFO
-    /// with no writer stalls forever, before the size check can run,
-    /// converting artifact loading into a startup denial of service when the
-    /// artifact directory is untrusted (audit finding: non-regular files
-    /// bypass the bounded-read protections).
-    #[cfg(unix)]
-    #[test]
-    fn read_artifact_file_rejects_fifo_without_blocking() {
-        use std::os::unix::ffi::OsStrExt as _;
-
-        let dir =
-            std::env::temp_dir().join(format!("qp-artifact-fifo-test-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
-
-        let fifo = dir.join("leaf_common.bin");
-        let c_path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
-        assert_eq!(
-            unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) },
-            0,
-            "mkfifo failed"
-        );
-
-        // Run the read on a helper thread so a regression (blocking open or
-        // read) surfaces as a test failure instead of hanging the suite.
-        let (tx, rx) = std::sync::mpsc::channel();
-        let fifo_for_thread = fifo.clone();
-        std::thread::spawn(move || {
-            let _ = tx.send(read_artifact_file(&fifo_for_thread).map(drop));
-        });
-
-        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
-            Ok(result) => {
-                let err = result.unwrap_err();
-                assert!(err.to_string().contains("not a regular file"), "got: {err}");
-            }
-            Err(_) => panic!("read_artifact_file blocked on a FIFO artifact path"),
-        }
 
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/wormhole/aggregator/src/config.rs
+++ b/wormhole/aggregator/src/config.rs
@@ -55,10 +55,9 @@ impl CircuitBinsConfig {
 
     /// Load config from a directory containing circuit binaries.
     ///
-    /// Reads through [`crate::common::utils::read_artifact_file`], which
-    /// rejects non-regular files and oversized inputs, so an untrusted bins
-    /// directory cannot stall or memory-starve config loading (this runs
-    /// before any of the `*.bin` artifacts are touched).
+    /// Reads through [`crate::common::utils::read_artifact_file`] (size-capped).
+    /// Artifact directories are assumed to come from attested CI builds; see
+    /// `wormhole/THREAT_MODEL.md`.
     ///
     /// # Errors
     /// Returns an error if the file cannot be read, parsed, or contains invalid values.
@@ -73,12 +72,7 @@ impl CircuitBinsConfig {
         Ok(config)
     }
 
-    /// Save config to a directory.
-    ///
-    /// Published through [`crate::common::utils::commit_artifact_set`]
-    /// (exclusive-create staging plus rename into place), so a symlink
-    /// pre-planted at `config.json` is replaced rather than followed and a
-    /// failed write never leaves a truncated config behind.
+    /// Save config to a directory (overwrites `config.json` in place).
     pub fn save<P: AsRef<Path>>(&self, bins_dir: P) -> Result<()> {
         let bins_dir = bins_dir.as_ref();
         let config_str = serde_json::to_string_pretty(self)

--- a/wormhole/aggregator/src/dummy_proof.rs
+++ b/wormhole/aggregator/src/dummy_proof.rs
@@ -153,7 +153,7 @@ pub fn build_dummy_circuit_inputs() -> Result<CircuitInputs> {
             block_number: DEFAULT_BLOCK_NUMBER,
         },
         private: PrivateCircuitInputs {
-            secret,
+            secret: secret.into(),
             transfer_count: DEFAULT_TRANSFER_COUNT,
             unspendable_account,
             parent_hash: BytesDigest::try_from(DEFAULT_PARENT_HASH)?,

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -314,16 +314,17 @@ impl ProofPool {
 
     /// Validate and admit a proof, returning the bucket key it landed in.
     ///
-    /// Checks run cheapest-first EXCEPT the duplicate-nullifier check:
-    /// capacity limits, public-input shape, dummy sentinel, bucket cap, the
-    /// verification budget ([`PoolLimits::max_verifies_per_window`]),
-    /// cryptographic verification, and only THEN duplicate-nullifier
-    /// rejection. The dedup check is deliberately gated behind verification so
-    /// its rejection cannot be used as a free, unlimited membership/status
-    /// oracle over the pool's not-yet-settled spends (see the check site). A
-    /// proof admitted here is individually valid and, by bucketing,
-    /// batch-compatible with every other proof in its bucket, so aggregation
-    /// over a bucket cannot fail deterministically on admitted inputs (#97067).
+    /// Checks run cheapest-first EXCEPT the pool-state membership tests:
+    /// capacity limits, public-input shape, dummy sentinel, the verification
+    /// budget ([`PoolLimits::max_verifies_per_window`]), cryptographic
+    /// verification, and only THEN the bucket-cap and duplicate-nullifier
+    /// checks. Both are deliberately gated behind verification so their
+    /// rejections cannot be used as a free, unlimited membership/status
+    /// oracle over the pool's not-yet-settled buckets or spends (see each
+    /// check site). A proof admitted here is individually valid and, by
+    /// bucketing, batch-compatible with every other proof in its bucket, so
+    /// aggregation over a bucket cannot fail deterministically on admitted
+    /// inputs (#97067).
     ///
     /// Buckets are NOT capped at one batch: a hot key keeps admitting (up to
     /// the global limits) while earlier batches for it are being proved;
@@ -353,15 +354,6 @@ impl ProofPool {
             );
         }
 
-        if !self.buckets.contains_key(&key) && self.buckets.len() >= self.limits.max_buckets {
-            bail!(
-                "proof pool bucket limit reached ({} buckets); \
-                 proof for block {:?} rejected",
-                self.limits.max_buckets,
-                key.block_hash
-            );
-        }
-
         // Verification budget: size caps only count ADMITTED proofs, and
         // invalid submissions never consume a slot, so without this an
         // attacker streaming well-formed-but-invalid proofs would buy a full
@@ -388,6 +380,29 @@ impl ProofPool {
                 e
             )
         })?;
+
+        // Bucket cap. Checked AFTER cryptographic verification and the verify
+        // budget for the same reason as the duplicate-nullifier check below:
+        // `buckets.contains_key(&key)` is a membership test over pool state
+        // keyed by ATTACKER-CONTROLLED public inputs of the submitted proof.
+        // Placed before verification (as a "cheapest-first" guard), a full
+        // pool answered it for free — at max_buckets, a well-formed-but-
+        // invalid probe carrying a candidate key was rejected instantly with
+        // this distinct error when the key was novel, but fell through to
+        // verification when the key was pooled, letting anyone enumerate
+        // which (block, asset, fee) tuples the miner is aggregating without
+        // holding a single valid proof (audit finding). Gated behind verify,
+        // the probe requires a cryptographically valid private-batch proof
+        // for the candidate key, and its cost is charged to the verify
+        // budget like any other admission attempt. The cap itself is
+        // operational (bounds bucket-map growth), not a CPU guard, so
+        // nothing is lost by paying verification first.
+        if !self.buckets.contains_key(&key) && self.buckets.len() >= self.limits.max_buckets {
+            bail!(
+                "proof pool bucket limit reached ({} buckets); proof rejected",
+                self.limits.max_buckets
+            );
+        }
 
         // A duplicate nullifier anywhere in the pool means the same leaf
         // spend is already staged; only one copy can ever settle. This is
@@ -1097,7 +1112,68 @@ mod tests {
         let err = pool
             .push(prove_fake(&data, &targets, &fake(2, 12)))
             .unwrap_err();
-        assert!(err.to_string().contains("bucket limit"), "got: {err}");
+        let msg = err.to_string();
+        assert!(msg.contains("bucket limit"), "got: {msg}");
+        // Must not echo the rejected (or any pooled) block hash: the
+        // submitter already knows their own key, and naming it (or a
+        // staged one) would make the distinct "bucket limit" error a
+        // confirmation channel for which keys are pooled.
+        assert!(
+            !msg.contains(&format!("{:?}", nullifier_digest(1)))
+                && !msg.contains(&format!("{:?}", nullifier_digest(2))),
+            "bucket-cap rejection must not echo block hashes: {msg}"
+        );
+    }
+
+    /// The bucket-cap membership test (`buckets.contains_key`) must run AFTER
+    /// cryptographic verification and the verify budget. Otherwise, once the
+    /// pool is at `max_buckets`, a well-formed-but-invalid probe carrying a
+    /// candidate key is rejected instantly with "bucket limit" when the key
+    /// is novel, but falls through to ~10-20ms verification when the key is
+    /// already pooled — a free membership oracle over which
+    /// (block, asset, fee) tuples the miner is aggregating (audit finding).
+    #[test]
+    fn bucket_cap_check_runs_after_verification() {
+        let (mut pool, data, targets) = make_pool(
+            1,
+            PoolLimits {
+                max_proofs: 16,
+                max_buckets: 1,
+                ..PoolLimits::default()
+            },
+        );
+
+        pool.push(prove_fake(&data, &targets, &fake(1, 11)))
+            .unwrap();
+
+        // Novel key (block 2), tampered so verification fails. Pre-fix this
+        // short-circuited on the bucket cap and returned "bucket limit"
+        // without verifying — confirming the key was not pooled. Post-fix
+        // it must fail verification first.
+        let mut novel_invalid = prove_fake(&data, &targets, &fake(2, 12));
+        novel_invalid.public_inputs[aggregated_output::ASSET_ID_OFFSET] =
+            F::from_canonical_u64(9);
+        let err = pool.push(novel_invalid).unwrap_err();
+        assert!(
+            err.to_string().contains("verification failed"),
+            "bucket-cap check must not short-circuit ahead of verification for a \
+             novel key, got: {err}"
+        );
+
+        // Existing key (block 1), also tampered. Same path: verify first,
+        // never a bucket-cap answer that would confirm membership.
+        let mut existing_invalid = prove_fake(&data, &targets, &fake(1, 13));
+        existing_invalid.public_inputs[aggregated_output::ASSET_ID_OFFSET] =
+            F::from_canonical_u64(9);
+        let err = pool.push(existing_invalid).unwrap_err();
+        assert!(
+            err.to_string().contains("verification failed"),
+            "got: {err}"
+        );
+        assert!(
+            !err.to_string().contains("bucket limit"),
+            "invalid proofs must not observe the bucket-cap branch: {err}"
+        );
     }
 
     /// Verification CPU must be bounded even though invalid proofs never

--- a/wormhole/aggregator/src/pool.rs
+++ b/wormhole/aggregator/src/pool.rs
@@ -1151,8 +1151,7 @@ mod tests {
         // without verifying — confirming the key was not pooled. Post-fix
         // it must fail verification first.
         let mut novel_invalid = prove_fake(&data, &targets, &fake(2, 12));
-        novel_invalid.public_inputs[aggregated_output::ASSET_ID_OFFSET] =
-            F::from_canonical_u64(9);
+        novel_invalid.public_inputs[aggregated_output::ASSET_ID_OFFSET] = F::from_canonical_u64(9);
         let err = pool.push(novel_invalid).unwrap_err();
         assert!(
             err.to_string().contains("verification failed"),

--- a/wormhole/aggregator/src/private_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/build.rs
@@ -11,7 +11,7 @@
 //! Expects `common.bin` and `verifier.bin` to already exist in the output directory.
 
 use anyhow::{anyhow, Context, Result};
-use plonky2::{plonk::circuit_data::CommonCircuitData, util::serialization::DefaultGateSerializer};
+use plonky2::util::serialization::DefaultGateSerializer;
 use qp_wormhole_inputs::validate_proof_count;
 use std::{fs::create_dir_all, path::Path};
 use zk_circuits_common::circuit::{wormhole_private_batch_circuit_config, C, D, F};
@@ -64,6 +64,19 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
         .with_context(|| format!("Failed to read {}/verifier.bin", output_path.display()))?;
     let leaf = load_canonical_leaf_verifier_data(&leaf_common_bytes, &leaf_verifier_bytes)?;
 
+    // Load AND validate the leaf dummy template before the expensive
+    // aggregation-circuit build. Every other consumer of dummy_proof.bin
+    // (the private/public batch prover constructors) enforces the dummy
+    // sentinel via verify_dummy_leaf_template; the build path must too,
+    // or a valid-but-non-dummy leaf planted at dummy_proof.bin gets baked
+    // into the published dummy_private_batch_proof.bin as a "dummy"
+    // template that actually settles a real payout (audit finding).
+    let dummy_leaf = if include_prover {
+        Some(load_validated_dummy_leaf_template(output_path, &leaf)?)
+    } else {
+        None
+    };
+
     let agg_circuit = PrivateBatchCircuit::new(
         wormhole_private_batch_circuit_config(),
         &leaf.common,
@@ -80,16 +93,14 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     // partial public batches. Must happen BEFORE consuming circuit_data below
     // (prove() borrows, prover_data() moves). Only possible/needed when proving
     // artifacts are requested (requires the leaf dummy proof from the same run).
-    let dummy_batch_proof_bytes = if include_prover {
-        Some(generate_dummy_private_batch_proof(
+    let dummy_batch_proof_bytes = match dummy_leaf {
+        Some(dummy_leaf) => Some(generate_dummy_private_batch_proof(
             &circuit_data,
             &agg_targets,
-            &leaf.common,
-            output_path,
+            dummy_leaf,
             num_leaf_proofs,
-        )?)
-    } else {
-        None
+        )?),
+        None => None,
     };
 
     let verifier_data = circuit_data.verifier_data();
@@ -128,28 +139,50 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     Ok(())
 }
 
+/// Load `dummy_proof.bin` and verify it is a genuine all-dummy leaf template
+/// (dummy sentinel: zero block hash, zero outputs, zero asset_id, zero exit
+/// accounts, AND a passing cryptographic verify against the pinned leaf
+/// verifier) before it gets replayed into every slot of the published
+/// `dummy_private_batch_proof.bin`. This mirrors the check the prover
+/// constructors apply to the very same artifact; without it, a re-run over a
+/// pre-existing or attacker-populated bins dir would label a REAL proof as
+/// the all-dummy padding template and report success (#97026 family).
+fn load_validated_dummy_leaf_template(
+    bins_dir: &Path,
+    leaf: &plonky2::plonk::circuit_data::VerifierCircuitData<F, C, D>,
+) -> Result<plonky2::plonk::proof::ProofWithPublicInputs<F, C, D>> {
+    let dummy_leaf_bytes = read_artifact_file(&bins_dir.join("dummy_proof.bin"))
+        .with_context(|| format!("Failed to read {}/dummy_proof.bin", bins_dir.display()))?;
+    let dummy_leaf = crate::dummy_proof::load_dummy_proof(dummy_leaf_bytes, &leaf.common)
+        .map_err(|e| anyhow!("Failed to deserialize dummy leaf proof: {}", e))?;
+    crate::private_batch::prover::verify_dummy_leaf_template(&dummy_leaf, leaf).with_context(
+        || {
+            format!(
+                "{}/dummy_proof.bin is not a genuine all-dummy leaf template; refusing to bake \
+                 it into dummy_private_batch_proof.bin",
+                bins_dir.display()
+            )
+        },
+    )?;
+    Ok(dummy_leaf)
+}
+
 /// Prove a private batch consisting entirely of dummy leaf proofs.
 ///
 /// The resulting proof has `block_hash == 0` (the public-batch dummy sentinel),
 /// zeroed exit slots, and dummy-replaced nullifiers, and is used by the
-/// public-batch prover to pad partial batches. Requires `dummy_proof.bin`
-/// (the leaf dummy proof) from the same generation run.
+/// public-batch prover to pad partial batches. `dummy_leaf` must come from
+/// [`load_validated_dummy_leaf_template`].
 fn generate_dummy_private_batch_proof(
     circuit_data: &plonky2::plonk::circuit_data::CircuitData<F, C, D>,
     targets: &crate::private_batch::circuit::circuit_logic::PrivateBatchCircuitTargets,
-    leaf_common: &CommonCircuitData<F, D>,
-    bins_dir: &Path,
+    dummy_leaf: plonky2::plonk::proof::ProofWithPublicInputs<F, C, D>,
     num_leaf_proofs: usize,
 ) -> Result<Vec<u8>> {
     use plonky2::iop::witness::PartialWitness;
     use zk_circuits_common::utils::bytes_to_digest;
 
     println!("Generating dummy private-batch proof for public-batch padding...");
-
-    let dummy_leaf_bytes = read_artifact_file(&bins_dir.join("dummy_proof.bin"))
-        .with_context(|| format!("Failed to read {}/dummy_proof.bin", bins_dir.display()))?;
-    let dummy_leaf = crate::dummy_proof::load_dummy_proof(dummy_leaf_bytes, leaf_common)
-        .map_err(|e| anyhow!("Failed to deserialize dummy leaf proof: {}", e))?;
 
     let proofs = vec![dummy_leaf; num_leaf_proofs];
     let dummy_nullifier_pre_images: Vec<[F; 4]> = (0..num_leaf_proofs)
@@ -347,6 +380,55 @@ mod tests {
         assert!(
             innocent.exists(),
             "the sweep must not touch unrelated dotfiles"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A valid-but-non-dummy leaf proof planted at `dummy_proof.bin` must not
+    /// be baked into the published `dummy_private_batch_proof.bin`. The
+    /// recursive circuit only forces the leaf to be cryptographically valid;
+    /// a REAL leaf (nonzero block_hash) replayed into every slot passes all
+    /// cross-slot consistency checks, so without the sentinel check the build
+    /// would emit a real private-batch proof labelled as the all-dummy
+    /// padding template and report success (audit finding).
+    #[test]
+    fn build_rejects_non_dummy_leaf_planted_at_dummy_proof_bin() {
+        use test_helpers::TestInputs as _;
+        use wormhole_circuit::block_header::header::HeaderInputs;
+        use wormhole_circuit::inputs::CircuitInputs;
+
+        let dir = temp_dir("poisoned-dummy");
+        write_canonical_leaf_artifacts(&dir);
+
+        // A REAL leaf proof against the canonical leaf circuit: genuine block
+        // hash, so it deserializes and verifies fine but violates the dummy
+        // sentinel (non-zero block_hash).
+        let mut inputs = CircuitInputs::test_inputs_0();
+        inputs.public.block_hash = HeaderInputs::try_from(&inputs)
+            .expect("header inputs")
+            .block_hash();
+        let real_leaf = wormhole_prover::build_fresh()
+            .commit(&inputs)
+            .unwrap()
+            .prove()
+            .unwrap();
+        std::fs::write(dir.join("dummy_proof.bin"), real_leaf.to_bytes()).unwrap();
+
+        let err = generate_private_batch_circuit_binaries(&dir, 1, true).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("not a genuine all-dummy leaf template"),
+            "poisoned dummy_proof.bin must be rejected with attribution, got: {msg}"
+        );
+        assert!(
+            msg.contains("non-zero block_hash"),
+            "the sentinel violation must be named, got: {msg}"
+        );
+        assert!(
+            !dir.join("dummy_private_batch_proof.bin").exists()
+                && !dir.join("private_batch_common.bin").exists(),
+            "a rejected template must not publish any private-batch artifacts"
         );
 
         std::fs::remove_dir_all(&dir).unwrap();

--- a/wormhole/aggregator/src/private_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/build.rs
@@ -18,24 +18,17 @@ use zk_circuits_common::circuit::{wormhole_private_batch_circuit_config, C, D, F
 
 use crate::common::utils::{
     commit_artifact_set, load_canonical_leaf_verifier_data, read_artifact_file,
-    sweep_stale_artifact_droppings,
 };
 use crate::private_batch::circuit::circuit_logic::PrivateBatchCircuit;
 
 /// Generate prebuilt Private-batch aggregation circuit binaries.
 ///
-/// The private-batch files are published all-or-nothing (see
-/// `commit_artifact_set` in `common::utils`), so a failed re-run over an
-/// existing bins dir never leaves a fresh `private_batch_common.bin` beside a
-/// stale `private_batch_verifier.bin` or `dummy_private_batch_proof.bin`.
-/// When `include_prover` is `false`, any pre-existing
-/// `dummy_private_batch_proof.bin` is removed as part of the same publish: a
-/// stale template would fail verification against the fresh verifier data and
-/// take the whole bins directory offline for public-batch proving.
-/// Whole-directory consistency across all stages (leaf, private-batch,
-/// public-batch, `config.json`) is still only guaranteed by the staging
-/// `generate_all_circuit_binaries` flow in `circuit-builder`; prefer it unless
-/// deliberately regenerating this one stage into an existing set.
+/// Writes private-batch verifier artifacts (and optionally the dummy
+/// private-batch padding template). Prefer
+/// `generate_all_circuit_binaries` for production regenerates so a failed
+/// stage never mixes generations in the live output directory
+/// (`wormhole/THREAT_MODEL.md`). When `include_prover` is `false`, any
+/// pre-existing `dummy_private_batch_proof.bin` is removed.
 pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     output_dir: P,
     num_leaf_proofs: usize,
@@ -45,9 +38,6 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
     // Bound the per-layer count before any circuit construction (#97021, #97070).
     validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
     create_dir_all(output_path)?;
-    // A previous publish hard-killed mid-swap leaves orphaned temp/backup
-    // entries behind; we are about to replace the set, so sweep them now.
-    sweep_stale_artifact_droppings(output_path)?;
 
     println!(
         "Building prebuilt private-batch aggregation circuit (num_leaf_proofs={}, ZK row blinding)...",
@@ -114,9 +104,8 @@ pub fn generate_private_batch_circuit_binaries<P: AsRef<Path>>(
         .to_bytes()
         .map_err(|e| anyhow!("Failed to serialize aggregated verifier data: {}", e))?;
 
-    // Publish the whole set all-or-nothing. Without prover output, a stale
-    // dummy template from an earlier run is removed as part of the same swap:
-    // it would fail template verification against the fresh verifier data.
+    // Without prover output, drop a stale dummy template from an earlier run
+    // (it would fail template verification against the fresh verifier data).
     let mut files: Vec<(&str, Vec<u8>)> = Vec::new();
     let mut remove_stale: Vec<&str> = Vec::new();
     match dummy_batch_proof_bytes {
@@ -236,153 +225,6 @@ mod tests {
             leaf.verifier_only.to_bytes().unwrap(),
         )
         .unwrap();
-    }
-
-    /// The private-batch files are consumed as a matched set (public-batch
-    /// constructors pin them against a canonical rebuild and verify the dummy
-    /// template against them), so a directory holding a fresh file from one
-    /// generation beside a stale file from another is rejected until
-    /// regenerated. A publish that fails partway must therefore either leave
-    /// the previous set fully intact or replace it wholesale — never mix
-    /// (audit finding: non-atomic artifact-set publication).
-    #[test]
-    fn failed_artifact_publish_never_leaves_mixed_private_batch_set() {
-        let dir = temp_dir("mixed-set");
-        write_canonical_leaf_artifacts(&dir);
-        std::fs::write(dir.join("private_batch_common.bin"), b"old common").unwrap();
-        // A directory squatting on the verifier path makes a naive in-place
-        // write of the second file fail after the first was already clobbered.
-        create_dir_all(dir.join("private_batch_verifier.bin")).unwrap();
-
-        let result = generate_private_batch_circuit_binaries(&dir, 1, false);
-
-        let common_now = std::fs::read(dir.join("private_batch_common.bin")).unwrap();
-        match result {
-            Err(_) => assert_eq!(
-                common_now, b"old common",
-                "a failed publish must leave the previous artifact set untouched, \
-                 not a fresh common beside a stale verifier"
-            ),
-            Ok(()) => {
-                assert_ne!(
-                    common_now, b"old common",
-                    "a successful publish must replace the set wholesale"
-                );
-                assert!(
-                    dir.join("private_batch_verifier.bin").is_file(),
-                    "a successful publish must leave a real verifier artifact"
-                );
-            }
-        }
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    /// A symlink pre-planted at an artifact filename must not redirect the
-    /// write onto its target (audit finding: symlink-following artifact
-    /// writes). `commit_artifact_set` stages under exclusive-create temp names
-    /// and renames into place, which replaces the planted entry itself; this
-    /// guards against regressing to direct `std::fs::write` calls.
-    #[cfg(unix)]
-    #[test]
-    fn artifact_writes_do_not_follow_planted_symlinks() {
-        let dir = temp_dir("symlink-clobber");
-        write_canonical_leaf_artifacts(&dir);
-
-        let victim = dir.join("victim.txt");
-        std::fs::write(&victim, b"precious data").unwrap();
-        std::os::unix::fs::symlink(&victim, dir.join("private_batch_verifier.bin")).unwrap();
-
-        let result = generate_private_batch_circuit_binaries(&dir, 1, false);
-
-        assert_eq!(
-            std::fs::read(&victim).unwrap(),
-            b"precious data",
-            "artifact publication must never write through a planted symlink"
-        );
-        if result.is_ok() {
-            let verifier = std::fs::read(dir.join("private_batch_verifier.bin")).unwrap();
-            assert_ne!(
-                verifier, b"precious data",
-                "a successful run must have replaced the planted entry with a real artifact"
-            );
-        }
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    /// A verifier-only rerun (`include_prover == false`) over a directory that
-    /// previously held prover output must not leave the old
-    /// `dummy_private_batch_proof.bin` beside freshly regenerated
-    /// common/verifier data: the public-batch prover verifies the template
-    /// against the pinned private-batch verifier at startup, so a stale
-    /// template takes the whole bins directory offline (audit finding:
-    /// non-atomic artifact-set publication).
-    #[test]
-    fn verifier_only_rerun_removes_stale_dummy_template() {
-        let dir = temp_dir("stale-dummy");
-        write_canonical_leaf_artifacts(&dir);
-        std::fs::write(dir.join("dummy_private_batch_proof.bin"), b"stale template").unwrap();
-
-        generate_private_batch_circuit_binaries(&dir, 1, false).unwrap();
-
-        assert!(
-            !dir.join("dummy_private_batch_proof.bin").exists(),
-            "a verifier-only rerun must remove the stale dummy template"
-        );
-        // No staging or moved-aside droppings either.
-        let mut names: Vec<String> = std::fs::read_dir(&dir)
-            .unwrap()
-            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
-            .collect();
-        names.sort();
-        assert_eq!(
-            names,
-            vec![
-                "common.bin".to_string(),
-                "private_batch_common.bin".to_string(),
-                "private_batch_verifier.bin".to_string(),
-                "verifier.bin".to_string(),
-            ],
-            "publish must not leave temp/old files behind"
-        );
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    /// A publish hard-killed mid-swap (SIGKILL/power loss) leaves orphaned
-    /// `.<name>.tmp-*` / `.<name>.old-*` droppings that no later run adopts
-    /// (the random suffix is fresh per call). The builder path must sweep
-    /// them before regenerating so they do not accumulate forever (audit
-    /// finding: crash-path droppings never cleaned up). Unrelated dotfiles
-    /// must survive the sweep.
-    #[test]
-    fn rebuild_sweeps_droppings_of_interrupted_publish() {
-        let dir = temp_dir("crash-droppings");
-        write_canonical_leaf_artifacts(&dir);
-
-        // Simulate the post-SIGKILL state: originals moved aside, staged
-        // files still present, nothing live.
-        let dropping_old = dir.join(".private_batch_common.bin.old-12345-0123456789abcdef");
-        let dropping_tmp = dir.join(".private_batch_verifier.bin.tmp-12345-0123456789abcdef");
-        std::fs::write(&dropping_old, b"moved-aside original").unwrap();
-        std::fs::write(&dropping_tmp, b"orphaned staged file").unwrap();
-        // An unrelated dotfile must not be swept.
-        let innocent = dir.join(".gitignore");
-        std::fs::write(&innocent, b"*.log").unwrap();
-
-        generate_private_batch_circuit_binaries(&dir, 1, false).unwrap();
-
-        assert!(
-            !dropping_old.exists() && !dropping_tmp.exists(),
-            "regeneration must sweep droppings of an interrupted publish"
-        );
-        assert!(
-            innocent.exists(),
-            "the sweep must not touch unrelated dotfiles"
-        );
-
-        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     /// A valid-but-non-dummy leaf proof planted at `dummy_proof.bin` must not

--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -20,13 +20,18 @@
 //! sorted order rather than leaf-slot order, so its positions carry no
 //! correlation with the (positionally bound) exit slots — otherwise a nonzero
 //! exit slot would identify its proof's nullifier as real and pair the public
-//! payout with it. It deliberately does NOT check
-//! nullifiers for uniqueness — not against chain state, and not even across
-//! slots in the same batch. Two leaves spending the same deposit aggregate into
-//! a cryptographically valid batch; the wormhole pallet's persistent settled-
-//! nullifier set is the sole double-spend boundary and settles each nullifier
-//! at most once. See "Nullifiers and Double-Spend Prevention" in
-//! `wormhole/README.md`.
+//! payout with it.
+//!
+//! Real nullifiers are constrained to be pairwise DISTINCT across slots (dummy
+//! slots exempt). Because the exit-account grouping sums amounts across leaves,
+//! replaying one leaf proof into several slots would otherwise aggregate into a
+//! single inflated exit while the chain, keying its persistent settled-nullifier
+//! set, marks the one shared nullifier spent only once — minting value backed by
+//! a single spend. The uniqueness constraint makes such a batch unprovable, so
+//! the circuit is a first line of defense; the wormhole pallet's persistent
+//! settled-nullifier set remains the cross-batch double-spend boundary and also
+//! rejects intra-segment duplicates as defense in depth. See "Nullifiers and
+//! Double-Spend Prevention" in `wormhole/README.md`.
 
 use anyhow::{ensure, Result};
 use plonky2::{
@@ -364,6 +369,37 @@ fn build_private_batch_constraints(
 
         output_pis.push(final_sum);
         output_pis.extend_from_slice(&final_exit);
+    }
+
+    // =========================================================================
+    // Real-nullifier uniqueness (anti-replay within the batch)
+    // =========================================================================
+    //
+    // A legitimate private batch spends each leaf exactly once, so every real
+    // slot carries a distinct nullifier. Two real slots sharing a nullifier can
+    // only be the SAME leaf proof replayed across multiple slots. Left
+    // unconstrained, the exit-account grouping above sums that leaf's amount
+    // into a single inflated exit (N copies -> N*amount) while the chain marks
+    // the one shared nullifier spent exactly once — minting value backed by a
+    // single spend. Enforce pairwise distinctness of real nullifiers here so
+    // such a batch is unprovable in the first place.
+    //
+    // Dummy slots are exempt: their nullifiers are replaced below with hashes
+    // of fresh random preimages and never settle on-chain, so a (vanishingly
+    // unlikely) dummy/dummy or dummy/real value match is harmless.
+    let real_nullifiers: Vec<[Target; 4]> = (0..n_leaf)
+        .map(|i| limbs4_at_offset::<LEAF_PI_LEN, NULLIFIER_START>(leaf_pi_targets[i], 0))
+        .collect();
+    for i in 0..n_leaf {
+        let is_real_i = builder.not(is_dummy_flags[i]);
+        for j in (i + 1)..n_leaf {
+            let is_real_j = builder.not(is_dummy_flags[j]);
+            let both_real = builder.and(is_real_i, is_real_j);
+            let nullifiers_equal = bytes_digest_eq(builder, real_nullifiers[i], real_nullifiers[j]);
+            // collision = both_real AND nullifiers_equal must be false.
+            let collision = builder.and(both_real, nullifiers_equal);
+            builder.connect(collision.target, zero);
+        }
     }
 
     // =========================================================================

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -355,6 +355,11 @@ impl PrivateBatchProver {
 /// - `asset_id` must match across ALL proofs (dummies included),
 /// - `block_hash` and `volume_fee_bps` must match between non-dummy proofs
 ///   (`block_hash == 0` slots are exempt),
+/// - non-dummy nullifiers must be pairwise DISTINCT, mirroring the circuit's
+///   real-nullifier uniqueness constraint (dummy slots are exempt: the circuit
+///   replaces their nullifiers with hashes of fresh random preimages). Without
+///   this, replaying the same valid leaf proof twice passes per-proof
+///   verification and only fails inside the recursive proving run,
 /// - at least one proof must be non-dummy: an all-dummy batch settles nothing,
 ///   so proving it only burns the proving window. The intentional all-dummy
 ///   padding template is built on the circuit-build path, which fills the
@@ -366,13 +371,15 @@ impl PrivateBatchProver {
 /// this only improves failure latency and error quality.
 fn ensure_leaf_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) -> Result<()> {
     use crate::private_batch::circuit::constants::{
-        ASSET_ID_START, BLOCK_HASH_START, VOLUME_FEE_BPS_START,
+        ASSET_ID_START, BLOCK_HASH_START, NULLIFIER_START, VOLUME_FEE_BPS_START,
     };
+    use std::collections::HashMap;
 
     struct LeafMeta {
         asset_id: u64,
         volume_fee_bps: u64,
         block_hash: [u64; 4],
+        nullifier: [u64; 4],
     }
     // PI lengths were validated by the caller.
     let metas: Vec<LeafMeta> = proofs
@@ -382,6 +389,9 @@ fn ensure_leaf_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) -> Re
             volume_fee_bps: proof.public_inputs[VOLUME_FEE_BPS_START].to_canonical_u64(),
             block_hash: core::array::from_fn(|i| {
                 proof.public_inputs[BLOCK_HASH_START + i].to_canonical_u64()
+            }),
+            nullifier: core::array::from_fn(|i| {
+                proof.public_inputs[NULLIFIER_START + i].to_canonical_u64()
             }),
         })
         .collect();
@@ -401,9 +411,10 @@ fn ensure_leaf_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) -> Re
     }
 
     let mut reference: Option<(usize, &LeafMeta)> = None;
+    let mut seen_nullifiers: HashMap<[u64; 4], usize> = HashMap::new();
     for (idx, meta) in metas.iter().enumerate() {
         if meta.block_hash == [0u64; 4] {
-            continue; // dummy sentinel: exempt from block/fee consistency
+            continue; // dummy sentinel: exempt from block/fee/nullifier consistency
         }
         match reference {
             None => reference = Some((idx, meta)),
@@ -427,6 +438,16 @@ fn ensure_leaf_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) -> Re
                     );
                 }
             }
+        }
+        if let Some(prev_idx) = seen_nullifiers.insert(meta.nullifier, idx) {
+            bail!(
+                "leaf proof {} carries the same nullifier as proof {}; the private-batch \
+                 circuit enforces pairwise-distinct real nullifiers, so this batch (e.g. \
+                 the same leaf proof supplied twice) would only fail after the expensive \
+                 recursive proving run",
+                idx,
+                prev_idx
+            );
         }
     }
     if reference.is_none() {
@@ -523,7 +544,8 @@ fn generate_dummy_nullifier_pre_images_for_slots(n_slots: usize) -> Vec<[F; 4]> 
 mod tests {
     use super::*;
     use crate::private_batch::circuit::constants::{
-        ASSET_ID_START, BLOCK_HASH_START, VOLUME_FEE_BPS_START,
+        ASSET_ID_START, BLOCK_HASH_START, NULLIFIER_START as LEAF_NULLIFIER_START,
+        VOLUME_FEE_BPS_START,
     };
     use plonky2::field::types::Field;
     use qp_wormhole_inputs::{
@@ -630,6 +652,14 @@ mod tests {
         pis
     }
 
+    fn with_nullifier(
+        mut pis: [F; PUBLIC_INPUTS_FELTS_LEN],
+        nullifier: u64,
+    ) -> [F; PUBLIC_INPUTS_FELTS_LEN] {
+        pis[LEAF_NULLIFIER_START] = F::from_canonical_u64(nullifier);
+        pis
+    }
+
     /// Cryptographically invalid (tampered) leaf proofs must be rejected at
     /// commit time, before the expensive recursive proving run starts — the
     /// same fail-fast guard PublicBatchProver applies to its inner proofs.
@@ -664,12 +694,70 @@ mod tests {
     fn compatible_leaf_batch_is_accepted() {
         let (leaf, targets) = build_fake_leaf_circuit();
         let proofs = vec![
-            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 1)),
-            prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 1)),
+            prove_fake_leaf(&leaf, &targets, with_nullifier(leaf_pis(0, 10, 1), 1)),
+            prove_fake_leaf(&leaf, &targets, with_nullifier(leaf_pis(0, 10, 1), 2)),
             // Dummy slot: exempt from block/fee consistency.
             prove_fake_leaf(&leaf, &targets, leaf_pis(0, 99, 0)),
         ];
         ensure_leaf_batch_compatible(&proofs).expect("compatible batch must be accepted");
+    }
+
+    /// The circuit rejects pairwise-equal real nullifiers (two real slots
+    /// sharing a nullifier would merge into one inflated exit while the chain
+    /// marks the shared nullifier spent once). The commit-boundary preflight
+    /// must mirror that rule, otherwise replaying the same valid leaf proof
+    /// twice passes per-proof verification and only fails after entering the
+    /// expensive recursive proving path — violating commit's fail-fast
+    /// contract.
+    #[test]
+    fn duplicate_real_nullifier_leaf_batch_is_rejected() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        // The same valid leaf proof supplied twice: identical nullifiers.
+        let replayed = prove_fake_leaf(&leaf, &targets, with_nullifier(leaf_pis(0, 10, 1), 7));
+        let proofs = vec![replayed.clone(), replayed];
+        let err = ensure_leaf_batch_compatible(&proofs).unwrap_err();
+        assert!(err.to_string().contains("same nullifier"), "got: {err}");
+    }
+
+    /// Dummy slots are exempt from nullifier uniqueness: the circuit replaces
+    /// their nullifiers with hashes of fresh random preimages, so equal
+    /// nullifier fields in supplied dummy proofs never collide on-chain.
+    #[test]
+    fn duplicate_dummy_nullifiers_are_exempt() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let proofs = vec![
+            prove_fake_leaf(&leaf, &targets, with_nullifier(leaf_pis(0, 10, 1), 7)),
+            // Two dummy slots (block 0) sharing nullifier 7 with each other
+            // AND with the real proof above.
+            prove_fake_leaf(&leaf, &targets, with_nullifier(leaf_pis(0, 10, 0), 7)),
+            prove_fake_leaf(&leaf, &targets, with_nullifier(leaf_pis(0, 10, 0), 7)),
+        ];
+        ensure_leaf_batch_compatible(&proofs)
+            .expect("dummy slots must be exempt from nullifier uniqueness");
+    }
+
+    /// End-to-end guard at the commit boundary: the same valid leaf proof
+    /// supplied twice must be rejected by `commit` (fail-fast, milliseconds),
+    /// not by the recursive proving run it precedes.
+    #[test]
+    fn commit_rejects_duplicate_real_nullifiers_before_proving() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let dummy = prove_fake_leaf(&leaf, &targets, [F::ZERO; PUBLIC_INPUTS_FELTS_LEN]);
+        let replayed = prove_fake_leaf(&leaf, &targets, with_nullifier(leaf_pis(0, 10, 1), 7));
+
+        let prover = PrivateBatchProver::new(
+            wormhole_private_batch_circuit_config(),
+            leaf.common.clone(),
+            &leaf.verifier_only,
+            2,
+            dummy,
+        )
+        .unwrap();
+
+        let err = prover
+            .commit(vec![replayed.clone(), replayed])
+            .expect_err("replayed leaf proof must be rejected at commit");
+        assert!(err.to_string().contains("same nullifier"), "got: {err}");
     }
 
     #[test]

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -454,7 +454,7 @@ fn ensure_leaf_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) -> Re
 /// make every padded batch unprovable: partial native-asset batches fail the
 /// in-circuit asset-equality constraint, and nonzero-asset batches are already
 /// rejected by the padding preflight — denying the partial-batch path entirely.
-fn verify_dummy_leaf_template(
+pub(crate) fn verify_dummy_leaf_template(
     template: &ProofWithPublicInputs<F, C, D>,
     leaf_verifier: &VerifierCircuitData<F, C, D>,
 ) -> Result<()> {

--- a/wormhole/aggregator/src/private_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/private_batch/prover/lib.rs
@@ -53,6 +53,11 @@ pub struct PrivateBatchProver {
     targets: Option<PrivateBatchCircuitTargets>,
     num_leaf_proofs: usize,
     dummy_proof_template: ProofWithPublicInputs<F, C, D>,
+    /// Leaf verifier data, kept so [`Self::commit`] can cheaply verify each
+    /// supplied leaf proof before starting the expensive recursive proving run
+    /// (mirrors [`crate::public_batch::prover::PublicBatchProver`]'s pinned
+    /// inner verifier).
+    leaf_verifier: VerifierCircuitData<F, C, D>,
 }
 
 impl PrivateBatchProver {
@@ -84,11 +89,11 @@ impl PrivateBatchProver {
         // `commit` clones this template into every padded slot, and the circuit
         // only exempts slots carrying the dummy sentinel — a caller-supplied
         // REAL proof here would replay its payout in every empty slot (#97026).
-        let leaf_verifier_data = VerifierCircuitData {
+        let leaf_verifier = VerifierCircuitData {
             verifier_only: leaf_verifier_only.clone(),
             common: leaf_common,
         };
-        verify_dummy_leaf_template(&dummy_proof_template, &leaf_verifier_data)?;
+        verify_dummy_leaf_template(&dummy_proof_template, &leaf_verifier)?;
 
         Ok(Self {
             circuit_data,
@@ -96,6 +101,7 @@ impl PrivateBatchProver {
             targets,
             num_leaf_proofs,
             dummy_proof_template,
+            leaf_verifier,
         })
     }
 
@@ -163,6 +169,7 @@ impl PrivateBatchProver {
             targets,
             num_leaf_proofs,
             dummy_proof_template,
+            leaf_verifier: leaf_verifier_data,
         })
     }
 
@@ -227,10 +234,13 @@ impl PrivateBatchProver {
 
     /// Commit leaf proofs to the aggregation circuit witness.
     ///
-    /// Performs padding with dummy proofs, shuffling, and witness filling.
-    /// Rejects batches the private-batch circuit's cross-slot constraints would
-    /// fail (mixed block hashes, asset ids, or fee rates) up front, so callers
-    /// get a precise error in milliseconds instead of a proving failure.
+    /// Fails fast (milliseconds, before the recursive proving run) on inputs
+    /// the private-batch circuit could never prove: each supplied leaf is
+    /// cryptographically verified against the pinned leaf verifier, batches
+    /// that would fail the circuit's cross-slot constraints (mixed block
+    /// hashes, asset ids, or fee rates) are rejected, and an all-dummy batch
+    /// is refused. Then pads with the dummy template, shuffles, and fills the
+    /// witness.
     pub fn commit(mut self, mut proofs: Vec<ProofWithPublicInputs<F, C, D>>) -> Result<Self> {
         let Some(targets) = self.targets.take() else {
             bail!("private-batch aggregation prover has already committed to inputs");
@@ -256,11 +266,19 @@ impl PrivateBatchProver {
         // equality across all proofs.
         let num_dummies_needed = self.num_leaf_proofs.saturating_sub(proofs.len());
 
-        // Validate every real proof's public-input length up front, regardless of
-        // whether padding is needed, so a malformed full batch is rejected at the
-        // API boundary instead of panicking inside witness assignment (#97073).
+        // Validate shape and cryptography up front so a malformed or invalid
+        // leaf is rejected at the API boundary instead of panicking inside
+        // witness assignment (#97073) or failing only after a full recursive
+        // prove (audit finding: leaf validity deferred to the expensive path).
         for (idx, proof) in proofs.iter().enumerate() {
             ensure_proof_public_input_len(proof, LEAF_PI_LEN, "leaf proof")?;
+            self.leaf_verifier.verify(proof.clone()).map_err(|e| {
+                anyhow!(
+                    "leaf proof {} failed verification against the pinned leaf verifier: {}",
+                    idx,
+                    e
+                )
+            })?;
             if num_dummies_needed > 0 {
                 let real_asset_id =
                     leaf_proof_asset_id(proof).map_err(|e| anyhow!("leaf proof {}: {}", idx, e))?;
@@ -315,7 +333,8 @@ impl PrivateBatchProver {
     ///
     /// This is the intended client (CLI / mobile) entry point: a client knows
     /// its complete leaf set up front, so there is no queue — pass everything
-    /// at once. Cross-proof compatibility is checked fail-fast in `commit`.
+    /// at once. Leaf verification and cross-proof compatibility are checked
+    /// fail-fast in `commit`.
     pub fn aggregate(
         self,
         proofs: Vec<ProofWithPublicInputs<F, C, D>>,
@@ -609,6 +628,36 @@ mod tests {
         pis[VOLUME_FEE_BPS_START] = F::from_canonical_u64(volume_fee_bps);
         pis[BLOCK_HASH_START] = F::from_canonical_u64(block);
         pis
+    }
+
+    /// Cryptographically invalid (tampered) leaf proofs must be rejected at
+    /// commit time, before the expensive recursive proving run starts — the
+    /// same fail-fast guard PublicBatchProver applies to its inner proofs.
+    #[test]
+    fn commit_rejects_tampered_leaf_proof_before_proving() {
+        let (leaf, targets) = build_fake_leaf_circuit();
+        let dummy = prove_fake_leaf(&leaf, &targets, [F::ZERO; PUBLIC_INPUTS_FELTS_LEN]);
+        let mut real = prove_fake_leaf(&leaf, &targets, leaf_pis(0, 10, 1));
+        // Right shape, wrong cryptography: mutate one public input so the
+        // proof no longer verifies against the pinned leaf verifier.
+        real.public_inputs[NULLIFIER_START_INDEX] = F::ONE;
+
+        let prover = PrivateBatchProver::new(
+            wormhole_private_batch_circuit_config(),
+            leaf.common.clone(),
+            &leaf.verifier_only,
+            1,
+            dummy,
+        )
+        .unwrap();
+
+        let err = prover
+            .commit(vec![real])
+            .expect_err("tampered leaf proof must be rejected at commit");
+        assert!(
+            err.to_string().contains("failed verification"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/wormhole/aggregator/src/private_batch/prover/mod.rs
+++ b/wormhole/aggregator/src/private_batch/prover/mod.rs
@@ -1,6 +1,6 @@
 pub mod lib;
 pub mod witness;
 
-pub use lib::PrivateBatchProver;
 pub(crate) use lib::verify_dummy_leaf_template;
+pub use lib::PrivateBatchProver;
 pub use witness::fill_private_batch_witness;

--- a/wormhole/aggregator/src/private_batch/prover/mod.rs
+++ b/wormhole/aggregator/src/private_batch/prover/mod.rs
@@ -2,4 +2,5 @@ pub mod lib;
 pub mod witness;
 
 pub use lib::PrivateBatchProver;
+pub(crate) use lib::verify_dummy_leaf_template;
 pub use witness::fill_private_batch_witness;

--- a/wormhole/aggregator/src/public_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/build.rs
@@ -19,29 +19,19 @@ use zk_circuits_common::circuit::{wormhole_public_batch_circuit_config, C, D, F}
 
 use crate::common::utils::{
     canonical_leaf_verifier_data, commit_artifact_set, load_canonical_private_batch_verifier_data,
-    read_artifact_file, sweep_stale_artifact_droppings,
+    read_artifact_file,
 };
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 
 /// Build and write all public-batch artifacts into `output_dir`.
 ///
-/// The two public-batch files are published all-or-nothing (see
-/// [`commit_artifact_set`]), so a failed re-run over an existing bins dir
-/// never leaves a fresh `public_batch_common.bin` beside a stale
-/// `public_batch_verifier.bin`. Whole-directory consistency across all
-/// stages (leaf, private-batch, public-batch, `config.json`) is still only
-/// guaranteed by the staging `generate_all_circuit_binaries` flow in
-/// `circuit-builder`; prefer it unless deliberately regenerating this one
-/// stage into an existing set.
+/// Writes public-batch verifier artifacts. Prefer
+/// `generate_all_circuit_binaries` for production regenerates
+/// (`wormhole/THREAT_MODEL.md`).
 ///
 /// `num_leaf_proofs` is the private-batch leaf count the on-disk
-/// `private_batch_*.bin` artifacts were built for. It is taken from the
-/// caller (who already knows it — typically
-/// [`crate::config::CircuitBinsConfig`]) rather than peeked out of the
-/// untrusted common artifact: reading `num_public_inputs` via a full
-/// `CommonCircuitData::from_bytes` asked the allocator for capacities from
-/// attacker-controlled length fields before canonical pinning could reject
-/// the file (audit finding).
+/// `private_batch_*.bin` artifacts were built for (caller-supplied;
+/// typically [`crate::config::CircuitBinsConfig`]).
 pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
     output_dir: P,
     num_private_batch_proofs: usize,
@@ -53,9 +43,6 @@ pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
     validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
     create_dir_all(output_dir)
         .with_context(|| format!("Failed to create output dir {}", output_dir.display()))?;
-    // A previous publish hard-killed mid-swap leaves orphaned temp/backup
-    // entries behind; we are about to replace the set, so sweep them now.
-    sweep_stale_artifact_droppings(output_dir)?;
 
     // Pin the private-batch artifacts to the canonical private-batch circuit
     // BEFORE baking their verifier key into the public-batch circuit as
@@ -124,7 +111,7 @@ fn write_verifier_artifacts(
         .to_bytes()
         .map_err(|e| anyhow!("Failed to serialize public_batch verifier data: {}", e))?;
 
-    // Published all-or-nothing; see `commit_artifact_set` in `common::utils`.
+    // Prefer whole-dir staging via `generate_all_circuit_binaries` for production.
     commit_artifact_set(
         bins_dir,
         &[
@@ -141,7 +128,6 @@ mod tests {
     use crate::common::utils::MAX_ARTIFACT_FILE_BYTES;
     use std::fs::File;
     use std::path::PathBuf;
-    use test_helpers::fake_leaf::build_fake_leaf_circuit;
 
     fn temp_dir(tag: &str) -> PathBuf {
         let dir = std::env::temp_dir().join(format!(
@@ -200,147 +186,6 @@ mod tests {
             !dir.join("public_batch_common.bin").exists()
                 && !dir.join("public_batch_verifier.bin").exists(),
             "a rejected private-batch pin must not publish public-batch artifacts"
-        );
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    /// `public_batch_common.bin` and `public_batch_verifier.bin` are a matched
-    /// set: consumers load both and pin them against a canonical rebuild, so a
-    /// directory holding one new file beside one stale file is rejected until
-    /// regenerated. A publish that fails partway must therefore either leave
-    /// the previous set fully intact or replace it wholesale — never mix.
-    #[test]
-    fn failed_artifact_publish_never_leaves_mixed_verifier_set() {
-        let dir = temp_dir("mixed-set");
-        std::fs::write(dir.join("public_batch_common.bin"), b"old common").unwrap();
-        // A directory squatting on the verifier path makes a naive in-place
-        // write of the second file fail after the first was already clobbered.
-        create_dir_all(dir.join("public_batch_verifier.bin")).unwrap();
-
-        let verifier_data = build_fake_leaf_circuit().0.verifier_data();
-        let result = write_verifier_artifacts(&dir, &verifier_data);
-
-        let common_now = std::fs::read(dir.join("public_batch_common.bin")).unwrap();
-        match result {
-            Err(_) => assert_eq!(
-                common_now, b"old common",
-                "a failed publish must leave the previous artifact set untouched, \
-                 not a fresh common beside a stale verifier"
-            ),
-            Ok(()) => {
-                assert_ne!(
-                    common_now, b"old common",
-                    "a successful publish must replace the set wholesale"
-                );
-                assert!(
-                    dir.join("public_batch_verifier.bin").is_file(),
-                    "a successful publish must leave a real verifier artifact"
-                );
-            }
-        }
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    /// A symlink pre-planted at an artifact filename must not redirect the
-    /// write onto its target (audit finding: symlink-following artifact
-    /// writes). `commit_artifact_set` stages under exclusive-create temp names
-    /// and renames into place, which replaces the planted entry itself; this
-    /// guards against regressing to direct `std::fs::write` calls.
-    #[cfg(unix)]
-    #[test]
-    fn artifact_writes_do_not_follow_planted_symlinks() {
-        let dir = temp_dir("symlink-clobber");
-
-        let victim = dir.join("victim.txt");
-        std::fs::write(&victim, b"precious data").unwrap();
-        std::os::unix::fs::symlink(&victim, dir.join("public_batch_verifier.bin")).unwrap();
-
-        let verifier_data = build_fake_leaf_circuit().0.verifier_data();
-        let result = write_verifier_artifacts(&dir, &verifier_data);
-
-        assert_eq!(
-            std::fs::read(&victim).unwrap(),
-            b"precious data",
-            "artifact publication must never write through a planted symlink"
-        );
-        if result.is_ok() {
-            let verifier = std::fs::read(dir.join("public_batch_verifier.bin")).unwrap();
-            assert_ne!(
-                verifier, b"precious data",
-                "a successful run must have replaced the planted entry with a real artifact"
-            );
-        }
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    /// A publish hard-killed mid-swap (SIGKILL/power loss) leaves orphaned
-    /// `.<name>.tmp-*` / `.<name>.old-*` droppings that no later run adopts
-    /// (the random suffix is fresh per call). The builder path must sweep
-    /// them before regenerating so they do not accumulate forever (audit
-    /// finding: crash-path droppings never cleaned up). Unrelated dotfiles
-    /// must survive the sweep.
-    #[test]
-    fn rebuild_sweeps_droppings_of_interrupted_publish() {
-        let dir = temp_dir("crash-droppings");
-
-        // Simulate the post-SIGKILL state: originals moved aside, staged
-        // files still present, nothing live. Generation will fail for lack of
-        // private-batch artifacts, but the sweep must still run first.
-        let dropping_old = dir.join(".public_batch_common.bin.old-12345-0123456789abcdef");
-        let dropping_tmp = dir.join(".public_batch_verifier.bin.tmp-12345-0123456789abcdef");
-        std::fs::write(&dropping_old, b"moved-aside original").unwrap();
-        std::fs::write(&dropping_tmp, b"orphaned staged file").unwrap();
-        let innocent = dir.join(".gitignore");
-        std::fs::write(&innocent, b"*.log").unwrap();
-
-        let _ = generate_public_batch_circuit_binaries(&dir, 1, 1);
-
-        assert!(
-            !dropping_old.exists() && !dropping_tmp.exists(),
-            "regeneration must sweep droppings of an interrupted publish"
-        );
-        assert!(
-            innocent.exists(),
-            "the sweep must not touch unrelated dotfiles"
-        );
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    /// A successful re-publish over an existing set must replace both files
-    /// and leave no staging or moved-aside droppings behind in the bins dir.
-    #[test]
-    fn artifact_publish_replaces_set_wholesale_without_droppings() {
-        let dir = temp_dir("clean-publish");
-        std::fs::write(dir.join("public_batch_common.bin"), b"old common").unwrap();
-        std::fs::write(dir.join("public_batch_verifier.bin"), b"old verifier").unwrap();
-
-        let verifier_data = build_fake_leaf_circuit().0.verifier_data();
-        write_verifier_artifacts(&dir, &verifier_data).unwrap();
-
-        assert_ne!(
-            std::fs::read(dir.join("public_batch_common.bin")).unwrap(),
-            b"old common"
-        );
-        assert_ne!(
-            std::fs::read(dir.join("public_batch_verifier.bin")).unwrap(),
-            b"old verifier"
-        );
-        let mut names: Vec<String> = std::fs::read_dir(&dir)
-            .unwrap()
-            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
-            .collect();
-        names.sort();
-        assert_eq!(
-            names,
-            vec![
-                "public_batch_common.bin".to_string(),
-                "public_batch_verifier.bin".to_string()
-            ],
-            "publish must not leave temp/old files behind"
         );
 
         std::fs::remove_dir_all(&dir).unwrap();

--- a/wormhole/aggregator/src/public_batch/circuit/build.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/build.rs
@@ -19,8 +19,7 @@ use zk_circuits_common::circuit::{wormhole_public_batch_circuit_config, C, D, F}
 
 use crate::common::utils::{
     canonical_leaf_verifier_data, commit_artifact_set, load_canonical_private_batch_verifier_data,
-    private_batch_num_leaves_from_padded_pi_len, read_artifact_file,
-    sweep_stale_artifact_droppings,
+    read_artifact_file, sweep_stale_artifact_droppings,
 };
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 
@@ -34,24 +33,35 @@ use crate::public_batch::circuit::circuit_logic::PublicBatchCircuit;
 /// guaranteed by the staging `generate_all_circuit_binaries` flow in
 /// `circuit-builder`; prefer it unless deliberately regenerating this one
 /// stage into an existing set.
+///
+/// `num_leaf_proofs` is the private-batch leaf count the on-disk
+/// `private_batch_*.bin` artifacts were built for. It is taken from the
+/// caller (who already knows it — typically
+/// [`crate::config::CircuitBinsConfig`]) rather than peeked out of the
+/// untrusted common artifact: reading `num_public_inputs` via a full
+/// `CommonCircuitData::from_bytes` asked the allocator for capacities from
+/// attacker-controlled length fields before canonical pinning could reject
+/// the file (audit finding).
 pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
     output_dir: P,
     num_private_batch_proofs: usize,
+    num_leaf_proofs: usize,
 ) -> Result<()> {
     let output_dir = output_dir.as_ref();
-    // Bound the per-layer count before any circuit construction (#97021, #97070).
+    // Bound the per-layer counts before any circuit construction (#97021, #97070).
     validate_proof_count(num_private_batch_proofs, "num_private_batch_proofs")?;
+    validate_proof_count(num_leaf_proofs, "num_leaf_proofs")?;
     create_dir_all(output_dir)
         .with_context(|| format!("Failed to create output dir {}", output_dir.display()))?;
     // A previous publish hard-killed mid-swap leaves orphaned temp/backup
     // entries behind; we are about to replace the set, so sweep them now.
     sweep_stale_artifact_droppings(output_dir)?;
 
-    // Pin the private-batch artifacts to the canonical private-batch circuit BEFORE
-    // baking their verifier key into the public-batch circuit as constants. The leaf
-    // count is derived from the (untrusted) common data first, but the subsequent
-    // byte-exact comparison against a canonically rebuilt circuit for that count
-    // rejects any substituted or stale artifact.
+    // Pin the private-batch artifacts to the canonical private-batch circuit
+    // BEFORE baking their verifier key into the public-batch circuit as
+    // constants. Pinning compares the raw artifact bytes to a canonical
+    // rebuild for `num_leaf_proofs` and never deserializes the untrusted
+    // common data (see `load_canonical_private_batch_verifier_data`).
     let private_batch_common_bytes =
         read_artifact_file(&output_dir.join("private_batch_common.bin")).with_context(|| {
             format!(
@@ -67,14 +77,11 @@ pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
             )
         })?;
 
-    let claimed_pi_len = peek_common_num_public_inputs(&private_batch_common_bytes)?;
-    let private_batch_num_leaves = private_batch_num_leaves_from_padded_pi_len(claimed_pi_len)?;
-
     let private_batch = load_canonical_private_batch_verifier_data(
         &private_batch_common_bytes,
         &private_batch_verifier_bytes,
         &canonical_leaf_verifier_data(),
-        private_batch_num_leaves,
+        num_leaf_proofs,
     )
     .context("Failed to load private-batch verifier data")?;
 
@@ -85,7 +92,7 @@ pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
         private_batch.common,
         &private_batch.verifier_only,
         num_private_batch_proofs,
-        private_batch_num_leaves,
+        num_leaf_proofs,
     )?;
 
     let verifier_data = public_batch_circuit.build_verifier();
@@ -95,25 +102,10 @@ pub fn generate_public_batch_circuit_binaries<P: AsRef<Path>>(
         "Public-batch circuit artifacts written to {} (num_private_batch_proofs={}, private_batch_num_leaves={})",
         output_dir.display(),
         num_private_batch_proofs,
-        private_batch_num_leaves
+        num_leaf_proofs
     );
 
     Ok(())
-}
-
-/// Decode the claimed public-input count from serialized common circuit data.
-///
-/// Used only to derive the leaf count needed to rebuild the canonical
-/// private-batch circuit; the artifact is then pinned byte-exactly against that
-/// canonical rebuild, so a lie here cannot survive the comparison.
-fn peek_common_num_public_inputs(common_bytes: &[u8]) -> Result<usize> {
-    let gate_serializer = DefaultGateSerializer;
-    let common = plonky2::plonk::circuit_data::CommonCircuitData::<F, D>::from_bytes(
-        common_bytes.to_vec(),
-        &gate_serializer,
-    )
-    .map_err(|e| anyhow!("Failed to deserialize private_batch_common.bin: {}", e))?;
-    Ok(common.num_public_inputs)
 }
 
 fn write_verifier_artifacts(
@@ -163,8 +155,7 @@ mod tests {
     }
 
     /// An oversized (sparse) private-batch artifact must be rejected by the
-    /// size cap before its contents are allocated into memory and fed into
-    /// `peek_common_num_public_inputs`'s full deserialization.
+    /// size cap before its contents are allocated into memory.
     #[test]
     fn oversized_private_batch_common_artifact_is_rejected_by_size_cap() {
         let dir = temp_dir("oversized-common");
@@ -174,10 +165,41 @@ mod tests {
             .unwrap();
         std::fs::write(dir.join("private_batch_verifier.bin"), b"irrelevant").unwrap();
 
-        let err = generate_public_batch_circuit_binaries(&dir, 1).unwrap_err();
+        let err = generate_public_batch_circuit_binaries(&dir, 1, 1).unwrap_err();
         assert!(
             format!("{err:#}").contains("exceeds the"),
             "oversized artifact must be rejected by the size cap, got: {err:#}"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A capped-but-poisoned `private_batch_common.bin` whose serialized
+    /// length fields would force huge `try_reserve` calls under a full
+    /// `CommonCircuitData::from_bytes` must be rejected by the byte-exact
+    /// canonical pin — never deserialized for a leaf-count peek (audit
+    /// finding). Sprinkling enormous little-endian usizes through a small
+    /// buffer covers whatever offset the first length-prefixed vector occupies.
+    #[test]
+    fn poisoned_private_batch_common_is_rejected_without_deserialize_peek() {
+        let dir = temp_dir("poisoned-common");
+        let mut poisoned = vec![0u8; 4096];
+        for i in (0..poisoned.len()).step_by(8) {
+            poisoned[i..i + 8].copy_from_slice(&(usize::MAX / 16).to_le_bytes());
+        }
+        std::fs::write(dir.join("private_batch_common.bin"), &poisoned).unwrap();
+        std::fs::write(dir.join("private_batch_verifier.bin"), &poisoned[..128]).unwrap();
+
+        let err = generate_public_batch_circuit_binaries(&dir, 1, 1).unwrap_err();
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("does not match the canonical"),
+            "poisoned common must fail the byte pin (not a deserialize OOM/IoError), got: {chain}"
+        );
+        assert!(
+            !dir.join("public_batch_common.bin").exists()
+                && !dir.join("public_batch_verifier.bin").exists(),
+            "a rejected private-batch pin must not publish public-batch artifacts"
         );
 
         std::fs::remove_dir_all(&dir).unwrap();
@@ -217,6 +239,73 @@ mod tests {
                 );
             }
         }
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A symlink pre-planted at an artifact filename must not redirect the
+    /// write onto its target (audit finding: symlink-following artifact
+    /// writes). `commit_artifact_set` stages under exclusive-create temp names
+    /// and renames into place, which replaces the planted entry itself; this
+    /// guards against regressing to direct `std::fs::write` calls.
+    #[cfg(unix)]
+    #[test]
+    fn artifact_writes_do_not_follow_planted_symlinks() {
+        let dir = temp_dir("symlink-clobber");
+
+        let victim = dir.join("victim.txt");
+        std::fs::write(&victim, b"precious data").unwrap();
+        std::os::unix::fs::symlink(&victim, dir.join("public_batch_verifier.bin")).unwrap();
+
+        let verifier_data = build_fake_leaf_circuit().0.verifier_data();
+        let result = write_verifier_artifacts(&dir, &verifier_data);
+
+        assert_eq!(
+            std::fs::read(&victim).unwrap(),
+            b"precious data",
+            "artifact publication must never write through a planted symlink"
+        );
+        if result.is_ok() {
+            let verifier = std::fs::read(dir.join("public_batch_verifier.bin")).unwrap();
+            assert_ne!(
+                verifier, b"precious data",
+                "a successful run must have replaced the planted entry with a real artifact"
+            );
+        }
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A publish hard-killed mid-swap (SIGKILL/power loss) leaves orphaned
+    /// `.<name>.tmp-*` / `.<name>.old-*` droppings that no later run adopts
+    /// (the random suffix is fresh per call). The builder path must sweep
+    /// them before regenerating so they do not accumulate forever (audit
+    /// finding: crash-path droppings never cleaned up). Unrelated dotfiles
+    /// must survive the sweep.
+    #[test]
+    fn rebuild_sweeps_droppings_of_interrupted_publish() {
+        let dir = temp_dir("crash-droppings");
+
+        // Simulate the post-SIGKILL state: originals moved aside, staged
+        // files still present, nothing live. Generation will fail for lack of
+        // private-batch artifacts, but the sweep must still run first.
+        let dropping_old = dir.join(".public_batch_common.bin.old-12345-0123456789abcdef");
+        let dropping_tmp = dir.join(".public_batch_verifier.bin.tmp-12345-0123456789abcdef");
+        std::fs::write(&dropping_old, b"moved-aside original").unwrap();
+        std::fs::write(&dropping_tmp, b"orphaned staged file").unwrap();
+        let innocent = dir.join(".gitignore");
+        std::fs::write(&innocent, b"*.log").unwrap();
+
+        let _ = generate_public_batch_circuit_binaries(&dir, 1, 1);
+
+        assert!(
+            !dropping_old.exists() && !dropping_tmp.exists(),
+            "regeneration must sweep droppings of an interrupted publish"
+        );
+        assert!(
+            innocent.exists(),
+            "the sweep must not touch unrelated dotfiles"
+        );
 
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -426,7 +426,11 @@ fn ensure_private_batch_compatible(proofs: &[ProofWithPublicInputs<F, C, D>]) ->
 /// private-batch proof carrying the zero block-hash sentinel and zero forwarded
 /// payouts, so poisoned padding cannot inject real exits into partial public
 /// batches (#97026).
-fn verify_dummy_private_batch_template(
+///
+/// `pub(crate)` so [`crate::aggregator::PublicBatchAggregator`] can validate the
+/// template once at construction and pin it for every later `prove_batch`,
+/// instead of re-reading a mutable artifact path.
+pub(crate) fn verify_dummy_private_batch_template(
     template: &ProofWithPublicInputs<F, C, D>,
     private_batch_verifier: &VerifierCircuitData<F, C, D>,
 ) -> Result<()> {

--- a/wormhole/aggregator/src/public_batch/prover/mod.rs
+++ b/wormhole/aggregator/src/public_batch/prover/mod.rs
@@ -2,3 +2,4 @@ pub mod lib;
 pub mod witness;
 
 pub use lib::{PublicBatchInputs, PublicBatchProver};
+pub(crate) use lib::verify_dummy_private_batch_template;

--- a/wormhole/aggregator/src/public_batch/prover/mod.rs
+++ b/wormhole/aggregator/src/public_batch/prover/mod.rs
@@ -9,5 +9,5 @@ pub mod lib;
 /// all-dummy batches occupy a proving window).
 pub(crate) mod witness;
 
-pub use lib::{PublicBatchInputs, PublicBatchProver};
 pub(crate) use lib::verify_dummy_private_batch_template;
+pub use lib::{PublicBatchInputs, PublicBatchProver};

--- a/wormhole/aggregator/src/public_batch/prover/mod.rs
+++ b/wormhole/aggregator/src/public_batch/prover/mod.rs
@@ -1,5 +1,13 @@
 pub mod lib;
-pub mod witness;
+/// Low-level witness filler — not an untrusted-input boundary.
+///
+/// Cryptographic verification, metadata compatibility, dummy-padding, and the
+/// non-all-dummy admission check live in [`PublicBatchProver::commit`]. This
+/// module is `pub(crate)` so downstream services cannot bypass those checks by
+/// calling [`witness::fill_public_batch_witness`] directly (audit finding:
+/// exposed helper deferred rejection until the expensive proving path / let
+/// all-dummy batches occupy a proving window).
+pub(crate) mod witness;
 
 pub use lib::{PublicBatchInputs, PublicBatchProver};
 pub(crate) use lib::verify_dummy_private_batch_template;

--- a/wormhole/aggregator/src/public_batch/prover/witness.rs
+++ b/wormhole/aggregator/src/public_batch/prover/witness.rs
@@ -1,4 +1,9 @@
 //! Witness filling for the public-batch aggregation circuit.
+//!
+//! Crate-private: callers with untrusted proof vectors must go through
+//! [`super::PublicBatchProver::commit`], which verifies each inner proof,
+//! enforces metadata compatibility, pads only after validation, and rejects
+//! all-dummy batches before this helper runs.
 
 use anyhow::{bail, Result};
 use plonky2::iop::witness::{PartialWitness, WitnessWrite};
@@ -11,7 +16,10 @@ use crate::common::utils::ensure_proof_shape_matches_targets;
 use crate::public_batch::circuit::circuit_logic::PublicBatchCircuitTargets;
 
 /// Fill a partial witness for the public-batch aggregation circuit.
-pub fn fill_public_batch_witness(
+///
+/// Structural checks only (proof count + shape). Not safe for untrusted inputs
+/// on its own — see the module docs.
+pub(crate) fn fill_public_batch_witness(
     pw: &mut PartialWitness<F>,
     targets: &PublicBatchCircuitTargets,
     private_batch_proofs: &[ProofWithPublicInputs<F, C, D>],

--- a/wormhole/circuit-builder/README.md
+++ b/wormhole/circuit-builder/README.md
@@ -2,6 +2,14 @@
 
 CLI to generate Wormhole circuit binaries for proving and verification.
 
+**Trust assumption:** this tool is meant to run in **CI (or an equivalently
+controlled builder)**. The build host and the output directory during
+generation are trusted. Local filesystem adversary findings against the
+publisher (symlink TOCTOU, planted FIFOs, concurrent staging replacement,
+etc.) are out of scope under the Wormhole threat model — see
+[`../THREAT_MODEL.md`](../THREAT_MODEL.md). Distribute the resulting directory
+via an attested channel; provers should load only that attested path.
+
 ```sh
 cargo run --release -p qp-wormhole-circuit-builder -- --num-leaf-proofs <N> [--num-private-batch-proofs <M>] --output generated-bins
 ```

--- a/wormhole/circuit-builder/examples/public_batch_bench.rs
+++ b/wormhole/circuit-builder/examples/public_batch_bench.rs
@@ -110,7 +110,7 @@ fn main() -> anyhow::Result<()> {
 
         // 1) Build + serialize the public-batch verifier artifacts.
         let build_start = Instant::now();
-        generate_public_batch_circuit_binaries(&dir, m)?;
+        generate_public_batch_circuit_binaries(&dir, m, NUM_LEAF_PROOFS)?;
         let build_time = build_start.elapsed();
         CircuitBinsConfig::new(NUM_LEAF_PROOFS, Some(m))?.save(&dir)?;
         let verifier_bins_size = file_size(&dir.join("public_batch_common.bin"))

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -1,3 +1,15 @@
+//! Wormhole circuit artifact generation (leaf / private-batch / public-batch).
+//!
+//! # Trust boundary
+//!
+//! This crate is intended to run on a **trusted CI build host**. The checkout,
+//! toolchain, and output parent during generation are not modeled as
+//! adversarial. Local filesystem races against the publisher (symlink TOCTOU,
+//! planted FIFOs, concurrent staging replacement, etc.) are **out of scope**;
+//! see `wormhole/THREAT_MODEL.md`. Remaining in-scope obligations when these
+//! artifacts are later loaded: no prover.bin, canonical verifier pinning,
+//! and dummy-template validation.
+
 use anyhow::{anyhow, bail, Context, Result};
 use std::fs;
 use std::fs::create_dir_all;

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -216,6 +216,61 @@ fn create_staging_dir(output_dir: &Path) -> Result<PathBuf> {
     );
 }
 
+/// Identity of a plain directory we intend to publish, captured via
+/// `symlink_metadata` so a symlink-at-that-path never counts as a directory.
+/// On Unix we also pin `(dev, ino)` so a TOCTOU replacement of the staging
+/// path with a different directory (or symlink) between the check and
+/// `rename` is detectable after publication.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PlainDirId {
+    #[cfg(unix)]
+    dev: u64,
+    #[cfg(unix)]
+    ino: u64,
+}
+
+fn plain_dir_id(path: &Path) -> Result<PlainDirId> {
+    let meta = fs::symlink_metadata(path).with_context(|| {
+        format!("failed to inspect artifact path {}", path.display())
+    })?;
+    // `symlink_metadata` + `is_dir` rejects symlinks even when their target
+    // is a directory — that is the whole point of the staging-path check.
+    if !meta.is_dir() {
+        bail!(
+            "artifact path {} is not a plain directory (symlink or file)",
+            path.display()
+        );
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Ok(PlainDirId {
+            dev: meta.dev(),
+            ino: meta.ino(),
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = meta;
+        Ok(PlainDirId {})
+    }
+}
+
+/// Remove a just-published path that failed the post-rename identity check.
+/// It may be a symlink (the TOCTOU attack), a file, or a wrong directory.
+fn remove_bad_publish_path(path: &Path) -> std::io::Result<()> {
+    let meta = match fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    if meta.file_type().is_symlink() || meta.is_file() {
+        fs::remove_file(path)
+    } else {
+        fs::remove_dir_all(path)
+    }
+}
+
 /// Replace `output_dir` with the fully staged `staging_dir` via directory
 /// renames. `rename` cannot overwrite a non-empty directory, so a pre-existing
 /// output dir is first moved aside, then removed after the swap. A crash
@@ -234,6 +289,15 @@ fn create_staging_dir(output_dir: &Path) -> Result<PathBuf> {
 /// success made automation treat a live, complete artifact update as a failed
 /// run (false rollback / retry / alert) whenever the old path was not a
 /// recursively-removable directory (audit finding).
+///
+/// Symlink / inode TOCTOU: a single `symlink_metadata` check before `rename`
+/// is not atomic with the rename's pathname lookup. A local attacker who can
+/// write the output parent could replace the staging directory with a symlink
+/// after the check and have that symlink published as `output_dir` while the
+/// previous artifact set is deleted. We pin the staging directory's identity,
+/// re-validate it immediately before the rename, and require the same identity
+/// at `output_dir` afterward — rolling back (and refusing success) on mismatch
+/// (audit finding).
 fn commit_staging_dir(staging_dir: &Path, output_dir: &Path) -> Result<()> {
     commit_staging_dir_impl(staging_dir, output_dir, |src, dst| fs::rename(src, dst))
 }
@@ -245,22 +309,16 @@ fn commit_staging_dir_impl(
     output_dir: &Path,
     rename: impl Fn(&Path, &Path) -> std::io::Result<()>,
 ) -> Result<()> {
-    // Never publish a staging path we did not stage as a real directory:
-    // renaming a symlink into place would hand out an artifact dir whose
-    // contents remain mutable by whoever owns the link target.
-    let staging_meta = fs::symlink_metadata(staging_dir).with_context(|| {
+    // Pin the staging directory's identity up front. Renaming a symlink into
+    // place would hand out an artifact dir whose contents remain mutable by
+    // whoever owns the link target.
+    let staging_id = plain_dir_id(staging_dir).with_context(|| {
         format!(
-            "failed to inspect staged artifact dir {}",
+            "staged artifact path {} is not a plain directory; \
+             refusing to publish it as the artifact dir",
             staging_dir.display()
         )
     })?;
-    if !staging_meta.is_dir() {
-        bail!(
-            "staged artifact path {} is not a plain directory (symlink or file); \
-             refusing to publish it as the artifact dir",
-            staging_dir.display()
-        );
-    }
 
     let mut old_name = staging_dir.file_name().unwrap_or_default().to_os_string();
     old_name.push(".old");
@@ -271,20 +329,14 @@ fn commit_staging_dir_impl(
         // `--output` is a directory, and moving a non-directory aside would
         // leave `remove_dir_all` unable to clean it up after a successful
         // publish (the exact cleanup/success conflation this function avoids).
-        let prev_meta = fs::symlink_metadata(output_dir).with_context(|| {
-            format!(
-                "failed to inspect previous artifact path {}",
-                output_dir.display()
-            )
-        })?;
-        if !prev_meta.is_dir() {
+        if let Err(e) = plain_dir_id(output_dir) {
             let _ = fs::remove_dir_all(staging_dir);
-            bail!(
+            return Err(e).context(format!(
                 "output path {} exists but is not a plain directory (symlink or file); \
                  refusing to treat it as the previous artifact set — remove or rename \
                  it and retry",
                 output_dir.display()
-            );
+            ));
         }
 
         if let Err(e) = rename(output_dir, &old_path) {
@@ -300,6 +352,31 @@ fn commit_staging_dir_impl(
             });
         }
     }
+
+    // Re-validate immediately before the rename's pathname lookup. Still not
+    // fully atomic with the rename, but shrinks the race; the post-rename
+    // identity check below is what makes a won race fail closed.
+    let staging_id_pre_rename = plain_dir_id(staging_dir).with_context(|| {
+        format!(
+            "staged artifact path {} was replaced after the initial check \
+             (no longer a plain directory); refusing to publish",
+            staging_dir.display()
+        )
+    })?;
+    if staging_id_pre_rename != staging_id {
+        // A different directory now sits at the staging path. Do not publish
+        // it; restore any moved-aside previous set first.
+        if previous_exists {
+            let _ = rename(&old_path, output_dir);
+        }
+        let _ = fs::remove_dir_all(staging_dir);
+        bail!(
+            "staged artifact path {} was replaced with a different directory \
+             before publish; refusing to publish attacker-controlled contents",
+            staging_dir.display()
+        );
+    }
+
     if let Err(e) = rename(staging_dir, output_dir) {
         // The previous set (if any) has been moved aside and output_dir is
         // empty, so the staged directory may hold the ONLY copy of the new
@@ -347,6 +424,47 @@ fn commit_staging_dir_impl(
             )
         });
     }
+
+    // Close the check-then-rename TOCTOU: the path published at output_dir
+    // must be the same plain directory inode we staged. If an attacker swapped
+    // in a symlink (or another directory) between the pre-rename check and
+    // rename's lookup, detect it here and roll back before declaring success
+    // or deleting the previous artifact set.
+    match plain_dir_id(output_dir) {
+        Ok(published_id) if published_id == staging_id => {}
+        Ok(_) | Err(_) => {
+            let _ = remove_bad_publish_path(output_dir);
+            if previous_exists {
+                match rename(&old_path, output_dir) {
+                    Ok(()) => {
+                        bail!(
+                            "published path {} was not the staged artifact directory \
+                             (replaced by a symlink or different directory during \
+                             rename); previous artifacts were restored",
+                            output_dir.display()
+                        );
+                    }
+                    Err(rollback_err) => {
+                        bail!(
+                            "published path {} was not the staged artifact directory \
+                             (replaced during rename), and restoring the previous \
+                             artifacts also failed ({}); previous artifacts remain at {}",
+                            output_dir.display(),
+                            rollback_err,
+                            old_path.display()
+                        );
+                    }
+                }
+            }
+            bail!(
+                "published path {} was not the staged artifact directory \
+                 (replaced by a symlink or different directory during rename); \
+                 refusing to treat the publish as successful",
+                output_dir.display()
+            );
+        }
+    }
+
     if previous_exists {
         // The new set is already live at output_dir. Cleanup of the moved-aside
         // previous copy must not flip the command to failure: operators and CI
@@ -605,6 +723,118 @@ mod tests {
         assert!(
             fs::symlink_metadata(&output).is_err(),
             "a symlinked staging path must never be published as the artifact dir"
+        );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// TOCTOU (audit finding): the pre-rename plain-directory check and the
+    /// `rename` pathname lookup are separate. A local attacker who replaces
+    /// the staging directory with a symlink in that window must not get a
+    /// successful publish that leaves `--output` as attacker-mutable storage
+    /// while the previous artifact set is deleted. The post-rename inode /
+    /// type check must fail closed and restore the previous set.
+    #[cfg(unix)]
+    #[test]
+    fn commit_rolls_back_if_staging_replaced_by_symlink_during_rename() {
+        let root = unique_tmp_dir("commit-toctou-symlink");
+        let _ = fs::remove_dir_all(&root);
+        create_dir_all(&root).unwrap();
+        let output = root.join("bins");
+        let staging = create_staging_dir(&output).unwrap();
+
+        create_dir_all(&output).unwrap();
+        write(output.join("previous.bin"), b"previous").unwrap();
+        write(staging.join("fresh.bin"), b"fresh").unwrap();
+
+        let attacker_target = root.join("attacker-target");
+        create_dir_all(&attacker_target).unwrap();
+        write(attacker_target.join("evil.bin"), b"attacker mutable").unwrap();
+
+        let staging_src = staging.clone();
+        let attacker = attacker_target.clone();
+        let err = commit_staging_dir_impl(&staging, &output, |src, dst| {
+            if src == staging_src {
+                // Win the race at rename time: drop our staging dir and plant
+                // a symlink under the same path, then rename that symlink.
+                let _ = fs::remove_dir_all(src);
+                std::os::unix::fs::symlink(&attacker, src)?;
+                fs::rename(src, dst)
+            } else {
+                fs::rename(src, dst)
+            }
+        })
+        .unwrap_err();
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("not the staged artifact directory")
+                || msg.contains("previous artifacts were restored"),
+            "got: {msg}"
+        );
+        assert!(
+            output.join("previous.bin").exists(),
+            "previous artifact set must be restored after a TOCTOU publish attempt"
+        );
+        assert!(
+            !output.join("evil.bin").exists(),
+            "attacker-controlled contents must not remain published at output_dir"
+        );
+        let out_meta = fs::symlink_metadata(&output).unwrap();
+        assert!(
+            out_meta.is_dir() && !out_meta.file_type().is_symlink(),
+            "output_dir must be a plain directory again after rollback"
+        );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Same TOCTOU window, but the replacement is a different plain directory
+    /// (different inode). Publishing it would still hand the attacker a
+    /// successful exit with contents they control; the inode pin must reject it.
+    #[cfg(unix)]
+    #[test]
+    fn commit_rolls_back_if_staging_replaced_by_different_directory_during_rename() {
+        let root = unique_tmp_dir("commit-toctou-dir");
+        let _ = fs::remove_dir_all(&root);
+        create_dir_all(&root).unwrap();
+        let output = root.join("bins");
+        let staging = create_staging_dir(&output).unwrap();
+
+        create_dir_all(&output).unwrap();
+        write(output.join("previous.bin"), b"previous").unwrap();
+        write(staging.join("fresh.bin"), b"fresh").unwrap();
+
+        let attacker_dir = root.join("attacker-dir");
+        create_dir_all(&attacker_dir).unwrap();
+        write(attacker_dir.join("evil.bin"), b"attacker mutable").unwrap();
+
+        let staging_src = staging.clone();
+        let attacker = attacker_dir.clone();
+        let err = commit_staging_dir_impl(&staging, &output, |src, dst| {
+            if src == staging_src {
+                let _ = fs::remove_dir_all(src);
+                // Move the attacker's directory onto the staging path (same
+                // parent, so rename is atomic) then publish that inode.
+                fs::rename(&attacker, src)?;
+                fs::rename(src, dst)
+            } else {
+                fs::rename(src, dst)
+            }
+        })
+        .unwrap_err();
+
+        assert!(
+            format!("{err:#}").contains("not the staged artifact directory"),
+            "got: {err:#}"
+        );
+        assert!(
+            output.join("previous.bin").exists(),
+            "previous artifact set must be restored"
+        );
+        assert!(
+            !output.join("evil.bin").exists(),
+            "attacker directory must not remain published"
         );
 
         fs::remove_dir_all(&root).unwrap();

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -27,21 +27,13 @@ pub use wormhole_aggregator::CircuitBinsConfig;
 
 /// Generate only the leaf wormhole circuit binaries.
 ///
-/// This is a low-level helper for partial artifact generation. For the full flow that also
-/// emits `config.json`, use [`generate_all_circuit_binaries`].
+/// Low-level helper for partial regenerates. Prefer
+/// [`generate_all_circuit_binaries`] for production builds (whole-directory
+/// staging; see `wormhole/THREAT_MODEL.md`).
 ///
-/// The three leaf files are published all-or-nothing through the aggregator's
-/// `commit_artifact_set` (exclusive-create staging plus rename into place), so
-/// a failed re-run never leaves a mixed leaf set and a symlink pre-planted at
-/// an artifact filename is replaced rather than followed. Whole-directory
-/// consistency across all stages is still only guaranteed by
-/// [`generate_all_circuit_binaries`]; prefer it unless you are deliberately
-/// regenerating one stage into an existing set.
-///
-/// Note: no `prover.bin` is emitted for the leaf circuit. `WormholeProver` always builds
-/// the (small, fast-to-build) leaf circuit from source; loading prover-only artifacts was
-/// removed because a poisoned artifact could exfiltrate private witness data through the
-/// proof's public-input list.
+/// Note: no `prover.bin` is emitted. `WormholeProver` always builds the leaf
+/// circuit from source so a poisoned prover artifact cannot exfiltrate
+/// witness data through the proof's public-input list.
 pub fn generate_circuit_binaries<P: AsRef<Path>>(output_dir: P) -> Result<()> {
     println!(
         "Building wormhole leaf circuit (non-ZK by design; ZK lives at the private-batch layer)..."
@@ -56,9 +48,6 @@ pub fn generate_circuit_binaries<P: AsRef<Path>>(output_dir: P) -> Result<()> {
 
     let output_path = output_dir.as_ref();
     create_dir_all(output_path)?;
-    // A previous publish hard-killed mid-swap leaves orphaned temp/backup
-    // entries behind; we are about to replace the set, so sweep them now.
-    wormhole_aggregator::common::utils::sweep_stale_artifact_droppings(output_path)?;
 
     // Generate dummy proof BEFORE consuming circuit_data (prove() borrows, prover_data() moves)
     println!("Generating dummy proof for aggregation padding...");
@@ -172,18 +161,9 @@ pub fn generate_all_circuit_binaries<P: AsRef<Path>>(
     commit_staging_dir(&staging_path, output_path)
 }
 
-/// Create the private staging directory that artifact generation writes into:
-/// a sibling of `output_dir` (same filesystem, so the final `rename` is
-/// atomic), created exclusively under an unpredictable name.
-///
-/// Exclusive `create_dir` (create-new semantics) is the symlink-safety
-/// guarantee: `mkdir` refuses to follow a symlink at the final component and
-/// fails if anything already exists at the path, so a local attacker with
-/// write access to the output parent can never get a pre-planted symlink (or
-/// a directory seeded with artifact-name symlinks) adopted as the staging
-/// dir and redirect the builder's `std::fs::write` calls onto arbitrary
-/// files. The random suffix makes the path unpredictable, so a planted entry
-/// cannot even force an error, and the pid keeps stale leftovers attributable.
+/// Create a private staging directory next to `output_dir` (same filesystem
+/// so the final `rename` is atomic), under an unpredictable name to avoid
+/// colliding with a concurrent builder or leftover from a crashed run.
 fn create_staging_dir(output_dir: &Path) -> Result<PathBuf> {
     let Some(name) = output_dir.file_name().and_then(|n| n.to_str()) else {
         bail!(
@@ -201,8 +181,6 @@ fn create_staging_dir(output_dir: &Path) -> Result<PathBuf> {
             })?;
         }
     }
-    // A few attempts are plenty: a collision requires an identical 64-bit
-    // random suffix to appear in the same parent under the same pid.
     for _ in 0..8 {
         let candidate = output_dir.with_file_name(format!(
             ".{}.staging-{}-{:016x}",
@@ -228,132 +206,44 @@ fn create_staging_dir(output_dir: &Path) -> Result<PathBuf> {
     );
 }
 
-/// Identity of a plain directory we intend to publish, captured via
-/// `symlink_metadata` so a symlink-at-that-path never counts as a directory.
-/// On Unix we also pin `(dev, ino)` so a TOCTOU replacement of the staging
-/// path with a different directory (or symlink) between the check and
-/// `rename` is detectable after publication.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct PlainDirId {
-    #[cfg(unix)]
-    dev: u64,
-    #[cfg(unix)]
-    ino: u64,
-}
-
-fn plain_dir_id(path: &Path) -> Result<PlainDirId> {
-    let meta = fs::symlink_metadata(path).with_context(|| {
-        format!("failed to inspect artifact path {}", path.display())
-    })?;
-    // `symlink_metadata` + `is_dir` rejects symlinks even when their target
-    // is a directory — that is the whole point of the staging-path check.
-    if !meta.is_dir() {
-        bail!(
-            "artifact path {} is not a plain directory (symlink or file)",
-            path.display()
-        );
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        Ok(PlainDirId {
-            dev: meta.dev(),
-            ino: meta.ino(),
-        })
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = meta;
-        Ok(PlainDirId {})
-    }
-}
-
-/// Remove a just-published path that failed the post-rename identity check.
-/// It may be a symlink (the TOCTOU attack), a file, or a wrong directory.
-fn remove_bad_publish_path(path: &Path) -> std::io::Result<()> {
-    let meta = match fs::symlink_metadata(path) {
-        Ok(m) => m,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => return Err(e),
-    };
-    if meta.file_type().is_symlink() || meta.is_file() {
-        fs::remove_file(path)
-    } else {
-        fs::remove_dir_all(path)
-    }
-}
-
 /// Replace `output_dir` with the fully staged `staging_dir` via directory
-/// renames. `rename` cannot overwrite a non-empty directory, so a pre-existing
-/// output dir is first moved aside, then removed after the swap. A crash
-/// between the renames leaves the old set aside and the new set staged — never
-/// a directory mixing files from both generations.
+/// renames. A pre-existing output dir is moved aside, then removed after the
+/// swap. Whole-directory staging is operator hygiene against mixed leaf /
+/// private-batch / public-batch generations — not a local-FS adversary
+/// defense (see `wormhole/THREAT_MODEL.md`).
 ///
-/// Failure cleanup never deletes the only surviving artifact copy: if the
-/// swap-in fails after the previous set was moved aside, the previous set is
-/// rolled back into place (and only then is the redundant staged copy
-/// removed); if even the rollback fails, both copies are left on disk and the
-/// error reports their locations.
-///
-/// After the staged directory has been renamed into `output_dir`, the publish
-/// has succeeded: failing to delete the moved-aside previous copy is reported
-/// as a warning, not as command failure. Conflating that cleanup with publish
-/// success made automation treat a live, complete artifact update as a failed
-/// run (false rollback / retry / alert) whenever the old path was not a
-/// recursively-removable directory (audit finding).
-///
-/// Symlink / inode TOCTOU: a single `symlink_metadata` check before `rename`
-/// is not atomic with the rename's pathname lookup. A local attacker who can
-/// write the output parent could replace the staging directory with a symlink
-/// after the check and have that symlink published as `output_dir` while the
-/// previous artifact set is deleted. We pin the staging directory's identity,
-/// re-validate it immediately before the rename, and require the same identity
-/// at `output_dir` afterward — rolling back (and refusing success) on mismatch
-/// (audit finding).
+/// After a successful swap-in, failing to delete the moved-aside previous
+/// copy is reported as a warning, not as command failure.
 fn commit_staging_dir(staging_dir: &Path, output_dir: &Path) -> Result<()> {
     commit_staging_dir_impl(staging_dir, output_dir, |src, dst| fs::rename(src, dst))
 }
 
-/// [`commit_staging_dir`] with an injectable rename, so tests can force a
-/// failure at each step of the swap and assert the cleanup guarantees.
+/// [`commit_staging_dir`] with an injectable rename for rollback tests.
 fn commit_staging_dir_impl(
     staging_dir: &Path,
     output_dir: &Path,
     rename: impl Fn(&Path, &Path) -> std::io::Result<()>,
 ) -> Result<()> {
-    // Pin the staging directory's identity up front. Renaming a symlink into
-    // place would hand out an artifact dir whose contents remain mutable by
-    // whoever owns the link target.
-    let staging_id = plain_dir_id(staging_dir).with_context(|| {
-        format!(
-            "staged artifact path {} is not a plain directory; \
-             refusing to publish it as the artifact dir",
+    if !staging_dir.is_dir() {
+        bail!(
+            "staged artifact path {} is not a directory; refusing to publish",
             staging_dir.display()
-        )
-    })?;
+        );
+    }
 
     let mut old_name = staging_dir.file_name().unwrap_or_default().to_os_string();
     old_name.push(".old");
     let old_path = staging_dir.with_file_name(old_name);
     let previous_exists = output_dir.exists();
     if previous_exists {
-        // Refuse to treat a file or symlink as the previous artifact set:
-        // `--output` is a directory, and moving a non-directory aside would
-        // leave `remove_dir_all` unable to clean it up after a successful
-        // publish (the exact cleanup/success conflation this function avoids).
-        if let Err(e) = plain_dir_id(output_dir) {
+        if !output_dir.is_dir() {
             let _ = fs::remove_dir_all(staging_dir);
-            return Err(e).context(format!(
-                "output path {} exists but is not a plain directory (symlink or file); \
-                 refusing to treat it as the previous artifact set — remove or rename \
-                 it and retry",
+            bail!(
+                "output path {} exists but is not a directory; remove or rename it and retry",
                 output_dir.display()
-            ));
+            );
         }
-
         if let Err(e) = rename(output_dir, &old_path) {
-            // Nothing has moved: the previous set still serves from
-            // output_dir, so the staged copy is safe to discard.
             let _ = fs::remove_dir_all(staging_dir);
             return Err(e).with_context(|| {
                 format!(
@@ -365,39 +255,10 @@ fn commit_staging_dir_impl(
         }
     }
 
-    // Re-validate immediately before the rename's pathname lookup. Still not
-    // fully atomic with the rename, but shrinks the race; the post-rename
-    // identity check below is what makes a won race fail closed.
-    let staging_id_pre_rename = plain_dir_id(staging_dir).with_context(|| {
-        format!(
-            "staged artifact path {} was replaced after the initial check \
-             (no longer a plain directory); refusing to publish",
-            staging_dir.display()
-        )
-    })?;
-    if staging_id_pre_rename != staging_id {
-        // A different directory now sits at the staging path. Do not publish
-        // it; restore any moved-aside previous set first.
-        if previous_exists {
-            let _ = rename(&old_path, output_dir);
-        }
-        let _ = fs::remove_dir_all(staging_dir);
-        bail!(
-            "staged artifact path {} was replaced with a different directory \
-             before publish; refusing to publish attacker-controlled contents",
-            staging_dir.display()
-        );
-    }
-
     if let Err(e) = rename(staging_dir, output_dir) {
-        // The previous set (if any) has been moved aside and output_dir is
-        // empty, so the staged directory may hold the ONLY copy of the new
-        // artifacts — never delete it before restoring something to
-        // output_dir.
         if previous_exists {
             match rename(&old_path, output_dir) {
                 Ok(()) => {
-                    // Previous set restored; the staged copy is redundant.
                     let _ = fs::remove_dir_all(staging_dir);
                     return Err(e).with_context(|| {
                         format!(
@@ -424,8 +285,6 @@ fn commit_staging_dir_impl(
                 }
             }
         }
-        // No previous set existed: the staged directory is the only copy of
-        // the artifacts at all; leave it for the operator.
         return Err(e).with_context(|| {
             format!(
                 "Failed to move staged artifacts {} into place at {}; \
@@ -437,51 +296,7 @@ fn commit_staging_dir_impl(
         });
     }
 
-    // Close the check-then-rename TOCTOU: the path published at output_dir
-    // must be the same plain directory inode we staged. If an attacker swapped
-    // in a symlink (or another directory) between the pre-rename check and
-    // rename's lookup, detect it here and roll back before declaring success
-    // or deleting the previous artifact set.
-    match plain_dir_id(output_dir) {
-        Ok(published_id) if published_id == staging_id => {}
-        Ok(_) | Err(_) => {
-            let _ = remove_bad_publish_path(output_dir);
-            if previous_exists {
-                match rename(&old_path, output_dir) {
-                    Ok(()) => {
-                        bail!(
-                            "published path {} was not the staged artifact directory \
-                             (replaced by a symlink or different directory during \
-                             rename); previous artifacts were restored",
-                            output_dir.display()
-                        );
-                    }
-                    Err(rollback_err) => {
-                        bail!(
-                            "published path {} was not the staged artifact directory \
-                             (replaced during rename), and restoring the previous \
-                             artifacts also failed ({}); previous artifacts remain at {}",
-                            output_dir.display(),
-                            rollback_err,
-                            old_path.display()
-                        );
-                    }
-                }
-            }
-            bail!(
-                "published path {} was not the staged artifact directory \
-                 (replaced by a symlink or different directory during rename); \
-                 refusing to treat the publish as successful",
-                output_dir.display()
-            );
-        }
-    }
-
     if previous_exists {
-        // The new set is already live at output_dir. Cleanup of the moved-aside
-        // previous copy must not flip the command to failure: operators and CI
-        // that key off the exit code would otherwise rerun expensive generation
-        // or roll back despite a successful publish (audit finding).
         if let Err(e) = fs::remove_dir_all(&old_path) {
             eprintln!(
                 "warning: published artifacts to {}, but failed to remove the previous \
@@ -507,9 +322,8 @@ mod tests {
         ))
     }
 
-    /// `--output` is a directory. A file (or symlink) planted at that path
-    /// must be rejected before the swap, not moved aside and then left as a
-    /// non-directory `.old` that `remove_dir_all` cannot clean (audit finding).
+    /// `--output` must be a directory; a file at that path is rejected before
+    /// the swap (operator hygiene, not local-FS adversary defense).
     #[test]
     fn commit_rejects_non_directory_previous_output() {
         let root = unique_tmp_dir("commit-not-dir");
@@ -523,7 +337,7 @@ mod tests {
 
         let err = commit_staging_dir(&staging, &output).unwrap_err();
         assert!(
-            format!("{err:#}").contains("not a plain directory"),
+            format!("{err:#}").contains("not a directory"),
             "got: {err:#}"
         );
         assert_eq!(
@@ -637,217 +451,6 @@ mod tests {
         commit_staging_dir(&staging, &output).unwrap();
         assert!(output.join("fresh.bin").exists());
         assert!(!staging.exists());
-
-        fs::remove_dir_all(&root).unwrap();
-    }
-
-    /// Staging paths must be minted fresh on every call (exclusive creation
-    /// under an unpredictable name), never re-derived from the pid alone: a
-    /// predictable path is what lets a local attacker pre-create it.
-    #[test]
-    fn create_staging_dir_mints_a_fresh_unique_directory_per_call() {
-        let root = unique_tmp_dir("staging-fresh");
-        let _ = fs::remove_dir_all(&root);
-        create_dir_all(&root).unwrap();
-        let output = root.join("bins");
-
-        let a = create_staging_dir(&output).unwrap();
-        let b = create_staging_dir(&output).unwrap();
-        assert_ne!(
-            a, b,
-            "staging paths must be unique per call, not a pid-only derivation"
-        );
-        for dir in [&a, &b] {
-            let meta = fs::symlink_metadata(dir).unwrap();
-            assert!(
-                meta.is_dir() && !meta.file_type().is_symlink(),
-                "staging path must be a freshly created real directory"
-            );
-            assert_eq!(
-                dir.parent(),
-                Some(root.as_path()),
-                "staging dir must stay a sibling of the output dir"
-            );
-            assert!(dir
-                .file_name()
-                .unwrap()
-                .to_str()
-                .unwrap()
-                .starts_with(".bins.staging-"));
-        }
-
-        fs::remove_dir_all(&root).unwrap();
-    }
-
-    /// A local attacker with write access to the output parent plants a
-    /// symlink at the predictable staging path. The builder must not adopt it:
-    /// artifact writes would land in attacker-controlled storage.
-    #[cfg(unix)]
-    #[test]
-    fn create_staging_dir_does_not_adopt_a_planted_symlink() {
-        let root = unique_tmp_dir("staging-symlink");
-        let _ = fs::remove_dir_all(&root);
-        create_dir_all(&root).unwrap();
-        let output = root.join("bins");
-        let attacker_target = root.join("attacker-target");
-        create_dir_all(&attacker_target).unwrap();
-
-        // The historical (predictable) staging name: .<name>.staging-<pid>.
-        let planted = output.with_file_name(format!(".bins.staging-{}", std::process::id()));
-        std::os::unix::fs::symlink(&attacker_target, &planted).unwrap();
-
-        let staging = create_staging_dir(&output).unwrap();
-        let meta = fs::symlink_metadata(&staging).unwrap();
-        assert!(
-            meta.is_dir() && !meta.file_type().is_symlink(),
-            "staging dir must be a freshly created real directory, not the planted symlink"
-        );
-        write(staging.join("probe.bin"), b"artifact").unwrap();
-        assert!(
-            !attacker_target.join("probe.bin").exists(),
-            "artifact writes must not land in attacker-controlled storage"
-        );
-
-        fs::remove_dir_all(&root).unwrap();
-    }
-
-    /// The commit phase must refuse to publish a staging path that is not a
-    /// plain directory: renaming a symlink into place would hand out an
-    /// artifact dir whose contents remain attacker-mutable.
-    #[cfg(unix)]
-    #[test]
-    fn commit_refuses_to_publish_a_symlinked_staging_dir() {
-        let root = unique_tmp_dir("commit-symlink");
-        let _ = fs::remove_dir_all(&root);
-        create_dir_all(&root).unwrap();
-        let output = root.join("bins");
-        let attacker_target = root.join("attacker-target");
-        create_dir_all(&attacker_target).unwrap();
-        write(attacker_target.join("fresh.bin"), b"attacker mutable").unwrap();
-        let staging = root.join(".bins.staging-evil");
-        std::os::unix::fs::symlink(&attacker_target, &staging).unwrap();
-
-        let err = commit_staging_dir(&staging, &output).unwrap_err();
-        assert!(
-            format!("{err:#}").contains("not a plain directory"),
-            "got: {err:#}"
-        );
-        assert!(
-            fs::symlink_metadata(&output).is_err(),
-            "a symlinked staging path must never be published as the artifact dir"
-        );
-
-        fs::remove_dir_all(&root).unwrap();
-    }
-
-    /// TOCTOU (audit finding): the pre-rename plain-directory check and the
-    /// `rename` pathname lookup are separate. A local attacker who replaces
-    /// the staging directory with a symlink in that window must not get a
-    /// successful publish that leaves `--output` as attacker-mutable storage
-    /// while the previous artifact set is deleted. The post-rename inode /
-    /// type check must fail closed and restore the previous set.
-    #[cfg(unix)]
-    #[test]
-    fn commit_rolls_back_if_staging_replaced_by_symlink_during_rename() {
-        let root = unique_tmp_dir("commit-toctou-symlink");
-        let _ = fs::remove_dir_all(&root);
-        create_dir_all(&root).unwrap();
-        let output = root.join("bins");
-        let staging = create_staging_dir(&output).unwrap();
-
-        create_dir_all(&output).unwrap();
-        write(output.join("previous.bin"), b"previous").unwrap();
-        write(staging.join("fresh.bin"), b"fresh").unwrap();
-
-        let attacker_target = root.join("attacker-target");
-        create_dir_all(&attacker_target).unwrap();
-        write(attacker_target.join("evil.bin"), b"attacker mutable").unwrap();
-
-        let staging_src = staging.clone();
-        let attacker = attacker_target.clone();
-        let err = commit_staging_dir_impl(&staging, &output, |src, dst| {
-            if src == staging_src {
-                // Win the race at rename time: drop our staging dir and plant
-                // a symlink under the same path, then rename that symlink.
-                let _ = fs::remove_dir_all(src);
-                std::os::unix::fs::symlink(&attacker, src)?;
-                fs::rename(src, dst)
-            } else {
-                fs::rename(src, dst)
-            }
-        })
-        .unwrap_err();
-
-        let msg = format!("{err:#}");
-        assert!(
-            msg.contains("not the staged artifact directory")
-                || msg.contains("previous artifacts were restored"),
-            "got: {msg}"
-        );
-        assert!(
-            output.join("previous.bin").exists(),
-            "previous artifact set must be restored after a TOCTOU publish attempt"
-        );
-        assert!(
-            !output.join("evil.bin").exists(),
-            "attacker-controlled contents must not remain published at output_dir"
-        );
-        let out_meta = fs::symlink_metadata(&output).unwrap();
-        assert!(
-            out_meta.is_dir() && !out_meta.file_type().is_symlink(),
-            "output_dir must be a plain directory again after rollback"
-        );
-
-        fs::remove_dir_all(&root).unwrap();
-    }
-
-    /// Same TOCTOU window, but the replacement is a different plain directory
-    /// (different inode). Publishing it would still hand the attacker a
-    /// successful exit with contents they control; the inode pin must reject it.
-    #[cfg(unix)]
-    #[test]
-    fn commit_rolls_back_if_staging_replaced_by_different_directory_during_rename() {
-        let root = unique_tmp_dir("commit-toctou-dir");
-        let _ = fs::remove_dir_all(&root);
-        create_dir_all(&root).unwrap();
-        let output = root.join("bins");
-        let staging = create_staging_dir(&output).unwrap();
-
-        create_dir_all(&output).unwrap();
-        write(output.join("previous.bin"), b"previous").unwrap();
-        write(staging.join("fresh.bin"), b"fresh").unwrap();
-
-        let attacker_dir = root.join("attacker-dir");
-        create_dir_all(&attacker_dir).unwrap();
-        write(attacker_dir.join("evil.bin"), b"attacker mutable").unwrap();
-
-        let staging_src = staging.clone();
-        let attacker = attacker_dir.clone();
-        let err = commit_staging_dir_impl(&staging, &output, |src, dst| {
-            if src == staging_src {
-                let _ = fs::remove_dir_all(src);
-                // Move the attacker's directory onto the staging path (same
-                // parent, so rename is atomic) then publish that inode.
-                fs::rename(&attacker, src)?;
-                fs::rename(src, dst)
-            } else {
-                fs::rename(src, dst)
-            }
-        })
-        .unwrap_err();
-
-        assert!(
-            format!("{err:#}").contains("not the staged artifact directory"),
-            "got: {err:#}"
-        );
-        assert!(
-            output.join("previous.bin").exists(),
-            "previous artifact set must be restored"
-        );
-        assert!(
-            !output.join("evil.bin").exists(),
-            "attacker directory must not remain published"
-        );
 
         fs::remove_dir_all(&root).unwrap();
     }
@@ -979,42 +582,6 @@ mod tests {
         assert!(format!("{err:#}").contains("move previous"), "got: {err:#}");
         assert!(output.join("previous.bin").exists());
         assert!(!staging.exists());
-
-        fs::remove_dir_all(&root).unwrap();
-    }
-
-    /// A symlink pre-planted at an artifact filename must not redirect the
-    /// write onto its target: `std::fs::write` follows symlinks and truncates,
-    /// so an attacker with write access to the output directory could make the
-    /// builder clobber any file writable by the invoking account (audit
-    /// finding: symlink-following artifact writes). Publishing must replace
-    /// the planted entry itself and leave the victim untouched.
-    #[cfg(unix)]
-    #[test]
-    fn leaf_artifact_writes_do_not_follow_planted_symlinks() {
-        let root = unique_tmp_dir("symlink-clobber");
-        let _ = fs::remove_dir_all(&root);
-        let output = root.join("bins");
-        create_dir_all(&output).unwrap();
-
-        let victim = root.join("victim.txt");
-        write(&victim, b"precious data").unwrap();
-        std::os::unix::fs::symlink(&victim, output.join("common.bin")).unwrap();
-
-        let result = generate_circuit_binaries(&output);
-
-        assert_eq!(
-            fs::read(&victim).unwrap(),
-            b"precious data",
-            "artifact publication must never write through a planted symlink"
-        );
-        if result.is_ok() {
-            let common = fs::read(output.join("common.bin")).unwrap();
-            assert_ne!(
-                common, b"precious data",
-                "a successful run must have replaced the planted entry with a real artifact"
-            );
-        }
 
         fs::remove_dir_all(&root).unwrap();
     }

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -227,6 +227,13 @@ fn create_staging_dir(output_dir: &Path) -> Result<PathBuf> {
 /// rolled back into place (and only then is the redundant staged copy
 /// removed); if even the rollback fails, both copies are left on disk and the
 /// error reports their locations.
+///
+/// After the staged directory has been renamed into `output_dir`, the publish
+/// has succeeded: failing to delete the moved-aside previous copy is reported
+/// as a warning, not as command failure. Conflating that cleanup with publish
+/// success made automation treat a live, complete artifact update as a failed
+/// run (false rollback / retry / alert) whenever the old path was not a
+/// recursively-removable directory (audit finding).
 fn commit_staging_dir(staging_dir: &Path, output_dir: &Path) -> Result<()> {
     commit_staging_dir_impl(staging_dir, output_dir, |src, dst| fs::rename(src, dst))
 }
@@ -260,6 +267,26 @@ fn commit_staging_dir_impl(
     let old_path = staging_dir.with_file_name(old_name);
     let previous_exists = output_dir.exists();
     if previous_exists {
+        // Refuse to treat a file or symlink as the previous artifact set:
+        // `--output` is a directory, and moving a non-directory aside would
+        // leave `remove_dir_all` unable to clean it up after a successful
+        // publish (the exact cleanup/success conflation this function avoids).
+        let prev_meta = fs::symlink_metadata(output_dir).with_context(|| {
+            format!(
+                "failed to inspect previous artifact path {}",
+                output_dir.display()
+            )
+        })?;
+        if !prev_meta.is_dir() {
+            let _ = fs::remove_dir_all(staging_dir);
+            bail!(
+                "output path {} exists but is not a plain directory (symlink or file); \
+                 refusing to treat it as the previous artifact set — remove or rename \
+                 it and retry",
+                output_dir.display()
+            );
+        }
+
         if let Err(e) = rename(output_dir, &old_path) {
             // Nothing has moved: the previous set still serves from
             // output_dir, so the staged copy is safe to discard.
@@ -321,14 +348,18 @@ fn commit_staging_dir_impl(
         });
     }
     if previous_exists {
-        // The new set is already committed at output_dir; failing to clean up
-        // the old copy is an error but loses nothing.
-        fs::remove_dir_all(&old_path).with_context(|| {
-            format!(
-                "Failed to remove previous artifact dir {}",
+        // The new set is already live at output_dir. Cleanup of the moved-aside
+        // previous copy must not flip the command to failure: operators and CI
+        // that key off the exit code would otherwise rerun expensive generation
+        // or roll back despite a successful publish (audit finding).
+        if let Err(e) = fs::remove_dir_all(&old_path) {
+            eprintln!(
+                "warning: published artifacts to {}, but failed to remove the previous \
+                 artifact copy at {}: {e}; remove it manually if it is no longer needed",
+                output_dir.display(),
                 old_path.display()
-            )
-        })?;
+            );
+        }
     }
     Ok(())
 }
@@ -344,6 +375,98 @@ mod tests {
             tag,
             std::process::id()
         ))
+    }
+
+    /// `--output` is a directory. A file (or symlink) planted at that path
+    /// must be rejected before the swap, not moved aside and then left as a
+    /// non-directory `.old` that `remove_dir_all` cannot clean (audit finding).
+    #[test]
+    fn commit_rejects_non_directory_previous_output() {
+        let root = unique_tmp_dir("commit-not-dir");
+        let _ = fs::remove_dir_all(&root);
+        create_dir_all(&root).unwrap();
+        let output = root.join("bins");
+        let staging = create_staging_dir(&output).unwrap();
+
+        write(&output, b"i am a file").unwrap();
+        write(staging.join("fresh.bin"), b"new artifact").unwrap();
+
+        let err = commit_staging_dir(&staging, &output).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("not a plain directory"),
+            "got: {err:#}"
+        );
+        assert_eq!(
+            fs::read(&output).unwrap(),
+            b"i am a file",
+            "previous non-directory must be left untouched"
+        );
+        assert!(
+            !staging.exists(),
+            "rejected commit discards the (uncommitted) staged copy"
+        );
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// After the staged directory is renamed into place the publish has
+    /// succeeded. An undeletable moved-aside previous copy must not flip the
+    /// result to Err — CI/operators keying off the exit code would otherwise
+    /// treat a live artifact update as a failed run (audit finding).
+    #[cfg(unix)]
+    #[test]
+    fn successful_publish_is_not_failed_by_old_copy_cleanup() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = unique_tmp_dir("commit-cleanup-best-effort");
+        let _ = fs::remove_dir_all(&root);
+        create_dir_all(&root).unwrap();
+        let output = root.join("bins");
+        let staging = create_staging_dir(&output).unwrap();
+
+        create_dir_all(&output).unwrap();
+        write(output.join("stale.bin"), b"old artifact").unwrap();
+        // Nested dir without write permission: remove_dir_all cannot unlink
+        // its children once this tree is the moved-aside `.old` copy.
+        let locked = output.join("locked");
+        create_dir_all(&locked).unwrap();
+        write(locked.join("x.bin"), b"x").unwrap();
+        let mut perms = fs::metadata(&locked).unwrap().permissions();
+        perms.set_mode(0o555);
+        fs::set_permissions(&locked, perms).unwrap();
+
+        write(staging.join("fresh.bin"), b"new artifact").unwrap();
+
+        let result = commit_staging_dir(&staging, &output);
+        assert!(
+            result.is_ok(),
+            "publish must report success even when old-copy cleanup fails: {result:?}"
+        );
+        assert!(
+            output.join("fresh.bin").exists(),
+            "new artifacts must be live at output_dir"
+        );
+        assert!(
+            !output.join("stale.bin").exists(),
+            "stale contents must not remain in the published dir"
+        );
+
+        // Make any leftover `.old` tree deletable so the test cleans up.
+        for entry in fs::read_dir(&root).unwrap() {
+            let path = entry.unwrap().path();
+            let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if !name.ends_with(".old") {
+                continue;
+            }
+            let locked_old = path.join("locked");
+            if locked_old.exists() {
+                let mut p = fs::metadata(&locked_old).unwrap().permissions();
+                p.set_mode(0o755);
+                fs::set_permissions(&locked_old, p).unwrap();
+            }
+        }
+
+        fs::remove_dir_all(&root).unwrap();
     }
 
     /// The swap must replace stale contents wholesale, not merge into them.

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -136,7 +136,11 @@ pub fn generate_all_circuit_binaries<P: AsRef<Path>>(
 
         // If num_private_batch_proofs is specified, generate public-batch aggregation circuit binaries
         if let Some(num_private_batch_proofs) = config.num_private_batch_proofs {
-            generate_public_batch_circuit_binaries(&staging_path, num_private_batch_proofs)?;
+            generate_public_batch_circuit_binaries(
+                &staging_path,
+                num_private_batch_proofs,
+                config.num_leaf_proofs,
+            )?;
         }
 
         // Save config file alongside binaries. Written last: its presence marks

--- a/wormhole/circuit-builder/src/main.rs
+++ b/wormhole/circuit-builder/src/main.rs
@@ -1,3 +1,9 @@
+//! CLI entry point for trusted CI artifact generation.
+//!
+//! The build host and `--output` directory are trusted during this run; see
+//! `wormhole/THREAT_MODEL.md` for the full boundary (local FS adversary on the
+//! builder is out of scope).
+
 use anyhow::Result;
 use clap::Parser;
 use qp_wormhole_circuit_builder::generate_all_circuit_binaries;

--- a/wormhole/circuit/Cargo.toml
+++ b/wormhole/circuit/Cargo.toml
@@ -13,6 +13,7 @@ hex = { workspace = true, features = ["alloc"] }
 qp-plonky2 = { workspace = true }
 qp-wormhole-inputs = { version = "=3.1.0", path = "../inputs", default-features = false }
 zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common", default-features = false }
+zeroize = { workspace = true }
 
 [features]
 default = ["std"]

--- a/wormhole/circuit/Cargo.toml
+++ b/wormhole/circuit/Cargo.toml
@@ -12,8 +12,8 @@ anyhow = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 qp-plonky2 = { workspace = true }
 qp-wormhole-inputs = { version = "=3.1.0", path = "../inputs", default-features = false }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common", default-features = false }
 zeroize = { workspace = true }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=3.1.0", path = "../../common", default-features = false }
 
 [features]
 default = ["std"]

--- a/wormhole/circuit/src/inputs.rs
+++ b/wormhole/circuit/src/inputs.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::new_without_default)]
 use crate::block_header::header::DIGEST_LOGS_SIZE;
+use crate::sensitive::SensitiveDigest;
 use alloc::vec::Vec;
 use anyhow::{bail, Context};
 use plonky2::field::goldilocks_field::GoldilocksField;
@@ -22,7 +23,9 @@ pub use qp_wormhole_inputs::{
 };
 
 /// Inputs required to commit to the wormhole circuit.
-#[derive(Clone)]
+///
+/// Deliberately not `Clone`: `private.secret` is a move-only
+/// [`SensitiveDigest`], so the spend credential cannot be silently duplicated.
 pub struct CircuitInputs {
     pub public: PublicCircuitInputs,
     pub private: PrivateCircuitInputs,
@@ -38,10 +41,14 @@ impl core::fmt::Debug for CircuitInputs {
 }
 
 /// All of the private inputs required for the circuit.
-#[derive(Clone)]
+///
+/// Deliberately not `Clone`: `secret` is a move-only [`SensitiveDigest`]
+/// (zeroized on drop), so the spend credential cannot be silently duplicated.
 pub struct PrivateCircuitInputs {
-    /// Raw bytes of the secret of the nullifier and the unspendable account
-    pub secret: BytesDigest,
+    /// The secret of the nullifier and the unspendable account. Move-only and
+    /// zeroized on drop; duplication requires an explicit
+    /// [`SensitiveDigest::expose_digest`] call at the use site.
+    pub secret: SensitiveDigest,
     /// Transfer count for this recipient
     pub transfer_count: u64,
     /// The unspendable account hash (recipient of the transfer).
@@ -385,7 +392,7 @@ mod tests {
 
     #[test]
     fn private_circuit_inputs_debug_redacts_private_fields() {
-        let secret = BytesDigest::try_from([0xab; 32].as_slice()).unwrap();
+        let secret = SensitiveDigest::try_from([0xab; 32]).unwrap();
         let unspendable_account = BytesDigest::try_from([0xcd; 32].as_slice()).unwrap();
         let inputs = PrivateCircuitInputs {
             secret,

--- a/wormhole/circuit/src/lib.rs
+++ b/wormhole/circuit/src/lib.rs
@@ -1,4 +1,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+// This crate handles the raw spend secret; keep memory handling auditable by
+// construction. Scrubbing that needs volatile writes goes through the vetted
+// `zeroize` dependency instead of local `unsafe` (see `sensitive`).
+#![forbid(unsafe_code)]
 
 extern crate alloc;
 
@@ -8,6 +12,7 @@ pub mod inputs;
 pub mod nullifier;
 #[cfg(feature = "profile")]
 pub mod profile;
+pub mod sensitive;
 pub mod substrate_account;
 pub mod unspendable_account;
 pub mod zk_merkle_proof; // 4-ary Poseidon Merkle proof

--- a/wormhole/circuit/src/nullifier.rs
+++ b/wormhole/circuit/src/nullifier.rs
@@ -60,8 +60,9 @@ pub const PREIMAGE_NUM_TARGETS: usize =
 pub const NULLIFIER_SIZE_FELTS: usize =
     POSEIDON2_OUTPUT + SECRET_NUM_TARGETS + TRANSFER_COUNT_NUM_TARGETS;
 
-/// Type alias for the secret as a fixed-size array (4 field elements for 32 bytes)
-pub type Secret = Digest;
+/// The felt-encoded spend secret, zeroized on drop (shared with
+/// `unspendable_account`; see [`crate::sensitive`]).
+pub use crate::sensitive::Secret;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct Nullifier {
@@ -85,7 +86,7 @@ impl Nullifier {
     pub fn new(digest: BytesDigest, secret: BytesDigest, transfer_count: u64) -> Self {
         let hash = bytes_to_digest(digest);
         // Use 8 bytes/felt encoding.
-        let secret = bytes_to_digest(secret);
+        let secret = bytes_to_digest(secret).into();
         let transfer_count = u64_to_felts(transfer_count);
 
         Self {
@@ -113,7 +114,7 @@ impl Nullifier {
 
         Self {
             hash,
-            secret: secret_felts,
+            secret: secret_felts.into(),
             transfer_count: transfer_count_felts,
         }
     }
@@ -123,7 +124,7 @@ impl ByteCodec for Nullifier {
     fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.extend(*digest_to_bytes(self.hash));
-        bytes.extend(*digest_to_bytes(self.secret));
+        bytes.extend(*digest_to_bytes(self.secret.expose_felts()));
         let transfer_count_uint = felts_to_u64(self.transfer_count).unwrap();
         bytes.extend(transfer_count_uint.to_le_bytes());
         bytes
@@ -158,7 +159,7 @@ impl ByteCodec for Nullifier {
                 .map_err(|e| {
                     anyhow::anyhow!("Failed to deserialize nullifier secret with error: {:?}", e)
                 })?;
-        let secret = bytes_to_digest(secret_bytes);
+        let secret = bytes_to_digest(secret_bytes).into();
         offset += secret_size;
 
         // Deserialize transfer_count
@@ -187,7 +188,7 @@ impl FieldElementCodec for Nullifier {
     fn to_field_elements(&self) -> Vec<F> {
         let mut elements = Vec::new();
         elements.extend(self.hash.to_vec());
-        elements.extend(self.secret);
+        elements.extend(self.secret.expose_felts());
         elements.extend(self.transfer_count);
         elements
     }
@@ -209,9 +210,10 @@ impl FieldElementCodec for Nullifier {
         offset += POSEIDON2_OUTPUT;
 
         // Deserialize secret (4 field elements)
-        let secret: Secret = elements[offset..offset + SECRET_NUM_TARGETS]
+        let secret_felts: Digest = elements[offset..offset + SECRET_NUM_TARGETS]
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to deserialize nullifier secret"))?;
+        let secret = Secret::from(secret_felts);
         offset += SECRET_NUM_TARGETS;
 
         // Deserialize transfer_count, enforcing the 32-bit limb invariant so a
@@ -232,9 +234,11 @@ impl FieldElementCodec for Nullifier {
 
 impl From<&CircuitInputs> for Nullifier {
     fn from(inputs: &CircuitInputs) -> Self {
+        // Explicit, transient duplication of the secret: it is immediately
+        // felt-encoded into `self.secret`, which scrubs itself on drop.
         Self::new(
             inputs.public.nullifier,
-            inputs.private.secret,
+            inputs.private.secret.expose_digest(),
             inputs.private.transfer_count,
         )
     }
@@ -326,7 +330,7 @@ impl CircuitFragment for Nullifier {
         targets: Self::Targets,
     ) -> anyhow::Result<()> {
         pw.set_hash_target(targets.hash, self.hash.into())?;
-        pw.set_hash_target(targets.secret, self.secret.into())?;
+        pw.set_hash_target(targets.secret, self.secret.expose_felts().into())?;
         pw.set_target_arr(&targets.transfer_count, &self.transfer_count)?;
         Ok(())
     }

--- a/wormhole/circuit/src/sensitive.rs
+++ b/wormhole/circuit/src/sensitive.rs
@@ -1,0 +1,188 @@
+//! Move-only, zeroize-on-drop wrappers for the Wormhole spend secret.
+//!
+//! This imitates `SensitiveBytes32` from `qp-rusty-crystals` (see
+//! `WormholePair` in the hdwallet crate, which already keeps the secret in
+//! such a wrapper). The protection was previously lost at the hand-off into
+//! this repository, where the secret degraded into a `Copy` [`BytesDigest`]
+//! inside a `Clone`-able `PrivateCircuitInputs`: any move or field access
+//! could silently duplicate the spend credential into stack frames, logs, or
+//! crash dumps that no drop-time scrub can reach.
+//!
+//! Two wrappers cover the secret's two encodings:
+//!
+//! - [`SensitiveDigest`]: the 32-byte form held by `PrivateCircuitInputs`.
+//! - [`Secret`]: the felt-encoded form (4 felts, 8 bytes/felt) held by
+//!   `Nullifier` and `UnspendableAccount` for witness filling.
+//!
+//! Shared properties:
+//!
+//! - **Zeroized on drop** via the [`zeroize`] crate, whose writes the
+//!   optimizer cannot elide. This crate is `#![forbid(unsafe_code)]`, so the
+//!   volatile scrubbing lives in that vetted dependency.
+//! - **No `Debug`**: a container that derives `Debug` over these fields fails
+//!   to compile, forcing a redacting manual impl instead.
+//! - Duplication out of a wrapper requires an explicitly named `expose_*`
+//!   call, making every copy searchable and visible in review.
+//!   [`SensitiveDigest`] is additionally move-only (no `Clone`).
+//!
+//! # Scope
+//!
+//! These wrappers cover the copies *we* own. Transient stack copies made
+//! while encoding the secret into field elements, and the copies plonky2
+//! keeps inside `PartialWitness`/`ProverCircuitData` during proving, are out
+//! of scope here (the latter requires upstream support to scrub).
+
+use plonky2::field::types::{Field, PrimeField64};
+use zeroize::Zeroize;
+use zk_circuits_common::circuit::F;
+use zk_circuits_common::utils::{
+    BytesDigest, Digest, DigestError, DIGEST_BYTES_LEN, POSEIDON2_OUTPUT,
+};
+
+/// The Wormhole spend secret: a validated 32-byte digest that is move-only
+/// and zeroized on drop.
+///
+/// Construction validates the same invariant as [`BytesDigest`] (every 8-byte
+/// limb is a canonical Goldilocks element), so [`SensitiveDigest::expose_digest`]
+/// can rebuild a `BytesDigest` without re-validation.
+pub struct SensitiveDigest([u8; DIGEST_BYTES_LEN]);
+
+impl SensitiveDigest {
+    /// Takes practical ownership of the secret: validates it, moves it into
+    /// the wrapper, and zeroizes the source bytes so no copy remains at the
+    /// call site (also on validation failure — an invalid secret is useless
+    /// to the caller anyway).
+    pub fn new(bytes: &mut [u8; DIGEST_BYTES_LEN]) -> Result<Self, DigestError> {
+        let validated = BytesDigest::try_from(*bytes);
+        let result = validated.map(|digest| Self(*digest));
+        bytes.zeroize();
+        result
+    }
+
+    /// Borrow the raw secret bytes.
+    pub fn as_bytes(&self) -> &[u8; DIGEST_BYTES_LEN] {
+        &self.0
+    }
+
+    /// Explicitly duplicate the secret as a `Copy` [`BytesDigest`].
+    ///
+    /// The returned value escapes this wrapper's zeroization, so keep it
+    /// transient: encode it and let it go out of scope. The deliberate name
+    /// makes every such duplication searchable and visible in review.
+    pub fn expose_digest(&self) -> BytesDigest {
+        // Validated at construction, so unchecked reconstruction is sound.
+        BytesDigest::new_unchecked(self.0)
+    }
+}
+
+/// Convenience for call sites that already hold a validated digest (tests,
+/// dummy proofs). Note `BytesDigest` is `Copy`: this cannot scrub the
+/// caller's original, so real secrets should enter via
+/// [`SensitiveDigest::new`] instead.
+impl From<BytesDigest> for SensitiveDigest {
+    fn from(digest: BytesDigest) -> Self {
+        Self(*digest)
+    }
+}
+
+/// Convenience for literals in tests and docs. Does not scrub the source
+/// array; real secrets should enter via [`SensitiveDigest::new`].
+impl TryFrom<[u8; DIGEST_BYTES_LEN]> for SensitiveDigest {
+    type Error = DigestError;
+
+    fn try_from(bytes: [u8; DIGEST_BYTES_LEN]) -> Result<Self, Self::Error> {
+        BytesDigest::try_from(bytes).map(Self::from)
+    }
+}
+
+impl Drop for SensitiveDigest {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+/// The felt-encoded spend secret (4 felts, 8 bytes/felt), zeroized on drop.
+///
+/// This is the in-circuit encoding counterpart of [`SensitiveDigest`]: the
+/// same 32-byte secret after `bytes_to_digest`, as held by `Nullifier` and
+/// `UnspendableAccount` for witness filling. It replaces the two identical
+/// `type Secret = [F; 4]` aliases those modules used to declare.
+///
+/// The limbs are stored as canonical `u64`s rather than `GoldilocksField`
+/// values because the field type is foreign and has no [`Zeroize`] impl;
+/// storing plain integers lets the vetted `zeroize` crate do the drop-time
+/// scrub without local `unsafe` (which this crate forbids). Conversion is
+/// lossless: the felts are
+/// canonicalized on the way in and rebuilt with `from_canonical_u64` on the
+/// way out.
+///
+/// Unlike [`SensitiveDigest`] this is `Clone`: the containing types need
+/// value semantics for their codecs, and every clone scrubs itself on drop,
+/// so duplication never escapes the zeroization invariant. Reading the felts
+/// out requires the explicitly named [`Secret::expose_felts`], and there is
+/// no `Debug` impl, so containers must redact it manually.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Secret([u64; POSEIDON2_OUTPUT]);
+
+impl Secret {
+    /// Explicitly duplicate the secret as plain `Copy` felts.
+    ///
+    /// The returned array escapes this wrapper's zeroization, so keep it
+    /// transient: encode it and let it go out of scope. The deliberate name
+    /// makes every such duplication searchable and visible in review.
+    pub fn expose_felts(&self) -> Digest {
+        self.0.map(F::from_canonical_u64)
+    }
+}
+
+/// Note the source `Digest` is `Copy`, so this cannot scrub the caller's
+/// original; the felts should be transient at the call site.
+impl From<Digest> for Secret {
+    fn from(felts: Digest) -> Self {
+        Self(felts.map(|f| f.to_canonical_u64()))
+    }
+}
+
+impl Drop for Secret {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_validates_and_zeroizes_source() {
+        let mut source = [0x11u8; 32];
+        let sensitive = SensitiveDigest::new(&mut source).unwrap();
+        assert_eq!(source, [0u8; 32], "source must be scrubbed");
+        assert_eq!(sensitive.as_bytes(), &[0x11u8; 32]);
+        assert_eq!(*sensitive.expose_digest(), [0x11u8; 32]);
+    }
+
+    #[test]
+    fn new_zeroizes_source_even_on_invalid_digest() {
+        // All-0xFF limbs are >= the Goldilocks modulus, so validation fails.
+        let mut source = [0xFFu8; 32];
+        assert!(SensitiveDigest::new(&mut source).is_err());
+        assert_eq!(source, [0u8; 32], "source must be scrubbed on failure too");
+    }
+
+    /// Guards against the `Drop` impls (the zeroization hook) being removed:
+    /// a plain byte/int array needs no drop glue, so `needs_drop` is `true`
+    /// for these types only while their scrubbing destructors exist.
+    #[test]
+    fn wrappers_have_drop_glue() {
+        assert!(core::mem::needs_drop::<SensitiveDigest>());
+        assert!(core::mem::needs_drop::<Secret>());
+    }
+
+    #[test]
+    fn secret_felts_round_trip() {
+        let felts: Digest = [1u64, 2, 3, u32::MAX as u64].map(F::from_canonical_u64);
+        let secret = Secret::from(felts);
+        assert_eq!(secret.expose_felts(), felts);
+    }
+}

--- a/wormhole/circuit/src/unspendable_account.rs
+++ b/wormhole/circuit/src/unspendable_account.rs
@@ -21,8 +21,9 @@ pub const ACCOUNT_ID_NUM_TARGETS: usize = POSEIDON2_OUTPUT; // 4
 pub const PREIMAGE_NUM_TARGETS: usize = 7;
 pub const UNSPENDABLE_SALT: &str = "wormhole";
 
-/// Type alias for the secret as a fixed-size array (4 felts, 8 bytes/felt)
-pub type Secret = [F; SECRET_NUM_TARGETS];
+/// The felt-encoded spend secret, zeroized on drop (shared with `nullifier`;
+/// see [`crate::sensitive`]).
+pub use crate::sensitive::Secret;
 
 #[derive(PartialEq, Eq, Clone)]
 pub struct UnspendableAccount {
@@ -50,7 +51,7 @@ impl UnspendableAccount {
         // Account ID uses 8 bytes/felt encoding (hash output)
         let account_id = bytes_to_digest(account_id);
         // Secret uses 8 bytes/felt encoding.
-        let secret = bytes_to_digest(secret);
+        let secret = bytes_to_digest(secret).into();
         Self { account_id, secret }
     }
 
@@ -79,7 +80,7 @@ impl UnspendableAccount {
 
         Self {
             account_id: outer_hash,
-            secret: secret_felts,
+            secret: secret_felts.into(),
         }
     }
 }
@@ -88,7 +89,7 @@ impl ByteCodec for UnspendableAccount {
     fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.extend(*digest_to_bytes(self.account_id));
-        bytes.extend(*digest_to_bytes(self.secret));
+        bytes.extend(*digest_to_bytes(self.secret.expose_felts()));
         bytes
     }
 
@@ -115,7 +116,7 @@ impl ByteCodec for UnspendableAccount {
         let secret_bytes: BytesDigest = slice[account_id_size..total_size]
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to deserialize unspendable account secret"))?;
-        let secret = bytes_to_digest(secret_bytes);
+        let secret = bytes_to_digest(secret_bytes).into();
 
         Ok(Self { account_id, secret })
     }
@@ -125,7 +126,7 @@ impl FieldElementCodec for UnspendableAccount {
     fn to_field_elements(&self) -> Vec<F> {
         let mut elements = Vec::new();
         elements.extend(self.account_id.to_vec());
-        elements.extend(self.secret);
+        elements.extend(self.secret.expose_felts());
         elements
     }
 
@@ -149,9 +150,10 @@ impl FieldElementCodec for UnspendableAccount {
             .map_err(|_| anyhow::anyhow!("Failed to deserialize unspendable account id"))?;
 
         // Deserialize secret (4 field elements)
-        let secret: Secret = elements[account_id_size..total_size]
+        let secret_felts: Digest = elements[account_id_size..total_size]
             .try_into()
             .map_err(|_| anyhow::anyhow!("Failed to deserialize unspendable account secret"))?;
+        let secret = Secret::from(secret_felts);
 
         Ok(Self { account_id, secret })
     }
@@ -159,7 +161,12 @@ impl FieldElementCodec for UnspendableAccount {
 
 impl From<&CircuitInputs> for UnspendableAccount {
     fn from(inputs: &CircuitInputs) -> Self {
-        Self::new(inputs.private.unspendable_account, inputs.private.secret)
+        // Explicit, transient duplication of the secret: it is immediately
+        // felt-encoded into `self.secret`, which scrubs itself on drop.
+        Self::new(
+            inputs.private.unspendable_account,
+            inputs.private.secret.expose_digest(),
+        )
     }
 }
 
@@ -216,7 +223,7 @@ impl CircuitFragment for UnspendableAccount {
         targets: Self::Targets,
     ) -> anyhow::Result<()> {
         pw.set_hash_target(targets.account_id, self.account_id.into())?;
-        pw.set_hash_target(targets.secret, self.secret.into())?;
+        pw.set_hash_target(targets.secret, self.secret.expose_felts().into())?;
 
         Ok(())
     }

--- a/wormhole/memprof/README.md
+++ b/wormhole/memprof/README.md
@@ -91,10 +91,12 @@ top of the production `wormhole_private_batch_circuit_config()` (currently
 RowBlinding ZK, `num_wires=135`, `num_routed_wires=60`). Run
 `cargo run -p wormhole-memprof --release -- --help` for the full list. Safe
 (non-security-affecting) knobs include `--zk-mode {polyfri,rowblinding}`,
-`--rate-bits` (auto-rebalances `num_query_rounds`), `--num-wires` (>= 135),
-`--num-routed-wires` (>= 37, <= num_wires), and
-`--max-quotient-degree-factor` (>= 7). Values below the documented structural
-floors are rejected at the CLI: they cannot express the recursion stack's
-gates, so profiling them would label broken circuit shapes as viable. Anything
-that lowers soundness or removes ZK is gated behind
-`--allow-weakening-security`.
+`--rate-bits` (auto-rebalances `num_query_rounds`;
+`ceil(log2(max_quotient_degree_factor)) <= rate_bits <= 8`), `--cap-height`
+(<= 8), `--num-wires` (>= 135), `--num-routed-wires` (>= 37, <= num_wires),
+and `--max-quotient-degree-factor` (>= 7). Values outside the documented
+structural bounds are rejected at the CLI: values below the floors cannot
+express the recursion stack's gates, and oversized FRI exponents
+(`rate_bits`, `cap_height`) drive `2^x` allocations inside plonky2 that
+would only crash deep into circuit construction. Anything that lowers
+soundness or removes ZK is gated behind `--allow-weakening-security`.

--- a/wormhole/memprof/src/config.rs
+++ b/wormhole/memprof/src/config.rs
@@ -59,12 +59,16 @@ pub struct AggConfigArgs {
     /// FRI blowup factor exponent (`blowup = 2^rate_bits`). Lower = less
     /// prover memory, larger proofs, slower verifier. The companion
     /// `num_query_rounds` is automatically adjusted to preserve the original
-    /// FRI soundness product (~rate_bits * queries). Production: 3.
+    /// FRI soundness product (~rate_bits * queries). Must satisfy
+    /// `rate_bits >= ceil(log2(max_quotient_degree_factor))` (a plonky2
+    /// prover requirement) and `rate_bits <= 8` (each extra bit doubles LDE
+    /// memory). Production: 3.
     #[arg(long)]
     pub rate_bits: Option<usize>,
 
     /// FRI Merkle cap height. Affects proof size only, not security or
-    /// prover memory. Production: 4.
+    /// prover memory. Must be <= 8 (cap sizing is `2^cap_height` per
+    /// oracle and per recursive verifier-data allocation). Production: 4.
     #[arg(long)]
     pub cap_height: Option<usize>,
 
@@ -137,6 +141,32 @@ const MIN_MAX_QUOTIENT_DEGREE_FACTOR: usize = 7;
 /// so none should ever be profiled as a safe memory-saving configuration.
 const MIN_NUM_ROUTED_WIRES: usize = 37;
 
+/// Ceiling for `--rate-bits`. Both FRI exponent knobs drive exponential
+/// allocations deep inside plonky2 (`FriParams::lde_size` is
+/// `1 << (degree_bits + rate_bits)` per committed polynomial), so an
+/// oversized but syntactically valid value passes clap and then either
+/// makes massive allocations or trips asserts only after the expensive
+/// circuit build has started. Production is 3; 8 already means a
+/// 32x-production LDE, which is as far as any memory sweep meaningfully
+/// goes. Reject anything larger at the CLI boundary.
+const MAX_RATE_BITS: usize = 8;
+
+/// Ceiling for `--cap-height`. The Merkle cap is `1 << cap_height` hashes
+/// per oracle, and the recursive verifier allocates `1 << cap_height` hash
+/// targets for the verifier data (`add_virtual_cap`), all registered as
+/// public inputs — so this knob blows up circuit size exponentially, not
+/// just proof size. `MerkleTree::new` additionally asserts
+/// `cap_height <= degree_bits + rate_bits` only mid-build; with the cap
+/// bounded at 8 (16x the production cap of 4) that assert is unreachable
+/// for any real aggregation circuit (`degree_bits` >= 12), so the bound
+/// also serves as the cap/degree consistency guard.
+const MAX_CAP_HEIGHT: usize = 8;
+
+/// `ceil(log2(n))` for `n >= 1`, mirroring plonky2's `log2_ceil`.
+fn log2_ceil(n: usize) -> usize {
+    (usize::BITS - (n - 1).leading_zeros()) as usize
+}
+
 impl AggConfigArgs {
     /// Validate the override knobs:
     ///   1. Numeric knobs must be > 0 (zero would silently break the
@@ -147,7 +177,18 @@ impl AggConfigArgs {
     ///      sweeps fail at the CLI boundary instead of panicking after the
     ///      leaf context is already built (or, worse, instantiating
     ///      zero-op-slot gates — see [`MIN_NUM_ROUTED_WIRES`]).
-    ///   3. Security-affecting knobs must be gated by
+    ///   3. FRI exponent ceilings (`rate_bits <= 8`, `cap_height <= 8`) —
+    ///      both knobs drive `1 << x` work in plonky2, so oversized values
+    ///      reach deep into circuit construction before causing massive
+    ///      allocations or asserts (see [`MAX_RATE_BITS`] /
+    ///      [`MAX_CAP_HEIGHT`]).
+    ///   4. Rate/quotient consistency: plonky2's prover asserts
+    ///      `ceil(log2(quotient_degree_factor)) <= rate_bits` only at
+    ///      proving time, after the full circuit build. Enforce it here on
+    ///      the EFFECTIVE values (override or production baseline) so e.g.
+    ///      `--rate-bits 2` fails immediately instead of after minutes of
+    ///      setup.
+    ///   5. Security-affecting knobs must be gated by
     ///      `--allow-weakening-security`.
     pub fn validate(&self) -> Result<(), String> {
         for (name, v) in [
@@ -166,6 +207,43 @@ impl AggConfigArgs {
             if v == Some(0) {
                 return Err(format!("{name} must be greater than 0"));
             }
+        }
+
+        if let Some(v) = self.rate_bits {
+            if v > MAX_RATE_BITS {
+                return Err(format!(
+                    "--rate-bits must be <= {MAX_RATE_BITS} (LDE memory doubles per bit: \
+                     lde_size = 2^(degree_bits + rate_bits) per committed polynomial), got {v}"
+                ));
+            }
+        }
+        if let Some(v) = self.cap_height {
+            if v > MAX_CAP_HEIGHT {
+                return Err(format!(
+                    "--cap-height must be <= {MAX_CAP_HEIGHT} (Merkle caps and recursive \
+                     verifier-data allocations scale as 2^cap_height), got {v}"
+                ));
+            }
+        }
+
+        // Plonky2's prover asserts `ceil(log2(quotient_degree_factor)) <=
+        // rate_bits` only at proving time; check the effective pair here so a
+        // doomed sweep fails before the circuit build. With the quotient
+        // floor of 7 (bits = 3) this also means --rate-bits below 3 can
+        // never prove, regardless of other flags.
+        let baseline = wormhole_private_batch_circuit_config();
+        let effective_rate = self.rate_bits.unwrap_or(baseline.fri_config.rate_bits);
+        let effective_quotient = self
+            .max_quotient_degree_factor
+            .unwrap_or(baseline.max_quotient_degree_factor);
+        let quotient_degree_bits = log2_ceil(effective_quotient.max(1));
+        if effective_rate < quotient_degree_bits {
+            return Err(format!(
+                "--rate-bits ({effective_rate}) must be >= ceil(log2(max_quotient_degree_factor \
+                 = {effective_quotient})) = {quotient_degree_bits}; plonky2's prover cannot \
+                 compute quotient chunks of degree higher than the FRI rate and asserts this \
+                 only at proving time, after the full circuit build"
+            ));
         }
 
         if let Some(v) = self.num_wires {
@@ -426,5 +504,57 @@ mod tests {
     fn zero_knobs_are_still_rejected() {
         let err = args_with(|a| a.rate_bits = Some(0)).validate().unwrap_err();
         assert!(err.contains("greater than 0"), "got: {err}");
+    }
+
+    /// Both FRI exponents drive `1 << x` allocations inside plonky2
+    /// (`lde_size = 2^(degree_bits + rate_bits)`, caps of `2^cap_height`
+    /// hashes per oracle), so syntactically valid but oversized values
+    /// previously sailed through validation and only failed deep inside
+    /// circuit construction — after massive allocations or setup time.
+    #[test]
+    fn oversized_fri_exponents_are_rejected() {
+        for bits in [9, 20, 63, usize::MAX] {
+            let err = args_with(|a| a.rate_bits = Some(bits))
+                .validate()
+                .expect_err(&format!("--rate-bits {bits} must be rejected"));
+            assert!(err.contains("<= 8"), "got: {err}");
+
+            let err = args_with(|a| a.cap_height = Some(bits))
+                .validate()
+                .expect_err(&format!("--cap-height {bits} must be rejected"));
+            assert!(err.contains("<= 8"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn fri_exponent_ceilings_are_accepted() {
+        args_with(|a| a.rate_bits = Some(8)).validate().unwrap();
+        args_with(|a| a.cap_height = Some(8)).validate().unwrap();
+    }
+
+    /// Plonky2's prover asserts `ceil(log2(quotient_degree_factor)) <=
+    /// rate_bits` only at proving time. With the quotient floor of 7
+    /// (bits = 3), any --rate-bits below 3 builds the entire aggregation
+    /// circuit and then dies in the prover; validation must reject it at
+    /// the CLI boundary instead.
+    #[test]
+    fn rate_bits_below_quotient_degree_are_rejected() {
+        for bits in [1, 2] {
+            let err = args_with(|a| a.rate_bits = Some(bits))
+                .validate()
+                .expect_err(&format!("--rate-bits {bits} cannot prove"));
+            assert!(err.contains("proving time"), "got: {err}");
+        }
+        // Lowering the quotient factor to its floor (7 -> bits = 3) does not
+        // relax the rate floor below 3 either.
+        let err = args_with(|a| {
+            a.rate_bits = Some(2);
+            a.max_quotient_degree_factor = Some(7);
+        })
+        .validate()
+        .unwrap_err();
+        assert!(err.contains("ceil(log2("), "got: {err}");
+        // Production pair (rate 3, factor 8) stays valid.
+        args_with(|a| a.rate_bits = Some(3)).validate().unwrap();
     }
 }

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -7,16 +7,26 @@ use plonky2::plonk::proof::ProofWithPublicInputs;
 use qp_wormhole_inputs::{BytesDigest, PublicCircuitInputs};
 use std::path::PathBuf;
 use std::sync::{Once, OnceLock};
-use test_helpers::{compute_zk_leaf_hash, TestInputs};
+use test_helpers::block_header::{
+    DEFAULT_BLOCK_NUMBERS, DEFAULT_DIGESTS, DEFAULT_EXTRINSICS_ROOTS, DEFAULT_STATE_ROOTS,
+};
+use test_helpers::{
+    compute_zk_leaf_hash, TestInputs, DEFAULT_EXIT_ACCOUNT, DEFAULT_INPUT_AMOUNTS, DEFAULT_SECRETS,
+    DEFAULT_TRANSFER_COUNTS, DEFAULT_VOLUME_FEE_BPS,
+};
 use wormhole_aggregator::aggregator::PublicBatchAggregator;
 use wormhole_aggregator::common::utils::{
     load_canonical_leaf_verifier_data, load_canonical_private_batch_verifier_data,
 };
 use wormhole_aggregator::pool::BatchKey;
 use wormhole_aggregator::private_batch::prover::PrivateBatchProver;
-use wormhole_circuit::inputs::{CircuitInputs, ParsePublicInputs};
+use wormhole_circuit::inputs::{CircuitInputs, ParsePublicInputs, PrivateCircuitInputs};
+use wormhole_circuit::nullifier::Nullifier;
+use wormhole_circuit::unspendable_account::UnspendableAccount;
 use wormhole_prover::WormholeProver;
 use zk_circuits_common::circuit::{C, D, F};
+use zk_circuits_common::utils::digest_to_bytes;
+use zk_circuits_common::zk_merkle::{hash_node, Hash256, SIBLINGS_PER_LEVEL};
 
 use crate::aggregator::circuit_config;
 
@@ -150,6 +160,94 @@ fn test_inputs_with_asset(asset_id: u32) -> CircuitInputs {
     inputs
 }
 
+/// Depth-1 merkle proof for `leaf_index` in a 4-child node (arity 4).
+fn depth1_merkle_proof(
+    leaf_index: usize,
+    leaves: &[Hash256; 4],
+) -> (Vec<[Hash256; SIBLINGS_PER_LEVEL]>, Vec<u8>, Hash256) {
+    let root = hash_node(leaves).expect("test leaves are canonical");
+    let mut children = *leaves;
+    let current = children[leaf_index];
+    children.sort();
+    let sorted_position = children.iter().position(|h| *h == current).unwrap() as u8;
+    let mut siblings = [[0u8; 32]; SIBLINGS_PER_LEVEL];
+    let mut sib_idx = 0;
+    for (i, child) in children.iter().enumerate() {
+        if i as u8 != sorted_position {
+            siblings[sib_idx] = *child;
+            sib_idx += 1;
+        }
+    }
+    (vec![siblings], vec![sorted_position], root)
+}
+
+/// Two distinct real spends under one shared zk-tree root / block_hash.
+///
+/// Depth-0 fixtures cannot do this: `block_hash` commits to `zk_tree_root`, and
+/// a depth-0 root equals the single leaf hash — so two different spends would
+/// get two different blocks. A depth-1 (4-ary) tree lets both leaves share a
+/// root. Required now that the private-batch circuit rejects duplicate real
+/// nullifiers (replaying one leaf across two slots is no longer valid).
+fn two_real_leaves_same_block(asset_id: u32) -> (CircuitInputs, CircuitInputs) {
+    let mut leaf_hashes = [[0u8; 32]; 4];
+    let mut accounts = [BytesDigest::default(); 2];
+    let mut nullifiers = [BytesDigest::default(); 2];
+    let mut secrets = [BytesDigest::default(); 2];
+
+    for i in 0..2 {
+        let secret: BytesDigest = hex::decode(DEFAULT_SECRETS[i].trim()).unwrap()[..32]
+            .try_into()
+            .unwrap();
+        secrets[i] = secret;
+        accounts[i] = digest_to_bytes(UnspendableAccount::from_secret(secret).account_id);
+        nullifiers[i] =
+            digest_to_bytes(Nullifier::from_preimage(secret, DEFAULT_TRANSFER_COUNTS[i]).hash);
+        leaf_hashes[i] = compute_zk_leaf_hash(
+            &accounts[i],
+            DEFAULT_TRANSFER_COUNTS[i],
+            asset_id,
+            DEFAULT_INPUT_AMOUNTS[i],
+        );
+    }
+    // Pad the 4-ary node with zero hashes (canonical empty siblings).
+
+    let exit_account = BytesDigest::try_from(DEFAULT_EXIT_ACCOUNT).unwrap();
+    let mut out = Vec::with_capacity(2);
+    for i in 0..2 {
+        let (siblings, positions, root) = depth1_merkle_proof(i, &leaf_hashes);
+        let inputs = CircuitInputs {
+            public: PublicCircuitInputs {
+                asset_id,
+                output_amount_1: 0,
+                output_amount_2: 0,
+                volume_fee_bps: DEFAULT_VOLUME_FEE_BPS,
+                nullifier: nullifiers[i],
+                exit_account_1: exit_account,
+                exit_account_2: BytesDigest::default(),
+                block_hash: BytesDigest::try_from([0u8; 32]).unwrap(),
+                block_number: DEFAULT_BLOCK_NUMBERS[0],
+            },
+            private: PrivateCircuitInputs {
+                secret: secrets[i].into(),
+                transfer_count: DEFAULT_TRANSFER_COUNTS[i],
+                unspendable_account: accounts[i],
+                parent_hash: BytesDigest::try_from([0u8; 32]).unwrap(),
+                state_root: BytesDigest::try_from(DEFAULT_STATE_ROOTS[0]).unwrap(),
+                extrinsics_root: DEFAULT_EXTRINSICS_ROOTS[0].try_into().unwrap(),
+                digest: DEFAULT_DIGESTS[0],
+                input_amount: DEFAULT_INPUT_AMOUNTS[i],
+                zk_tree_root: root,
+                zk_merkle_siblings: siblings,
+                zk_merkle_positions: positions,
+            },
+        };
+        out.push(with_real_block(inputs));
+    }
+    assert_eq!(out[0].public.block_hash, out[1].public.block_hash);
+    assert_ne!(out[0].public.nullifier, out[1].public.nullifier);
+    (out.remove(0), out.remove(0))
+}
+
 // ============================================================================
 // Client-side (private batch): one-shot aggregation, no queue
 // ============================================================================
@@ -169,17 +267,16 @@ fn aggregate_single_proof() {
 
 #[test]
 fn aggregate_proofs_into_tree() {
-    // All proofs must be from the SAME BLOCK for fixed-structure aggregation.
-    let inputs = test_inputs_with_real_block();
+    // Same block, distinct nullifiers (depth-1 shared zk tree).
+    let (inputs_0, inputs_1) = two_real_leaves_same_block(0);
 
-    let proof_0 = make_leaf_proof(&inputs);
-    let proof_1 = make_leaf_proof(&inputs);
+    let proof_0 = make_leaf_proof(&inputs_0);
+    let proof_1 = make_leaf_proof(&inputs_1);
 
     let pi0 = PublicCircuitInputs::try_from_proof(&proof_0).unwrap();
     let pi1 = PublicCircuitInputs::try_from_proof(&proof_1).unwrap();
-
-    println!("proof_0 public inputs = {:?}", pi0);
-    println!("proof_1 public inputs = {:?}", pi1);
+    assert_eq!(pi0.block_hash, pi1.block_hash);
+    assert_ne!(pi0.nullifier, pi1.nullifier);
 
     let aggregated = make_private_batch_prover()
         .aggregate(vec![proof_0, proof_1])
@@ -191,15 +288,18 @@ fn aggregate_proofs_into_tree() {
 
 #[test]
 fn commit_rejects_nonzero_asset_id_when_dummy_padding_is_needed() {
-    // Tampering with asset_id invalidates the proof cryptographically, but the
-    // prover's commit API does not verify proofs; the asset-id padding
-    // preflight must still reject it before witness filling.
-    let mut proof = make_leaf_proof(&CircuitInputs::test_inputs_0());
-    proof.public_inputs[0] = F::from_canonical_u64(1);
+    // A cryptographically valid non-native-asset leaf in a partial batch needs
+    // dummy padding (asset_id = 0). Commit must reject that mismatch before
+    // proving. (Tampering with asset_id on an existing proof would fail the
+    // leaf-verify-at-commit check first; this exercises the padding preflight.)
+    let proof = make_leaf_proof(&with_real_block(test_inputs_with_asset(5)));
 
     let prover = make_private_batch_prover();
     let err = prover.commit(vec![proof]).unwrap_err();
-    assert!(err.to_string().contains("dummy proofs use asset_id=0"));
+    assert!(
+        err.to_string().contains("dummy proofs use asset_id=0"),
+        "got: {err}"
+    );
 }
 
 #[test]
@@ -231,10 +331,11 @@ fn commit_rejects_batch_incompatible_proofs() {
 fn full_batch_of_same_nonzero_asset_aggregates() {
     // Sanity check for the fail-fast path: a FULL batch of same-asset proofs
     // needs no dummy padding, so a non-native asset is fine and the
-    // compatibility preflight lets it through to real proving.
-    let inputs = with_real_block(test_inputs_with_asset(5));
-    let proof_0 = make_leaf_proof(&inputs);
-    let proof_1 = make_leaf_proof(&inputs);
+    // compatibility preflight lets it through to real proving. Nullifiers
+    // must still be distinct.
+    let (inputs_0, inputs_1) = two_real_leaves_same_block(5);
+    let proof_0 = make_leaf_proof(&inputs_0);
+    let proof_1 = make_leaf_proof(&inputs_1);
 
     let aggregated = make_private_batch_prover()
         .aggregate(vec![proof_0, proof_1])
@@ -253,15 +354,15 @@ fn full_batch_of_same_nonzero_asset_aggregates() {
 fn aggregate_proofs_from_separate_prover_instances_hex_serialized() {
     setup_test_binaries();
 
+    let (inputs_1, inputs_2) = two_real_leaves_same_block(0);
+
     // Proof 1 from prover A
     let prover_a = WormholeProver::new(circuit_config());
-    let inputs_1 = test_inputs_with_real_block();
     let proof_1 = prover_a.commit(&inputs_1).unwrap().prove().unwrap();
     let proof_1_hex = hex::encode(proof_1.to_bytes());
 
-    // Proof 2 from prover B (same block)
+    // Proof 2 from prover B (same block, distinct nullifier)
     let prover_b = WormholeProver::new(circuit_config());
-    let inputs_2 = test_inputs_with_real_block();
     let proof_2 = prover_b.commit(&inputs_2).unwrap().prove().unwrap();
     let proof_2_hex = hex::encode(proof_2.to_bytes());
 

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -679,7 +679,15 @@ fn public_batch_aggregator_prove_batch_ignores_bins_dir_after_init() {
     // mutable bins_dir on every call. Replacing artifacts after init could
     // make the aggregator spend a proving window and return a proof its own
     // pinned verifier rejects. Construction must pin every proving input;
-    // mutating the directory afterwards must be a no-op for prove_batch.
+    // mutating the directory afterwards must be a no-op for proving.
+    //
+    // This test proves through the split API's OWNED ProvingContext (review
+    // finding: the previous split API borrowed &self, so a mutex caller kept
+    // the aggregator locked for the whole proving run). The context is
+    // captured as the short-lock phase would, the aggregator is dropped
+    // entirely, and proving runs on a separate worker thread — pinning down
+    // that the context is self-sufficient, movable (Send), and never reads
+    // the scrubbed bins_dir.
     setup_public_test_binaries();
 
     let dir = test_bins_root().join("public-pinned-after-init");
@@ -698,8 +706,16 @@ fn public_batch_aggregator_prove_batch_ignores_bins_dir_after_init() {
         .push_proof(private_batch_proof)
         .expect("admit private-batch proof");
 
-    // Scrub every artifact prove_batch used to re-read. If it still touches
-    // the path, proving or the pinned-verifier check will fail.
+    // Short-lock phase of the split API: snapshot the batch and clone the
+    // owned proving context, then release the aggregator (a service would
+    // drop its mutex guard here; dropping the aggregator outright is the
+    // stronger form of the same claim).
+    let proofs = aggregator.snapshot_batch(&key).expect("snapshot batch");
+    let prover = aggregator.proving_context();
+    drop(aggregator);
+
+    // Scrub every artifact proving used to re-read. If the context still
+    // touches the path, proving or the pinned-verifier check will fail.
     for name in [
         "private_batch_common.bin",
         "private_batch_verifier.bin",
@@ -711,10 +727,14 @@ fn public_batch_aggregator_prove_batch_ignores_bins_dir_after_init() {
         std::fs::write(dir.join(name), b"not a trusted artifact").unwrap();
     }
 
-    let aggregated = aggregator
-        .aggregate(&key)
+    // Proving worker: the context and snapshot move to the thread; nothing
+    // of the aggregator survives on this side.
+    let verifier = prover.clone();
+    let aggregated = std::thread::spawn(move || prover.prove_batch(proofs))
+        .join()
+        .expect("proving worker must not panic")
         .expect("prove_batch must use pinned artifacts, not the scrubbed bins_dir");
-    aggregator
+    verifier
         .verify(aggregated)
         .expect("proof must verify under the verifier pinned at init");
 

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -485,7 +485,7 @@ fn public_batch_build_rejects_substituted_private_batch_artifacts() {
     vk_bytes[last] ^= 0x01;
     std::fs::write(dir.join("private_batch_verifier.bin"), vk_bytes).unwrap();
 
-    let err = generate_public_batch_circuit_binaries(&dir, 1)
+    let err = generate_public_batch_circuit_binaries(&dir, 1, PRIVATE_NUM_LEAVES)
         .expect_err("substituted private-batch artifacts must be rejected before baking");
     // `{err:#}` prints the whole context chain; the canonical mismatch is the cause.
     let chain = format!("{err:#}");

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -573,6 +573,54 @@ fn public_batch_prover_ignores_prover_artifact() {
 }
 
 #[test]
+fn public_batch_aggregator_prove_batch_ignores_bins_dir_after_init() {
+    // Audit finding: prove_batch used to rebuild PublicBatchProver from the
+    // mutable bins_dir on every call. Replacing artifacts after init could
+    // make the aggregator spend a proving window and return a proof its own
+    // pinned verifier rejects. Construction must pin every proving input;
+    // mutating the directory afterwards must be a no-op for prove_batch.
+    setup_public_test_binaries();
+
+    let dir = test_bins_root().join("public-pinned-after-init");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    for entry in std::fs::read_dir(public_bins_dir()).unwrap() {
+        let entry = entry.unwrap();
+        std::fs::copy(entry.path(), dir.join(entry.file_name())).unwrap();
+    }
+
+    let private_batch_proof = make_private_batch_proof_in_public_dir();
+    let address = BytesDigest::try_from([1u8; 32]).expect("valid address");
+    let mut aggregator =
+        PublicBatchAggregator::new(&dir, address).expect("aggregator init pins artifacts");
+    let key = aggregator
+        .push_proof(private_batch_proof)
+        .expect("admit private-batch proof");
+
+    // Scrub every artifact prove_batch used to re-read. If it still touches
+    // the path, proving or the pinned-verifier check will fail.
+    for name in [
+        "private_batch_common.bin",
+        "private_batch_verifier.bin",
+        "dummy_private_batch_proof.bin",
+        "public_batch_common.bin",
+        "public_batch_verifier.bin",
+        "config.json",
+    ] {
+        std::fs::write(dir.join(name), b"not a trusted artifact").unwrap();
+    }
+
+    let aggregated = aggregator
+        .aggregate(&key)
+        .expect("prove_batch must use pinned artifacts, not the scrubbed bins_dir");
+    aggregator
+        .verify(aggregated)
+        .expect("proof must verify under the verifier pinned at init");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn pool_rejects_invalid_proofs_and_aggregates_by_bucket() {
     setup_public_test_binaries();
     let dir = public_bins_dir();

--- a/wormhole/tests/src/circuit/nullifier_tests.rs
+++ b/wormhole/tests/src/circuit/nullifier_tests.rs
@@ -66,7 +66,7 @@ fn invalid_secret_fails_proof() {
     let mut invalid_bytes = hex::decode(DEFAULT_SECRETS[0]).unwrap();
     invalid_bytes[0] ^= 0xFF;
     let invalid_bytes: [u8; 32] = invalid_bytes[..32].try_into().unwrap();
-    valid_nullifier.secret = bytes_to_digest(BytesDigest::try_from(invalid_bytes).unwrap());
+    valid_nullifier.secret = bytes_to_digest(BytesDigest::try_from(invalid_bytes).unwrap()).into();
 
     let res = run_test(&valid_nullifier);
     assert!(res.is_err());

--- a/wormhole/tests/src/circuit/unspendable_account_tests.rs
+++ b/wormhole/tests/src/circuit/unspendable_account_tests.rs
@@ -119,7 +119,8 @@ fn unspendable_account_codec() {
             F::from_noncanonical_u64(6),
             F::from_noncanonical_u64(7),
             F::from_noncanonical_u64(8),
-        ],
+        ]
+        .into(),
     };
 
     // Encode the account as field elements and compare.

--- a/wormhole/tests/src/prover/prover_tests.rs
+++ b/wormhole/tests/src/prover/prover_tests.rs
@@ -369,7 +369,7 @@ fn test_random_tree_circuit_verification() {
             block_number: DEFAULT_BLOCK_NUMBERS[0],
         },
         private: PrivateCircuitInputs {
-            secret: secret_digest,
+            secret: secret_digest.into(),
             transfer_count,
             unspendable_account,
             parent_hash: BytesDigest::try_from([0u8; 32]).unwrap(),
@@ -475,7 +475,7 @@ fn test_depth_2_tree_circuit_verification() {
                 block_number: DEFAULT_BLOCK_NUMBERS[0],
             },
             private: PrivateCircuitInputs {
-                secret: secret_digest,
+                secret: secret_digest.into(),
                 transfer_count,
                 unspendable_account,
                 parent_hash: BytesDigest::try_from([0u8; 32]).unwrap(),
@@ -592,7 +592,7 @@ fn test_depth_3_tree_circuit_verification() {
                 block_number: DEFAULT_BLOCK_NUMBERS[0],
             },
             private: PrivateCircuitInputs {
-                secret: secret_digest,
+                secret: secret_digest.into(),
                 transfer_count,
                 unspendable_account,
                 parent_hash: BytesDigest::try_from([0u8; 32]).unwrap(),

--- a/wormhole/tests/test-helpers/src/lib.rs
+++ b/wormhole/tests/test-helpers/src/lib.rs
@@ -127,7 +127,7 @@ impl TestInputs for CircuitInputs {
                 block_number: DEFAULT_BLOCK_NUMBERS[0],
             },
             private: PrivateCircuitInputs {
-                secret,
+                secret: secret.into(),
                 transfer_count: DEFAULT_TRANSFER_COUNTS[0],
                 unspendable_account,
                 // These values are not validated for dummy proofs but needed for witness
@@ -178,7 +178,7 @@ impl TestInputs for CircuitInputs {
                 block_number: DEFAULT_BLOCK_NUMBERS[1],
             },
             private: PrivateCircuitInputs {
-                secret,
+                secret: secret.into(),
                 transfer_count: DEFAULT_TRANSFER_COUNTS[1],
                 unspendable_account,
                 parent_hash: BytesDigest::try_from([0u8; 32]).unwrap(),

--- a/wormhole/verifier/Cargo.toml
+++ b/wormhole/verifier/Cargo.toml
@@ -13,12 +13,6 @@ qp-plonky2-verifier = { version = "=1.5.4", default-features = false }
 qp-wormhole-inputs = { version = "=3.1.0", path = "../inputs", default-features = false }
 tiny-keccak = { workspace = true }
 
-# Only used by the std-gated artifact reader (O_NONBLOCK open); optional and
-# std-gated so --no-default-features builds keep libc (and libc/std) out of
-# the dependency graph entirely.
-[target.'cfg(unix)'.dependencies]
-libc = { version = "=0.2.186", default-features = false, optional = true }
-
 [dev-dependencies]
 criterion = { workspace = true }
 
@@ -26,7 +20,6 @@ criterion = { workspace = true }
 default = ["std"]
 std = [
 	"anyhow/std",
-	"dep:libc",
 	"qp-plonky2-verifier/std",
 	"qp-wormhole-inputs/std",
 ]

--- a/wormhole/verifier/src/lib.rs
+++ b/wormhole/verifier/src/lib.rs
@@ -137,45 +137,14 @@ fn keccak256(input: &[u8]) -> [u8; 32] {
 /// Read a verifier-artifact file, refusing anything larger than
 /// [`MAX_VERIFIER_ARTIFACT_BYTES`] before allocating for its contents.
 ///
-/// Only regular files are accepted. A FIFO, device node, or symlink to one
-/// planted at an artifact path would otherwise block `open` (a FIFO with no
-/// writer) or `read_to_end` (a stream that never reaches EOF) forever,
-/// independent of the size cap. On unix the open uses `O_NONBLOCK` so even
-/// the FIFO-open case cannot stall; the file type is then checked via `fstat`
-/// on the opened handle before any read. `O_NONBLOCK` has no effect on
-/// regular-file opens or reads.
-///
-/// The size is checked via `fstat` on the already-opened handle (no
-/// stat-then-open race), and the read itself is additionally capped with
-/// `Read::take` in case the file grows after the check.
-///
-/// This mirrors `read_artifact_file` in the aggregator crate; the verifier
-/// crate stays lean (no dependency on the prover-side crates), so the ~40
-/// lines are duplicated rather than shared. Keep the two in lockstep.
+/// Mirrors the aggregator's size-capped reader. Artifact paths are assumed
+/// to come from attested CI builds (`wormhole/THREAT_MODEL.md`).
 #[cfg(feature = "std")]
 fn read_artifact_file(path: &Path) -> anyhow::Result<Vec<u8>> {
     use anyhow::Context as _;
-    use std::io::Read as _;
 
-    let mut options = std::fs::File::options();
-    options.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        options.custom_flags(libc::O_NONBLOCK);
-    }
-    let file = options
-        .open(path)
-        .with_context(|| format!("failed to open artifact file {}", path.display()))?;
-    let metadata = file
-        .metadata()
+    let metadata = std::fs::metadata(path)
         .with_context(|| format!("failed to stat artifact file {}", path.display()))?;
-    if !metadata.file_type().is_file() {
-        return Err(anyhow!(
-            "artifact file {} is not a regular file; refusing to load it",
-            path.display()
-        ));
-    }
     let claimed_len = metadata.len();
     if claimed_len > MAX_VERIFIER_ARTIFACT_BYTES {
         return Err(anyhow!(
@@ -186,20 +155,7 @@ fn read_artifact_file(path: &Path) -> anyhow::Result<Vec<u8>> {
             MAX_VERIFIER_ARTIFACT_BYTES
         ));
     }
-
-    let mut bytes = Vec::with_capacity(claimed_len as usize);
-    file.take(MAX_VERIFIER_ARTIFACT_BYTES + 1)
-        .read_to_end(&mut bytes)
-        .with_context(|| format!("failed to read artifact file {}", path.display()))?;
-    if bytes.len() as u64 > MAX_VERIFIER_ARTIFACT_BYTES {
-        return Err(anyhow!(
-            "artifact file {} grew past the {} byte limit for verifier artifacts \
-             while being read; refusing to load it",
-            path.display(),
-            MAX_VERIFIER_ARTIFACT_BYTES
-        ));
-    }
-    Ok(bytes)
+    std::fs::read(path).with_context(|| format!("failed to read artifact file {}", path.display()))
 }
 
 impl WormholeVerifier {
@@ -291,11 +247,10 @@ impl WormholeVerifier {
 
     /// Creates a new [`WormholeVerifier`] from a verifier and common data files.
     ///
-    /// Both files are read through [`read_artifact_file`], which rejects
-    /// non-regular files and anything larger than [`MAX_VERIFIER_ARTIFACT_BYTES`]
-    /// before buffering, so an untrusted artifact path cannot stall or
-    /// memory-starve verifier startup. The keccak256 canonicality pin in
-    /// [`Self::new_from_bytes`] then rejects any non-canonical contents.
+    /// Both files are read through [`read_artifact_file`] (size-capped). The
+    /// keccak256 canonicality pin in [`Self::new_from_bytes`] then rejects any
+    /// non-canonical contents. Paths are assumed to come from attested CI
+    /// builds (`wormhole/THREAT_MODEL.md`).
     #[cfg(feature = "std")]
     pub fn new_from_files(
         verifier_data_path: &Path,
@@ -388,52 +343,6 @@ mod tests {
             format!("{err:#}").contains("exceeds the"),
             "oversized artifact must be rejected by the size cap, got: {err:#}"
         );
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
-    /// A FIFO planted at an artifact path must produce a prompt error, not a
-    /// hang: a blocking `File::open` on a FIFO with no writer stalls forever,
-    /// before any size or content check can run (audit finding: unbounded
-    /// trusted file reads).
-    #[cfg(unix)]
-    #[test]
-    fn new_from_files_rejects_fifo_without_blocking() {
-        use std::os::unix::ffi::OsStrExt as _;
-
-        let dir = temp_dir("fifo");
-
-        let fifo = dir.join("verifier.bin");
-        let c_path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
-        assert_eq!(
-            unsafe { libc::mkfifo(c_path.as_ptr(), 0o600) },
-            0,
-            "mkfifo failed"
-        );
-        let common_path = dir.join("common.bin");
-        std::fs::write(&common_path, b"irrelevant").unwrap();
-
-        // Run on a helper thread so a regression (blocking open or read)
-        // surfaces as a test failure instead of hanging the suite.
-        let (tx, rx) = std::sync::mpsc::channel();
-        let fifo_for_thread = fifo.clone();
-        let common_for_thread = common_path.clone();
-        std::thread::spawn(move || {
-            let _ = tx.send(
-                WormholeVerifier::new_from_files(&fifo_for_thread, &common_for_thread).map(drop),
-            );
-        });
-
-        match rx.recv_timeout(std::time::Duration::from_secs(5)) {
-            Ok(result) => {
-                let err = result.unwrap_err();
-                assert!(
-                    format!("{err:#}").contains("not a regular file"),
-                    "got: {err:#}"
-                );
-            }
-            Err(_) => panic!("new_from_files blocked on a FIFO artifact path"),
-        }
 
         std::fs::remove_dir_all(&dir).unwrap();
     }


### PR DESCRIPTION
# Wormhole v12 audit hardening + trusted-CI artifact model

## Summary

- Close Wormhole audit findings across circuits, aggregator admission, dummy templates, memprof knobs, and artifact loading (nullifier uniqueness, secret zeroization, leaf verify-at-commit, pool membership-oracle gating, dummy sentinel on build, FRI exponent bounds, pin-by-bytes).
- Document an explicit trust boundary: **CI build host + attested bins are trusted**; local filesystem adversary findings against the publisher are out of scope (`wormhole/THREAT_MODEL.md`).
- Simplify artifact I/O to match that model: drop symlink/FIFO/TOCTOU/basename hardening (~1.4k LOC), keep whole-dir staging, size caps, and canonical pins.

## Threat model (please read first)

See [`wormhole/THREAT_MODEL.md`](wormhole/THREAT_MODEL.md).

| Trusted | Untrusted / still in scope |
|---|---|
| CI builder, toolchain, output parent during generation | Client-submitted proofs until verify |
| Attested artifact directories loaded by nodes | Wrong-version / mismatched bins (canonical pin) |
| On-chain settlement (nullifier set) | Dummy padding templates (must stay sentinel + verify) |
| | No `prover.bin` (rebuild prover data from source) |

**Out of scope:** local FS races on the build host (symlink TOCTOU, planted FIFOs, staging replacement, basename escapes, cleanup≠publish as soundness).

## Security fixes (this branch)

- **Private-batch:** pairwise-distinct real nullifiers; verify leaf proofs at `PrivateBatchProver::commit`; validate `dummy_proof.bin` before baking `dummy_private_batch_proof.bin`.
- **Public-batch:** pin proving artifacts at init; keep witness filler crate-private; take `num_leaf_proofs` from caller and pin private-batch artifacts by raw bytes (no deserialize peek).
- **Secrets:** zeroize spend secret outside plonky2 (`SensitiveDigest` / `Secret`).
- **Comparison:** canonicalize 64-bit `is_const_less_than` over Goldilocks.
- **Proof pool:** gate bucket-cap (and nullifier dedup) behind cryptographic verify so admission is not a free membership oracle.
- **Memprof:** upper/consistency bounds on `--rate-bits` / `--cap-height` (and rate vs quotient degree).
- **Artifacts (pre-simplification hardening, then trimmed):** basename allowlist / atomic publish / staging cleanup — superseded for *security claims* by the trusted-CI model; whole-dir staging retained for mixed-generation hygiene.

## Simplification (trusted CI)

After documenting the model, remove publisher/local-FS adversary code paths:

- Drop symlink/FIFO/`O_NONBLOCK`/TOCTOU inode dance / basename scrubbing / orphan-sweep theater from aggregator utils, circuit-builder commit path, and verifier artifact reads.
- Keep: `generate_all_circuit_binaries` whole-directory staging, artifact size caps before pin, best-effort post-swap cleanup warnings, canonical byte-pin + dummy checks.

## Test plan

- [ ] `cargo test --release -p qp-wormhole-aggregator --lib`
- [ ] `cargo test --release -p qp-wormhole-circuit-builder --lib`
- [ ] `cargo test --release -p wormhole-memprof`
- [ ] `cargo test --release -p tests --lib` (aggregator / nullifier paths as needed)
- [ ] `cargo clippy --release -p qp-wormhole-aggregator -p qp-wormhole-circuit-builder --all-targets -- -D warnings`
- [ ] Confirm CI still builds bins via circuit-builder and provers load attested paths only
- [ ] Spot-check: poisoned / wrong-shape bins still fail canonical pin; invalid proofs still fail verify before pool membership answers

## Notes for reviewers

- Prefer classifying new “build-host filesystem” findings against `THREAT_MODEL.md` before treating them as protocol defects.
- Nullifier *uniqueness / double-spend* remains an on-chain pallet responsibility; circuits prove well-formedness (and now intra-batch distinct real nullifiers).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches ZK circuit constraints, proof admission, and artifact trust boundaries—incorrect changes could weaken soundness or enable value minting; the large artifact-model refactor also shifts which filesystem issues count as in-scope.
> 
> **Overview**
> This PR closes Wormhole v12 audit findings and **documents a trusted-CI artifact model** in `wormhole/THREAT_MODEL.md`: generation on a trusted build host and loading attested bins are in scope; local filesystem attacks on the publisher are explicitly out of scope.
> 
> **Circuit & crypto:** Private-batch now enforces **pairwise distinct real nullifiers** and verifies **each leaf at `PrivateBatchProver::commit`** before recursive proving. **`is_const_less_than` at 64 bits** uses a canonical half-split so Goldilocks wraparound cannot flip comparisons. Spend secrets move into **`SensitiveDigest` / `Secret`** (`zeroize`, no silent `Clone` on inputs).
> 
> **Aggregator & admission:** `PublicBatchAggregator` **pins** private-batch verifier, dummy template, and shapes at init; **`prove_batch` no longer re-reads `bins_dir`** and self-checks against the pinned verifier. Canonical artifact loading **byte-pins** without deserializing untrusted `common.bin`. The proof pool runs **bucket-cap and nullifier checks only after verify** to avoid membership oracles. Dummy leaf templates are **validated before** baking `dummy_private_batch_proof.bin`; public-batch witness fill stays crate-private.
> 
> **Artifacts & tooling:** Publisher I/O is simplified (drops symlink/FIFO/`O_NONBLOCK`/atomic per-file publish theater); **whole-dir staging**, size caps, and pins remain. `generate_public_batch_circuit_binaries` takes **`num_leaf_proofs` from the caller** instead of peeking PI length from bytes. **Memprof** caps `--rate-bits` / `--cap-height` and enforces rate vs quotient degree at the CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 713443bb28ddbc28593b896feefa67d1c31e759f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->