### PR TITLE
security: stop secret leaking through Nullifier/UnspendableAccount 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ qp-plonky2 = { version = "=1.5.4", default-features = false, features = ["std"] 
 qp-poseidon-core = { version = "=3.0.2", default-features = false }
 serde = { version = "=1.0.228", default-features = false, features = ["derive"] }
 tiny-keccak = { version = "=2.0.2", default-features = false, features = ["keccak"] }
-zeroize = { version = "=1.8.2", default-features = false }
+zeroize = { version = "=1.8.2", default-features = false, features = ["alloc"] }
 
 [workspace.package]
 authors = ["Quantus Network"]

--- a/wormhole/circuit/src/inputs.rs
+++ b/wormhole/circuit/src/inputs.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::new_without_default)]
 use crate::block_header::header::DIGEST_LOGS_SIZE;
-use crate::sensitive::SensitiveDigest;
+use crate::sensitive::Secret;
 use alloc::vec::Vec;
 use anyhow::{bail, Context};
 use plonky2::field::goldilocks_field::GoldilocksField;
@@ -24,8 +24,9 @@ pub use qp_wormhole_inputs::{
 
 /// Inputs required to commit to the wormhole circuit.
 ///
-/// Deliberately not `Clone`: `private.secret` is a move-only
-/// [`SensitiveDigest`], so the spend credential cannot be silently duplicated.
+/// Deliberately not `Clone`: `private.secret` is a zeroize-on-drop
+/// [`Secret`], so the spend credential cannot be silently duplicated via
+/// this container.
 pub struct CircuitInputs {
     pub public: PublicCircuitInputs,
     pub private: PrivateCircuitInputs,
@@ -42,13 +43,13 @@ impl core::fmt::Debug for CircuitInputs {
 
 /// All of the private inputs required for the circuit.
 ///
-/// Deliberately not `Clone`: `secret` is a move-only [`SensitiveDigest`]
-/// (zeroized on drop), so the spend credential cannot be silently duplicated.
+/// Deliberately not `Clone`: `secret` is a zeroize-on-drop [`Secret`], so
+/// the spend credential cannot be silently duplicated via this container.
 pub struct PrivateCircuitInputs {
-    /// The secret of the nullifier and the unspendable account. Move-only and
-    /// zeroized on drop; duplication requires an explicit
-    /// [`SensitiveDigest::expose_digest`] call at the use site.
-    pub secret: SensitiveDigest,
+    /// The secret of the nullifier and the unspendable account. Zeroized on
+    /// drop; duplication requires an explicit [`Secret::expose_digest`] (or
+    /// `expose_felts`) call at the use site.
+    pub secret: Secret,
     /// Transfer count for this recipient
     pub transfer_count: u64,
     /// The unspendable account hash (recipient of the transfer).
@@ -392,7 +393,7 @@ mod tests {
 
     #[test]
     fn private_circuit_inputs_debug_redacts_private_fields() {
-        let secret = SensitiveDigest::try_from([0xab; 32]).unwrap();
+        let secret = Secret::try_from([0xab; 32]).unwrap();
         let unspendable_account = BytesDigest::try_from([0xcd; 32].as_slice()).unwrap();
         let inputs = PrivateCircuitInputs {
             secret,

--- a/wormhole/circuit/src/nullifier.rs
+++ b/wormhole/circuit/src/nullifier.rs
@@ -101,16 +101,20 @@ impl Nullifier {
     }
 
     pub fn from_preimage(secret: BytesDigest, transfer_count: u64) -> Self {
-        let mut preimage = Vec::new();
-
         let salt =
             string_to_felts(NULLIFIER_SALT).expect("NULLIFIER_SALT within serialization cap");
         let secret_felts = bytes_to_digest(secret);
         let transfer_count_felts = u64_to_felts(transfer_count);
 
+        // Full capacity up front: growing after the secret is written would
+        // reallocate and free the old block unscrubbed. The scrubbing wrapper
+        // then zeroizes the buffer once hashing is done.
+        let mut preimage =
+            Vec::with_capacity(SALT_NUM_TARGETS + SECRET_NUM_TARGETS + TRANSFER_COUNT_NUM_TARGETS);
         preimage.extend(salt);
         preimage.extend(secret_felts);
         preimage.extend(transfer_count_felts);
+        let preimage = SensitiveFelts::new(preimage);
 
         let inner_hash = Poseidon2Hash::hash_no_pad(&preimage).elements;
         let outer_hash = Poseidon2Hash::hash_no_pad(&inner_hash).elements;
@@ -129,7 +133,9 @@ impl Nullifier {
     /// the caller drops it. Do not copy the contents into logs, error
     /// contexts, or persistent storage.
     pub fn to_bytes(&self) -> Zeroizing<Vec<u8>> {
-        let mut bytes = Vec::new();
+        // Full capacity up front: growing after the secret is written would
+        // reallocate and free the old block unscrubbed.
+        let mut bytes = Vec::with_capacity(DIGEST_BYTES_LEN + SECRET_BYTES_LEN + size_of::<u64>());
         bytes.extend(*digest_to_bytes(self.hash));
         bytes.extend(*digest_to_bytes(self.secret.expose_felts()));
         let transfer_count_uint = felts_to_u64(self.transfer_count).unwrap();
@@ -196,8 +202,10 @@ impl Nullifier {
     /// caller drops it. Do not copy the contents into logs, error contexts,
     /// or persistent storage.
     pub fn to_field_elements(&self) -> SensitiveFelts {
-        let mut elements = Vec::new();
-        elements.extend(self.hash.to_vec());
+        // Full capacity up front: growing after the secret is written would
+        // reallocate and free the old block unscrubbed.
+        let mut elements = Vec::with_capacity(NULLIFIER_SIZE_FELTS);
+        elements.extend(self.hash);
         elements.extend(self.secret.expose_felts());
         elements.extend(self.transfer_count);
         SensitiveFelts::new(elements)

--- a/wormhole/circuit/src/nullifier.rs
+++ b/wormhole/circuit/src/nullifier.rs
@@ -35,9 +35,11 @@ use plonky2::{
     },
     plonk::{circuit_builder::CircuitBuilder, config::Hasher},
 };
+use zeroize::Zeroizing;
 use zk_circuits_common::circuit::{CircuitFragment, D, F};
-use zk_circuits_common::codec::{ByteCodec, FieldElementCodec};
 use zk_circuits_common::utils::{string_to_felts, u64_to_felts, BytesDigest, Digest};
+
+use crate::sensitive::SensitiveFelts;
 
 pub const SALT_BYTES_LEN: usize = 8;
 pub const NULLIFIER_SALT: &str = "~nullif~";
@@ -60,11 +62,13 @@ pub const PREIMAGE_NUM_TARGETS: usize =
 pub const NULLIFIER_SIZE_FELTS: usize =
     POSEIDON2_OUTPUT + SECRET_NUM_TARGETS + TRANSFER_COUNT_NUM_TARGETS;
 
-/// The felt-encoded spend secret, zeroized on drop (shared with
-/// `unspendable_account`; see [`crate::sensitive`]).
+/// The spend secret, zeroized on drop (shared with `unspendable_account`
+/// and `PrivateCircuitInputs`; see [`crate::sensitive`]).
 pub use crate::sensitive::Secret;
 
-#[derive(PartialEq, Eq, Clone)]
+/// Move-only (no `Clone`): holds the spend [`Secret`], which cannot be
+/// silently duplicated.
+#[derive(PartialEq, Eq)]
 pub struct Nullifier {
     pub hash: Digest,
     /// Secret encoded with 8 bytes/felt (4 field elements for 32 bytes)
@@ -118,19 +122,22 @@ impl Nullifier {
             transfer_count: transfer_count_felts,
         }
     }
-}
 
-impl ByteCodec for Nullifier {
-    fn to_bytes(&self) -> Vec<u8> {
+    /// Serialize including the spend secret.
+    ///
+    /// Returns a [`Zeroizing`] buffer so the exposed secret is scrubbed when
+    /// the caller drops it. Do not copy the contents into logs, error
+    /// contexts, or persistent storage.
+    pub fn to_bytes(&self) -> Zeroizing<Vec<u8>> {
         let mut bytes = Vec::new();
         bytes.extend(*digest_to_bytes(self.hash));
         bytes.extend(*digest_to_bytes(self.secret.expose_felts()));
         let transfer_count_uint = felts_to_u64(self.transfer_count).unwrap();
         bytes.extend(transfer_count_uint.to_le_bytes());
-        bytes
+        Zeroizing::new(bytes)
     }
 
-    fn from_bytes(slice: &[u8]) -> anyhow::Result<Self> {
+    pub fn from_bytes(slice: &[u8]) -> anyhow::Result<Self> {
         let hash_size = DIGEST_BYTES_LEN;
         let secret_size = SECRET_BYTES_LEN;
         let transfer_count_size = size_of::<u64>();
@@ -182,18 +189,21 @@ impl ByteCodec for Nullifier {
             transfer_count,
         })
     }
-}
 
-impl FieldElementCodec for Nullifier {
-    fn to_field_elements(&self) -> Vec<F> {
+    /// Serialize including the spend secret.
+    ///
+    /// Returns [`SensitiveFelts`] so the exposed secret is scrubbed when the
+    /// caller drops it. Do not copy the contents into logs, error contexts,
+    /// or persistent storage.
+    pub fn to_field_elements(&self) -> SensitiveFelts {
         let mut elements = Vec::new();
         elements.extend(self.hash.to_vec());
         elements.extend(self.secret.expose_felts());
         elements.extend(self.transfer_count);
-        elements
+        SensitiveFelts::new(elements)
     }
 
-    fn from_field_elements(elements: &[F]) -> anyhow::Result<Self> {
+    pub fn from_field_elements(elements: &[F]) -> anyhow::Result<Self> {
         if elements.len() != NULLIFIER_SIZE_FELTS {
             return Err(anyhow::anyhow!(
                 "Expected {} field elements for Nullifier, got: {}",
@@ -340,7 +350,7 @@ mod tests {
     use super::Nullifier;
     use plonky2::field::types::Field;
     use qp_wormhole_inputs::BytesDigest;
-    use zk_circuits_common::{circuit::F, codec::FieldElementCodec};
+    use zk_circuits_common::circuit::F;
 
     #[test]
     fn from_field_elements_rejects_oversized_transfer_count_limbs() {

--- a/wormhole/circuit/src/sensitive.rs
+++ b/wormhole/circuit/src/sensitive.rs
@@ -36,12 +36,15 @@
 //! These wrappers cover the copies *we* own. Transient stack copies made
 //! while encoding the secret into field elements, and the copies plonky2
 //! keeps inside `PartialWitness`/`ProverCircuitData` during proving, are out
-//! of scope here (the latter requires upstream support to scrub).
+//! of scope here (the latter requires upstream support to scrub). One known
+//! heap instance: qp-plonky2's `hash_no_pad` (`pad10_to_rate`) copies its
+//! input — including the secret preimage — into an internal rate-aligned
+//! `Vec` and frees it unscrubbed; see `tests/heap_zeroization.rs`, which
+//! exempts exactly that block and catches every leak on our side.
 
 use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
-use plonky2::field::types::{Field, PrimeField64};
 use zeroize::Zeroize;
 use zk_circuits_common::circuit::F;
 use zk_circuits_common::utils::{
@@ -144,10 +147,17 @@ impl Drop for Secret {
 
 /// Heap buffer of field elements that may contain an exposed spend secret.
 ///
-/// `F` has no [`Zeroize`] impl (foreign type), so drop scrubs each limb via
-/// its canonical `u64` representation and overwrites the slot with `F::ZERO`.
+/// `F` has no [`Zeroize`] impl (foreign type), but its inner `u64` limb is
+/// public, so drop applies the vetted `zeroize` primitives (volatile write
+/// plus compiler fence) directly to each heap slot. A plain `*felt = F::ZERO`
+/// store would not survive: the buffer is deallocated right after, so the
+/// optimizer may treat the store as dead and elide it.
+///
 /// Prefer this (or [`zeroize::Zeroizing`] for bytes) over returning a bare
-/// `Vec` from any API that serializes [`Secret`].
+/// `Vec` from any API that serializes [`Secret`]. Callers must build the
+/// inner `Vec` with its full capacity reserved up front: a `Vec` that grows
+/// after secret material is written reallocates and frees the old block
+/// unscrubbed, which no drop-time scrub can repair.
 pub struct SensitiveFelts(Vec<F>);
 
 impl SensitiveFelts {
@@ -182,18 +192,20 @@ impl AsRef<[F]> for SensitiveFelts {
 
 impl Drop for SensitiveFelts {
     fn drop(&mut self) {
+        // In-place volatile scrub of each heap limb through the public inner
+        // `u64`. Scrubbing a `to_canonical_u64()` temporary or assigning
+        // `F::ZERO` with a plain store would leave the heap bytes intact
+        // (the temporary is a stack copy; the dead store may be elided).
         for felt in &mut self.0 {
-            let mut limb = felt.to_canonical_u64();
-            limb.zeroize();
-            *felt = F::ZERO;
+            felt.0.zeroize();
         }
-        self.0.clear();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use plonky2::field::types::Field;
 
     #[test]
     fn new_validates_and_zeroizes_source() {

--- a/wormhole/circuit/src/sensitive.rs
+++ b/wormhole/circuit/src/sensitive.rs
@@ -68,8 +68,28 @@ use zk_circuits_common::utils::{
 /// `Debug` impl, so containers must redact the field manually. Call sites
 /// that must return the secret in a heap buffer (e.g. serialization) must
 /// wrap that buffer in [`zeroize::Zeroizing`] or [`SensitiveFelts`].
-#[derive(PartialEq, Eq)]
+///
+/// Equality is constant-time rather than derived, so comparing against an
+/// attacker-controlled candidate cannot leak the secret's bytes through
+/// timing.
 pub struct Secret([u8; DIGEST_BYTES_LEN]);
+
+/// Constant-time equality: accumulate XOR differences over every byte with
+/// no data-dependent branch. [`core::hint::black_box`] on the accumulator
+/// each iteration keeps the optimizer from reasoning about its value and
+/// rewriting the loop into an early-exit compare (the same hardening the
+/// `subtle` crate uses, without taking the dependency).
+impl PartialEq for Secret {
+    fn eq(&self, other: &Self) -> bool {
+        let mut diff = 0u8;
+        for (a, b) in self.0.iter().zip(other.0.iter()) {
+            diff = core::hint::black_box(diff | (a ^ b));
+        }
+        diff == 0
+    }
+}
+
+impl Eq for Secret {}
 
 impl Secret {
     /// Takes practical ownership of the secret: validates it, moves it into
@@ -242,5 +262,20 @@ mod tests {
     #[test]
     fn sensitive_felts_have_drop_glue() {
         assert!(core::mem::needs_drop::<SensitiveFelts>());
+    }
+
+    #[test]
+    fn secret_equality_semantics() {
+        let a = Secret::try_from([0x11u8; 32]).unwrap();
+        let b = Secret::try_from([0x11u8; 32]).unwrap();
+        assert!(a == b);
+
+        // Differ only in the last byte: an early-exit compare would still
+        // return the right answer, so this only checks semantics — the
+        // constant-time property lives in the branch-free implementation.
+        let mut last_byte_differs = [0x11u8; 32];
+        last_byte_differs[31] = 0x12;
+        let c = Secret::try_from(last_byte_differs).unwrap();
+        assert!(a != c);
     }
 }

--- a/wormhole/circuit/src/sensitive.rs
+++ b/wormhole/circuit/src/sensitive.rs
@@ -8,11 +8,14 @@
 //! could silently duplicate the spend credential into stack frames, logs, or
 //! crash dumps that no drop-time scrub can reach.
 //!
-//! Two wrappers cover the secret's two encodings:
+//! Two wrappers:
 //!
-//! - [`SensitiveDigest`]: the 32-byte form held by `PrivateCircuitInputs`.
-//! - [`Secret`]: the felt-encoded form (4 felts, 8 bytes/felt) held by
-//!   `Nullifier` and `UnspendableAccount` for witness filling.
+//! - [`Secret`]: the spend secret itself, held by `PrivateCircuitInputs`,
+//!   `Nullifier`, and `UnspendableAccount`. Stores the 32-byte form and
+//!   exposes either encoding (bytes via [`Secret::expose_digest`], felts via
+//!   [`Secret::expose_felts`]).
+//! - [`SensitiveFelts`]: a heap buffer of field elements that carries an
+//!   exposed secret out of a serialization API.
 //!
 //! Shared properties:
 //!
@@ -21,9 +24,12 @@
 //!   volatile scrubbing lives in that vetted dependency.
 //! - **No `Debug`**: a container that derives `Debug` over these fields fails
 //!   to compile, forcing a redacting manual impl instead.
-//! - Duplication out of a wrapper requires an explicitly named `expose_*`
-//!   call, making every copy searchable and visible in review.
-//!   [`SensitiveDigest`] is additionally move-only (no `Clone`).
+//! - [`Secret`] is move-only (no `Clone`): duplication out of the wrapper
+//!   requires an explicitly named `expose_*` call, making every copy
+//!   searchable and visible in review.
+//! - Serialization that must carry an exposed secret returns
+//!   [`zeroize::Zeroizing`] / [`SensitiveFelts`] so the heap buffer is
+//!   scrubbed when the caller drops it — never a bare `Vec`.
 //!
 //! # Scope
 //!
@@ -32,22 +38,37 @@
 //! keeps inside `PartialWitness`/`ProverCircuitData` during proving, are out
 //! of scope here (the latter requires upstream support to scrub).
 
+use alloc::vec::Vec;
+use core::ops::{Deref, DerefMut};
+
 use plonky2::field::types::{Field, PrimeField64};
 use zeroize::Zeroize;
 use zk_circuits_common::circuit::F;
 use zk_circuits_common::utils::{
-    BytesDigest, Digest, DigestError, DIGEST_BYTES_LEN, POSEIDON2_OUTPUT,
+    bytes_to_digest, digest_to_bytes, BytesDigest, Digest, DigestError, DIGEST_BYTES_LEN,
 };
 
-/// The Wormhole spend secret: a validated 32-byte digest that is move-only
-/// and zeroized on drop.
+/// The Wormhole spend secret: a validated 32-byte digest, zeroized on drop.
 ///
 /// Construction validates the same invariant as [`BytesDigest`] (every 8-byte
-/// limb is a canonical Goldilocks element), so [`SensitiveDigest::expose_digest`]
-/// can rebuild a `BytesDigest` without re-validation.
-pub struct SensitiveDigest([u8; DIGEST_BYTES_LEN]);
+/// limb is a canonical Goldilocks element), so both `expose_*` accessors can
+/// rebuild their encoding without re-validation:
+///
+/// - [`Secret::expose_digest`] for the 32-byte form (block-header hand-off),
+/// - [`Secret::expose_felts`] for the felt encoding (witness filling). The
+///   8-bytes-per-felt conversion is lossless in both directions.
+///
+/// Move-only (no `Clone`): the only ways to duplicate the secret are the
+/// explicitly named `expose_*` calls, so every copy is searchable and
+/// visible in review. This also keeps the containing types (`Nullifier`,
+/// `UnspendableAccount`, `PrivateCircuitInputs`) move-only. There is no
+/// `Debug` impl, so containers must redact the field manually. Call sites
+/// that must return the secret in a heap buffer (e.g. serialization) must
+/// wrap that buffer in [`zeroize::Zeroizing`] or [`SensitiveFelts`].
+#[derive(PartialEq, Eq)]
+pub struct Secret([u8; DIGEST_BYTES_LEN]);
 
-impl SensitiveDigest {
+impl Secret {
     /// Takes practical ownership of the secret: validates it, moves it into
     /// the wrapper, and zeroizes the source bytes so no copy remains at the
     /// call site (also on validation failure — an invalid secret is useless
@@ -73,21 +94,41 @@ impl SensitiveDigest {
         // Validated at construction, so unchecked reconstruction is sound.
         BytesDigest::new_unchecked(self.0)
     }
+
+    /// Explicitly duplicate the secret as plain `Copy` felts
+    /// (4 felts, 8 bytes/felt — the in-circuit encoding).
+    ///
+    /// The returned array escapes this wrapper's zeroization, so keep it
+    /// transient: encode it and let it go out of scope. The deliberate name
+    /// makes every such duplication searchable and visible in review.
+    pub fn expose_felts(&self) -> Digest {
+        bytes_to_digest(self.expose_digest())
+    }
 }
 
 /// Convenience for call sites that already hold a validated digest (tests,
 /// dummy proofs). Note `BytesDigest` is `Copy`: this cannot scrub the
-/// caller's original, so real secrets should enter via
-/// [`SensitiveDigest::new`] instead.
-impl From<BytesDigest> for SensitiveDigest {
+/// caller's original, so real secrets should enter via [`Secret::new`]
+/// instead.
+impl From<BytesDigest> for Secret {
     fn from(digest: BytesDigest) -> Self {
         Self(*digest)
     }
 }
 
+/// Convenience for call sites that hold the felt encoding (deserialization).
+/// Note the source `Digest` is `Copy`, so this cannot scrub the caller's
+/// original; the felts should be transient at the call site.
+impl From<Digest> for Secret {
+    fn from(felts: Digest) -> Self {
+        // Canonical field elements always produce a valid digest.
+        Self::from(digest_to_bytes(felts))
+    }
+}
+
 /// Convenience for literals in tests and docs. Does not scrub the source
-/// array; real secrets should enter via [`SensitiveDigest::new`].
-impl TryFrom<[u8; DIGEST_BYTES_LEN]> for SensitiveDigest {
+/// array; real secrets should enter via [`Secret::new`].
+impl TryFrom<[u8; DIGEST_BYTES_LEN]> for Secret {
     type Error = DigestError;
 
     fn try_from(bytes: [u8; DIGEST_BYTES_LEN]) -> Result<Self, Self::Error> {
@@ -95,57 +136,58 @@ impl TryFrom<[u8; DIGEST_BYTES_LEN]> for SensitiveDigest {
     }
 }
 
-impl Drop for SensitiveDigest {
-    fn drop(&mut self) {
-        self.0.zeroize();
-    }
-}
-
-/// The felt-encoded spend secret (4 felts, 8 bytes/felt), zeroized on drop.
-///
-/// This is the in-circuit encoding counterpart of [`SensitiveDigest`]: the
-/// same 32-byte secret after `bytes_to_digest`, as held by `Nullifier` and
-/// `UnspendableAccount` for witness filling. It replaces the two identical
-/// `type Secret = [F; 4]` aliases those modules used to declare.
-///
-/// The limbs are stored as canonical `u64`s rather than `GoldilocksField`
-/// values because the field type is foreign and has no [`Zeroize`] impl;
-/// storing plain integers lets the vetted `zeroize` crate do the drop-time
-/// scrub without local `unsafe` (which this crate forbids). Conversion is
-/// lossless: the felts are
-/// canonicalized on the way in and rebuilt with `from_canonical_u64` on the
-/// way out.
-///
-/// Unlike [`SensitiveDigest`] this is `Clone`: the containing types need
-/// value semantics for their codecs, and every clone scrubs itself on drop,
-/// so duplication never escapes the zeroization invariant. Reading the felts
-/// out requires the explicitly named [`Secret::expose_felts`], and there is
-/// no `Debug` impl, so containers must redact it manually.
-#[derive(Clone, PartialEq, Eq)]
-pub struct Secret([u64; POSEIDON2_OUTPUT]);
-
-impl Secret {
-    /// Explicitly duplicate the secret as plain `Copy` felts.
-    ///
-    /// The returned array escapes this wrapper's zeroization, so keep it
-    /// transient: encode it and let it go out of scope. The deliberate name
-    /// makes every such duplication searchable and visible in review.
-    pub fn expose_felts(&self) -> Digest {
-        self.0.map(F::from_canonical_u64)
-    }
-}
-
-/// Note the source `Digest` is `Copy`, so this cannot scrub the caller's
-/// original; the felts should be transient at the call site.
-impl From<Digest> for Secret {
-    fn from(felts: Digest) -> Self {
-        Self(felts.map(|f| f.to_canonical_u64()))
-    }
-}
-
 impl Drop for Secret {
     fn drop(&mut self) {
         self.0.zeroize();
+    }
+}
+
+/// Heap buffer of field elements that may contain an exposed spend secret.
+///
+/// `F` has no [`Zeroize`] impl (foreign type), so drop scrubs each limb via
+/// its canonical `u64` representation and overwrites the slot with `F::ZERO`.
+/// Prefer this (or [`zeroize::Zeroizing`] for bytes) over returning a bare
+/// `Vec` from any API that serializes [`Secret`].
+pub struct SensitiveFelts(Vec<F>);
+
+impl SensitiveFelts {
+    pub fn new(elements: Vec<F>) -> Self {
+        Self(elements)
+    }
+
+    pub fn as_slice(&self) -> &[F] {
+        &self.0
+    }
+}
+
+impl Deref for SensitiveFelts {
+    type Target = [F];
+
+    fn deref(&self) -> &[F] {
+        &self.0
+    }
+}
+
+impl DerefMut for SensitiveFelts {
+    fn deref_mut(&mut self) -> &mut [F] {
+        &mut self.0
+    }
+}
+
+impl AsRef<[F]> for SensitiveFelts {
+    fn as_ref(&self) -> &[F] {
+        &self.0
+    }
+}
+
+impl Drop for SensitiveFelts {
+    fn drop(&mut self) {
+        for felt in &mut self.0 {
+            let mut limb = felt.to_canonical_u64();
+            limb.zeroize();
+            *felt = F::ZERO;
+        }
+        self.0.clear();
     }
 }
 
@@ -156,7 +198,7 @@ mod tests {
     #[test]
     fn new_validates_and_zeroizes_source() {
         let mut source = [0x11u8; 32];
-        let sensitive = SensitiveDigest::new(&mut source).unwrap();
+        let sensitive = Secret::new(&mut source).unwrap();
         assert_eq!(source, [0u8; 32], "source must be scrubbed");
         assert_eq!(sensitive.as_bytes(), &[0x11u8; 32]);
         assert_eq!(*sensitive.expose_digest(), [0x11u8; 32]);
@@ -166,7 +208,7 @@ mod tests {
     fn new_zeroizes_source_even_on_invalid_digest() {
         // All-0xFF limbs are >= the Goldilocks modulus, so validation fails.
         let mut source = [0xFFu8; 32];
-        assert!(SensitiveDigest::new(&mut source).is_err());
+        assert!(Secret::new(&mut source).is_err());
         assert_eq!(source, [0u8; 32], "source must be scrubbed on failure too");
     }
 
@@ -175,7 +217,6 @@ mod tests {
     /// for these types only while their scrubbing destructors exist.
     #[test]
     fn wrappers_have_drop_glue() {
-        assert!(core::mem::needs_drop::<SensitiveDigest>());
         assert!(core::mem::needs_drop::<Secret>());
     }
 
@@ -184,5 +225,10 @@ mod tests {
         let felts: Digest = [1u64, 2, 3, u32::MAX as u64].map(F::from_canonical_u64);
         let secret = Secret::from(felts);
         assert_eq!(secret.expose_felts(), felts);
+    }
+
+    #[test]
+    fn sensitive_felts_have_drop_glue() {
+        assert!(core::mem::needs_drop::<SensitiveFelts>());
     }
 }

--- a/wormhole/circuit/src/unspendable_account.rs
+++ b/wormhole/circuit/src/unspendable_account.rs
@@ -6,9 +6,11 @@ use plonky2::{
     plonk::{circuit_builder::CircuitBuilder, config::Hasher},
 };
 
+use zeroize::Zeroizing;
+
 use crate::inputs::CircuitInputs;
+use crate::sensitive::SensitiveFelts;
 use zk_circuits_common::circuit::{CircuitFragment, D, F};
-use zk_circuits_common::codec::{ByteCodec, FieldElementCodec};
 use zk_circuits_common::utils::{
     bytes_to_digest, digest_to_bytes, string_to_felts, BytesDigest, Digest, POSEIDON2_OUTPUT,
 };
@@ -21,11 +23,13 @@ pub const ACCOUNT_ID_NUM_TARGETS: usize = POSEIDON2_OUTPUT; // 4
 pub const PREIMAGE_NUM_TARGETS: usize = 7;
 pub const UNSPENDABLE_SALT: &str = "wormhole";
 
-/// The felt-encoded spend secret, zeroized on drop (shared with `nullifier`;
-/// see [`crate::sensitive`]).
+/// The spend secret, zeroized on drop (shared with `nullifier` and
+/// `PrivateCircuitInputs`; see [`crate::sensitive`]).
 pub use crate::sensitive::Secret;
 
-#[derive(PartialEq, Eq, Clone)]
+/// Move-only (no `Clone`): holds the spend [`Secret`], which cannot be
+/// silently duplicated.
+#[derive(PartialEq, Eq)]
 pub struct UnspendableAccount {
     /// Account ID as 4 field elements (8 bytes/felt for hash output)
     pub account_id: Digest,
@@ -83,17 +87,20 @@ impl UnspendableAccount {
             secret: secret_felts.into(),
         }
     }
-}
 
-impl ByteCodec for UnspendableAccount {
-    fn to_bytes(&self) -> Vec<u8> {
+    /// Serialize including the spend secret.
+    ///
+    /// Returns a [`Zeroizing`] buffer so the exposed secret is scrubbed when
+    /// the caller drops it. Do not copy the contents into logs, error
+    /// contexts, or persistent storage.
+    pub fn to_bytes(&self) -> Zeroizing<Vec<u8>> {
         let mut bytes = Vec::new();
         bytes.extend(*digest_to_bytes(self.account_id));
         bytes.extend(*digest_to_bytes(self.secret.expose_felts()));
-        bytes
+        Zeroizing::new(bytes)
     }
 
-    fn from_bytes(slice: &[u8]) -> anyhow::Result<Self> {
+    pub fn from_bytes(slice: &[u8]) -> anyhow::Result<Self> {
         let account_id_size = 32; // 32 bytes for account ID
         let secret_size = 32; // 32 bytes for secret
         let total_size = account_id_size + secret_size;
@@ -120,17 +127,20 @@ impl ByteCodec for UnspendableAccount {
 
         Ok(Self { account_id, secret })
     }
-}
 
-impl FieldElementCodec for UnspendableAccount {
-    fn to_field_elements(&self) -> Vec<F> {
+    /// Serialize including the spend secret.
+    ///
+    /// Returns [`SensitiveFelts`] so the exposed secret is scrubbed when the
+    /// caller drops it. Do not copy the contents into logs, error contexts,
+    /// or persistent storage.
+    pub fn to_field_elements(&self) -> SensitiveFelts {
         let mut elements = Vec::new();
         elements.extend(self.account_id.to_vec());
         elements.extend(self.secret.expose_felts());
-        elements
+        SensitiveFelts::new(elements)
     }
 
-    fn from_field_elements(elements: &[F]) -> anyhow::Result<Self> {
+    pub fn from_field_elements(elements: &[F]) -> anyhow::Result<Self> {
         // Expected sizes
         let account_id_size = ACCOUNT_ID_NUM_TARGETS; // 4
         let secret_size = SECRET_NUM_TARGETS; // 4

--- a/wormhole/circuit/src/unspendable_account.rs
+++ b/wormhole/circuit/src/unspendable_account.rs
@@ -12,7 +12,8 @@ use crate::inputs::CircuitInputs;
 use crate::sensitive::SensitiveFelts;
 use zk_circuits_common::circuit::{CircuitFragment, D, F};
 use zk_circuits_common::utils::{
-    bytes_to_digest, digest_to_bytes, string_to_felts, BytesDigest, Digest, POSEIDON2_OUTPUT,
+    bytes_to_digest, digest_to_bytes, string_to_felts, BytesDigest, Digest, DIGEST_BYTES_LEN,
+    POSEIDON2_OUTPUT,
 };
 
 /// Number of field elements for the secret (32 bytes with 8 bytes/felt encoding)
@@ -63,12 +64,16 @@ impl UnspendableAccount {
         // Use 8 bytes/felt encoding for secrets.
         let secret_felts = bytes_to_digest(secret);
 
-        // Build preimage: salt + secret
-        let mut preimage = Vec::new();
+        // Build preimage: salt + secret. Full capacity up front: growing
+        // after the secret is written would reallocate and free the old block
+        // unscrubbed. The scrubbing wrapper then zeroizes the buffer once
+        // hashing is done.
+        let mut preimage = Vec::with_capacity(PREIMAGE_NUM_TARGETS);
         preimage.extend(
             string_to_felts(UNSPENDABLE_SALT).expect("UNSPENDABLE_SALT within serialization cap"),
         );
         preimage.extend(&secret_felts);
+        let preimage = SensitiveFelts::new(preimage);
 
         if preimage.len() != PREIMAGE_NUM_TARGETS {
             panic!(
@@ -94,7 +99,9 @@ impl UnspendableAccount {
     /// the caller drops it. Do not copy the contents into logs, error
     /// contexts, or persistent storage.
     pub fn to_bytes(&self) -> Zeroizing<Vec<u8>> {
-        let mut bytes = Vec::new();
+        // Full capacity up front: growing after the secret is written would
+        // reallocate and free the old block unscrubbed.
+        let mut bytes = Vec::with_capacity(2 * DIGEST_BYTES_LEN);
         bytes.extend(*digest_to_bytes(self.account_id));
         bytes.extend(*digest_to_bytes(self.secret.expose_felts()));
         Zeroizing::new(bytes)
@@ -134,8 +141,10 @@ impl UnspendableAccount {
     /// caller drops it. Do not copy the contents into logs, error contexts,
     /// or persistent storage.
     pub fn to_field_elements(&self) -> SensitiveFelts {
-        let mut elements = Vec::new();
-        elements.extend(self.account_id.to_vec());
+        // Full capacity up front: growing after the secret is written would
+        // reallocate and free the old block unscrubbed.
+        let mut elements = Vec::with_capacity(ACCOUNT_ID_NUM_TARGETS + SECRET_NUM_TARGETS);
+        elements.extend(self.account_id);
         elements.extend(self.secret.expose_felts());
         SensitiveFelts::new(elements)
     }

--- a/wormhole/circuit/tests/heap_zeroization.rs
+++ b/wormhole/circuit/tests/heap_zeroization.rs
@@ -1,0 +1,279 @@
+//! Regression test (security review): serializing or hashing the spend
+//! secret must never free heap memory that still contains it.
+//!
+//! Two past bugs motivate this:
+//!
+//! 1. `SensitiveFelts::drop` zeroized a stack temporary from
+//!    `to_canonical_u64` and wrote `F::ZERO` back with a plain store the
+//!    optimizer may elide as dead, leaving the heap limbs intact in the
+//!    freed buffer. The fix scrubs each limb in place through the public
+//!    inner `u64` with `zeroize`'s volatile writes.
+//! 2. The serialization and hash-preimage buffers grew from `Vec::new()`,
+//!    so an `extend` after the secret was written reallocated and freed the
+//!    old block unscrubbed — invisible to any drop-time scrub. The fix
+//!    reserves full capacity up front.
+//!
+//! Mirroring `keygen_zeroization.rs` in qp-rusty-crystals, the test installs
+//! a global allocator that scans every block for the secret pattern at
+//! `dealloc` time (the block is still valid inside the hook, so the scan is
+//! sound) and asserts no secret-bearing block is ever freed uncleared.
+//! This file contains exactly one test so unrelated concurrent allocations
+//! cannot race the scanner.
+//!
+//! # Coverage
+//!
+//! Every function the spend secret flows through (the `expose_*` naming
+//! makes this surface greppable):
+//!
+//! - `Secret`: `new`, `From<BytesDigest>`, `From<Digest>`,
+//!   `TryFrom<[u8; 32]>`, `expose_digest`, `expose_felts`, drop.
+//! - `Nullifier`: `new`, `from_preimage` (Poseidon2 preimage hashing),
+//!   `From<&CircuitInputs>`, `to_bytes`, `from_bytes`, `to_field_elements`,
+//!   `from_field_elements`, drop.
+//! - `UnspendableAccount`: `new`, `from_secret` (hashing),
+//!   `From<&CircuitInputs>`, `to_bytes`, `from_bytes`, `to_field_elements`,
+//!   `from_field_elements`, drop.
+//! - `PrivateCircuitInputs` / `CircuitInputs`: holding and dropping the
+//!   secret.
+//!
+//! Deliberately excluded:
+//!
+//! - `fill_targets` (both types): copies the secret into plonky2's
+//!   `PartialWitness`, which is upstream-owned memory the `sensitive.rs`
+//!   scope note already carves out; upstream support is needed to scrub it.
+//! - Prover/aggregator entry points: they delegate to the functions above
+//!   plus plonky2 proving (same carve-out).
+//! - `Debug` impls: redaction is asserted by unit tests; formatting renders
+//!   decimal text, which a byte-pattern scanner cannot see.
+//!
+//! # Known upstream exemption
+//!
+//! qp-plonky2's `hash_no_pad` (`pad10_to_rate` in `qp-plonky2-core`) copies
+//! its input — salt, secret, and terminator — into a rate-aligned heap
+//! `Vec<F>` and frees it unscrubbed; only upstream can fix that. The
+//! scanner exempts blocks that byte-for-byte equal the two expected pad
+//! buffers (one per constructor) and nothing else, so a leak of any of the
+//! buffers this crate owns — with different sizes/layouts — still fails.
+//! This is the "copies plonky2 keeps" carve-out documented in
+//! `sensitive.rs`.
+
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::OnceLock;
+
+use plonky2::field::types::{Field, PrimeField64};
+use qp_wormhole_circuit::block_header::header::DIGEST_LOGS_SIZE;
+use qp_wormhole_circuit::inputs::{CircuitInputs, PrivateCircuitInputs, PublicCircuitInputs};
+use qp_wormhole_circuit::nullifier::{Nullifier, NULLIFIER_SALT};
+use qp_wormhole_circuit::sensitive::Secret;
+use qp_wormhole_circuit::unspendable_account::{UnspendableAccount, UNSPENDABLE_SALT};
+use zk_circuits_common::circuit::F;
+use zk_circuits_common::utils::{
+    bytes_to_digest, digest_to_bytes, string_to_felts, u64_to_felts, BytesDigest,
+};
+
+/// Distinctive 32-byte pattern; a repeated single byte could false-positive
+/// against unrelated allocator noise. Every byte is ASCII (< 0x80), so each
+/// 8-byte limb stays below the Goldilocks modulus and the pattern is a valid
+/// `BytesDigest`. On the little-endian hosts we test on, the felt encoding
+/// (one canonical `u64` per 8-byte limb) has the same in-memory bytes, so a
+/// single scan covers both the byte and felt buffers.
+const SECRET_PATTERN: [u8; 32] = *b"wormhole-zeroize-regression-pat!";
+
+static SCANNING: AtomicBool = AtomicBool::new(false);
+static SECRET_FREED_UNCLEARED: AtomicBool = AtomicBool::new(false);
+static LEAKED_BLOCK_SIZE: AtomicUsize = AtomicUsize::new(0);
+static PHASE: AtomicUsize = AtomicUsize::new(0);
+static LEAKED_PHASE: AtomicUsize = AtomicUsize::new(0);
+
+/// Byte images of qp-plonky2's internal `pad10_to_rate` buffers for the two
+/// constructor hashes (see "Known upstream exemption" above). Populated
+/// before scanning starts; only an exact whole-block match is exempted.
+static UPSTREAM_PAD_BLOCKS: OnceLock<[Vec<u8>; 2]> = OnceLock::new();
+
+fn felts_to_le_bytes(felts: &[F]) -> Vec<u8> {
+    felts
+        .iter()
+        .flat_map(|f| f.to_canonical_u64().to_le_bytes())
+        .collect()
+}
+
+struct SecretScanningAllocator;
+
+unsafe impl GlobalAlloc for SecretScanningAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if SCANNING.load(Ordering::SeqCst) && layout.size() >= SECRET_PATTERN.len() {
+            let block = unsafe { core::slice::from_raw_parts(ptr, layout.size()) };
+            if block
+                .windows(SECRET_PATTERN.len())
+                .any(|w| w == SECRET_PATTERN)
+            {
+                let known_upstream = UPSTREAM_PAD_BLOCKS
+                    .get()
+                    .is_some_and(|pads| pads.iter().any(|pad| pad.as_slice() == block));
+                if !known_upstream {
+                    SECRET_FREED_UNCLEARED.store(true, Ordering::SeqCst);
+                    LEAKED_BLOCK_SIZE.store(layout.size(), Ordering::SeqCst);
+                    LEAKED_PHASE.store(PHASE.load(Ordering::SeqCst), Ordering::SeqCst);
+                }
+            }
+        }
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: SecretScanningAllocator = SecretScanningAllocator;
+
+const TRANSFER_COUNT: u64 = 42;
+/// Poseidon2 sponge rate (`SPONGE_RATE` in qp-poseidon-core); `pad10_to_rate`
+/// pads to a multiple of this.
+const RATE: usize = 8;
+
+/// Reconstruct the two `pad10_to_rate` buffers the constructor hashes create
+/// inside qp-plonky2: `input || F::ONE`, zero-filled to a `RATE` multiple.
+fn expected_upstream_pad_blocks(secret: BytesDigest) -> [Vec<u8>; 2] {
+    let secret_felts = bytes_to_digest(secret);
+
+    let mut nullifier_pad: Vec<F> =
+        string_to_felts(NULLIFIER_SALT).expect("salt within serialization cap");
+    nullifier_pad.extend(secret_felts);
+    nullifier_pad.extend(u64_to_felts(TRANSFER_COUNT));
+    nullifier_pad.push(F::ONE);
+    nullifier_pad.resize(2 * RATE, F::ZERO);
+
+    let mut account_pad: Vec<F> =
+        string_to_felts(UNSPENDABLE_SALT).expect("salt within serialization cap");
+    account_pad.extend(secret_felts);
+    account_pad.push(F::ONE);
+    assert_eq!(
+        account_pad.len(),
+        RATE,
+        "account preimage pads to one block"
+    );
+
+    [
+        felts_to_le_bytes(&nullifier_pad),
+        felts_to_le_bytes(&account_pad),
+    ]
+}
+
+#[test]
+fn serialization_never_frees_heap_memory_containing_the_secret() {
+    let secret = BytesDigest::try_from(SECRET_PATTERN).unwrap();
+    UPSTREAM_PAD_BLOCKS
+        .set(expected_upstream_pad_blocks(secret))
+        .expect("set once");
+
+    SECRET_FREED_UNCLEARED.store(false, Ordering::SeqCst);
+    SCANNING.store(true, Ordering::SeqCst);
+
+    PHASE.store(1, Ordering::SeqCst);
+    let nullifier = Nullifier::from_preimage(secret, TRANSFER_COUNT);
+    PHASE.store(2, Ordering::SeqCst);
+    let bytes = nullifier.to_bytes();
+    let round_trip = Nullifier::from_bytes(bytes.as_ref()).expect("byte round trip");
+    assert_eq!(round_trip, nullifier);
+    drop(bytes);
+    PHASE.store(3, Ordering::SeqCst);
+    let felts = nullifier.to_field_elements();
+    let round_trip = Nullifier::from_field_elements(felts.as_slice()).expect("felt round trip");
+    assert_eq!(round_trip, nullifier);
+    drop(felts);
+    drop(round_trip);
+    drop(nullifier);
+
+    PHASE.store(4, Ordering::SeqCst);
+    let direct = Nullifier::new(
+        BytesDigest::try_from([0x11u8; 32]).unwrap(),
+        secret,
+        TRANSFER_COUNT,
+    );
+    drop(direct);
+
+    PHASE.store(5, Ordering::SeqCst);
+    let account = UnspendableAccount::from_secret(secret);
+    PHASE.store(6, Ordering::SeqCst);
+    let bytes = account.to_bytes();
+    let round_trip = UnspendableAccount::from_bytes(bytes.as_ref()).expect("byte round trip");
+    assert_eq!(round_trip, account);
+    drop(bytes);
+    PHASE.store(7, Ordering::SeqCst);
+    let felts = account.to_field_elements();
+    let round_trip =
+        UnspendableAccount::from_field_elements(felts.as_slice()).expect("felt round trip");
+    assert_eq!(round_trip, account);
+    drop(felts);
+    drop(round_trip);
+
+    PHASE.store(8, Ordering::SeqCst);
+    let direct = UnspendableAccount::new(BytesDigest::try_from([0x11u8; 32]).unwrap(), secret);
+    drop(direct);
+
+    // `From<&CircuitInputs>` conversions plus holding/dropping the secret
+    // inside `PrivateCircuitInputs`.
+    PHASE.store(9, Ordering::SeqCst);
+    let inputs = CircuitInputs {
+        private: PrivateCircuitInputs {
+            secret: Secret::from(secret),
+            transfer_count: TRANSFER_COUNT,
+            unspendable_account: digest_to_bytes(account.account_id),
+            parent_hash: BytesDigest::try_from([5u8; 32]).unwrap(),
+            state_root: BytesDigest::try_from([3u8; 32]).unwrap(),
+            extrinsics_root: BytesDigest::try_from([4u8; 32]).unwrap(),
+            digest: [0xEE; DIGEST_LOGS_SIZE],
+            input_amount: 1000,
+            zk_tree_root: [0u8; 32],
+            zk_merkle_siblings: vec![],
+            zk_merkle_positions: vec![],
+        },
+        public: PublicCircuitInputs {
+            asset_id: 0,
+            output_amount_1: 900,
+            output_amount_2: 99,
+            volume_fee_bps: 10,
+            nullifier: BytesDigest::try_from([1u8; 32]).unwrap(),
+            block_hash: BytesDigest::try_from([0u8; 32]).unwrap(),
+            exit_account_1: BytesDigest::try_from([2u8; 32]).unwrap(),
+            exit_account_2: BytesDigest::try_from([3u8; 32]).unwrap(),
+            block_number: 1,
+        },
+    };
+    let from_inputs = Nullifier::from(&inputs);
+    assert_eq!(from_inputs.secret.expose_felts(), bytes_to_digest(secret));
+    drop(from_inputs);
+    let from_inputs = UnspendableAccount::from(&inputs);
+    assert_eq!(from_inputs.secret.expose_felts(), bytes_to_digest(secret));
+    drop(from_inputs);
+    drop(inputs);
+    drop(account);
+
+    // `Secret` entry points and explicit `expose_*` duplication.
+    PHASE.store(10, Ordering::SeqCst);
+    let mut source = SECRET_PATTERN;
+    let owned = Secret::new(&mut source).expect("valid digest");
+    assert_eq!(source, [0u8; 32], "Secret::new must scrub its source");
+    let via_digest = Secret::from(owned.expose_digest());
+    let via_felts = Secret::from(owned.expose_felts());
+    let via_array = Secret::try_from(SECRET_PATTERN).expect("valid digest");
+    assert!(owned == via_digest && via_digest == via_felts && via_felts == via_array);
+    drop(owned);
+    drop(via_digest);
+    drop(via_felts);
+    drop(via_array);
+
+    SCANNING.store(false, Ordering::SeqCst);
+
+    assert!(
+        !SECRET_FREED_UNCLEARED.load(Ordering::SeqCst),
+        "a heap block of {} bytes still containing the spend secret was freed \
+         unscrubbed during phase {}; check SensitiveFelts::drop and the \
+         with_capacity pre-sizing of the serialization/preimage buffers",
+        LEAKED_BLOCK_SIZE.load(Ordering::SeqCst),
+        LEAKED_PHASE.load(Ordering::SeqCst)
+    );
+}

--- a/wormhole/tests/src/circuit/nullifier_tests.rs
+++ b/wormhole/tests/src/circuit/nullifier_tests.rs
@@ -3,7 +3,6 @@ use test_helpers::{DEFAULT_SECRETS, DEFAULT_TRANSFER_COUNTS};
 use wormhole_circuit::nullifier::{Nullifier, NullifierTargets};
 use zk_circuits_common::{
     circuit::{CircuitFragment, C, D, F},
-    codec::FieldElementCodec,
     utils::{bytes_to_digest, BytesDigest},
 };
 

--- a/wormhole/tests/src/circuit/unspendable_account_tests.rs
+++ b/wormhole/tests/src/circuit/unspendable_account_tests.rs
@@ -2,7 +2,6 @@ use plonky2::{field::types::Field, plonk::proof::ProofWithPublicInputs};
 use wormhole_circuit::unspendable_account::{UnspendableAccount, UnspendableAccountTargets};
 use zk_circuits_common::{
     circuit::{CircuitFragment, C, D, F},
-    codec::FieldElementCodec,
     utils::{bytes_to_digest, digest_to_bytes, BytesDigest},
 };
 


### PR DESCRIPTION
## Summary

- Closes the secret-leak footgun in `Nullifier` / `UnspendableAccount` serialization: public `ByteCodec` / `FieldElementCodec` impls called `expose_felts()` and returned bare `Vec` buffers that were never zeroized. Those trait impls are gone; inherent methods now return `Zeroizing<Vec<u8>>` / `SensitiveFelts` so the buffer is scrubbed on drop.
- Merges `SensitiveDigest` into a single move-only `Secret` (stores the validated 32-byte form; exposes bytes via `expose_digest()` and felts via `expose_felts()`). `PrivateCircuitInputs`, `Nullifier`, and `UnspendableAccount` all hold the same type.
- Drops `Clone` from `Secret`, `Nullifier`, and `UnspendableAccount` so the spend credential cannot be silently duplicated — only explicit `expose_*` calls remain.

## Motivation

The `sensitive` module contract says secret duplication must go through named `expose_*` calls and that resulting copies stay transient. Codec methods violated that by putting the secret into ordinary heap buffers. The prover witness path did not call these APIs, but the surface allowed misuse (logs, error contexts, persistent storage).

## Breaking changes

- `Nullifier` / `UnspendableAccount` no longer implement `ByteCodec` or `FieldElementCodec`. Use inherent `to_bytes` / `from_bytes` / `to_field_elements` / `from_field_elements`.
- `to_bytes` returns `Zeroizing<Vec<u8>>`; `to_field_elements` returns `SensitiveFelts` (not bare `Vec`s).
- `SensitiveDigest` is removed; use `Secret`.
- `Secret`, `Nullifier`, and `UnspendableAccount` are no longer `Clone`.

## Test plan

- [x] `cargo test -p qp-wormhole-circuit --lib`
- [x] `cargo test -p tests codec`
- [x] `cargo clippy --workspace --all-targets`
- [ ] Confirm no downstream crates in the monorepo / consumers still call the removed trait impls or clone these types
- [ ] Manual review: greppable `expose_digest` / `expose_felts` call sites remain the only secret-duplication paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spend-credential APIs and breaking serialization/Clone semantics for security-critical types; prover witness paths use `From<CircuitInputs>` and should be unaffected, but downstream crates using the removed trait impls need migration.
> 
> **Overview**
> **Tightens how the wormhole spend secret is stored and serialized** so it cannot leak through ordinary `Vec` buffers or silent copies.
> 
> `SensitiveDigest` is removed in favor of a single move-only **`Secret`** (32-byte validated form with `expose_digest` / `expose_felts`). `PrivateCircuitInputs`, `Nullifier`, and `UnspendableAccount` all use that type.
> 
> **`Nullifier` and `UnspendableAccount` no longer implement `ByteCodec` / `FieldElementCodec`**, which previously called `expose_felts()` and returned bare heap buffers. Inherent `to_bytes` / `to_field_elements` now return **`Zeroizing<Vec<u8>>`** and **`SensitiveFelts`** (new zeroize-on-drop felt buffer). **`Clone` is removed** from `Secret`, `Nullifier`, and `UnspendableAccount`.
> 
> Workspace **`zeroize`** gains the **`alloc`** feature for `Zeroizing<Vec<u8>>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eac0dfe2ad9c33035f2869d1acf97c42513fa6cf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->