### PR TITLE
V12 zk-e2e

### DIFF
--- a/common/src/circuit.rs
+++ b/common/src/circuit.rs
@@ -413,6 +413,163 @@ pub fn wormhole_public_batch_circuit_config() -> CircuitConfig {
     CircuitConfig::standard_recursion_config() // zero_knowledge: false
 }
 
+// ============================================================================
+// CircuitConfig structural validation
+// ============================================================================
+//
+// Shared policy enforced by every public Wormhole circuit constructor before
+// the config reaches `CircuitBuilder::new` (audit finding: constructors
+// treated caller-supplied `CircuitConfig` as trusted, so structurally
+// impossible values panicked deep inside plonky2 mid-construction and
+// resource-pathological values caused exponential allocations during the
+// expensive build phase). The same floors/ceilings back the memprof CLI's
+// flag validation; keep them here so the two policies cannot drift.
+
+/// The Poseidon gate needs 135 wire columns; a smaller `num_wires` panics
+/// deep inside plonky2's `check_gate_compatibility` mid-build instead of
+/// failing at the API boundary.
+pub const MIN_NUM_WIRES: usize = 135;
+
+/// Structural routed-wire floor for the pinned plonky2 recursion stack.
+///
+/// Gates pack operations into the routed-wire prefix, and several derive
+/// their op count from `num_routed_wires`: base arithmetic uses 4 routed
+/// wires per op, extension arithmetic `4*D = 8`, and the FRI verifier's
+/// random-access gate `2 + 2^4 = 18` per copy. Below a gate's width it
+/// instantiates with ZERO operation slots: `find_slot`'s `num_ops - 1`
+/// underflows (debug panic; in release an under-constraining zero-op gate is
+/// added and the build only dies later on a routability assert). The binding
+/// floor is the 16-point coset-interpolation gate, which routes
+/// `1 + 16*D + D + D = 37` wires outright; plonky2's own
+/// `check_recursion_config` assert for it fires only mid-build.
+pub const MIN_NUM_ROUTED_WIRES: usize = 37;
+
+/// Poseidon constraints have degree 7; a smaller quotient degree factor
+/// cannot express them and fails during circuit construction.
+pub const MIN_MAX_QUOTIENT_DEGREE_FACTOR: usize = 7;
+
+/// Ceiling for FRI `rate_bits`. The exponent drives exponential allocations
+/// deep inside plonky2 (`FriParams::lde_size` is
+/// `1 << (degree_bits + rate_bits)` per committed polynomial), so an
+/// oversized value passes construction and then makes massive allocations or
+/// trips asserts only after the expensive circuit build has started.
+/// Production is 3; 8 already means a 32x-production LDE.
+pub const MAX_RATE_BITS: usize = 8;
+
+/// Ceiling for FRI `cap_height`. The Merkle cap is `1 << cap_height` hashes
+/// per oracle, and the recursive verifier allocates `1 << cap_height` hash
+/// targets for the verifier data (`add_virtual_cap`), all registered as
+/// public inputs — so this knob blows up circuit size exponentially, not
+/// just proof size. `MerkleTree::new` additionally asserts
+/// `cap_height <= degree_bits + rate_bits` only mid-build; with the cap
+/// bounded at 8 (16x the production cap of 4) that assert is unreachable
+/// for any real Wormhole circuit (`degree_bits >= 12`), so the bound also
+/// serves as the cap/degree consistency guard.
+pub const MAX_CAP_HEIGHT: usize = 8;
+
+/// `ceil(log2(n))` for `n >= 1`, mirroring plonky2's `log2_ceil`.
+fn log2_ceil(n: usize) -> usize {
+    (usize::BITS - (n - 1).leading_zeros()) as usize
+}
+
+/// Structural and resource-bound validation for a caller-supplied
+/// [`CircuitConfig`], enforced by every public Wormhole circuit constructor
+/// BEFORE the config reaches `CircuitBuilder::new`.
+///
+/// Rejects, with a controlled error instead of a mid-build panic or an
+/// exponential allocation:
+/// - zero-valued knobs (`num_challenges`, `security_bits`,
+///   `fri_config.num_query_rounds`) that plonky2 only trips over deep
+///   inside construction or proving;
+/// - structural floors of the pinned recursion stack
+///   (`num_wires >= 135`, `37 <= num_routed_wires <= num_wires`,
+///   `max_quotient_degree_factor >= 7`);
+/// - FRI exponent ceilings (`rate_bits <= 8`, `cap_height <= 8`), both of
+///   which drive `1 << x` work and memory;
+/// - the rate/quotient consistency rule
+///   (`rate_bits >= ceil(log2(max_quotient_degree_factor))`) that plonky2's
+///   prover asserts only at proving time, after the full circuit build.
+///
+/// This is deliberately a STRUCTURAL policy, not a canonicality check:
+/// profiling sweeps and tests legitimately build variant configs, and
+/// canonicality of production artifacts is pinned at the artifact-load
+/// boundaries. Every canonical `wormhole_*_circuit_config()` passes.
+pub fn validate_circuit_config(config: &CircuitConfig) -> anyhow::Result<()> {
+    use anyhow::ensure;
+
+    for (name, value) in [
+        ("num_challenges", config.num_challenges),
+        ("security_bits", config.security_bits),
+        (
+            "fri_config.num_query_rounds",
+            config.fri_config.num_query_rounds,
+        ),
+    ] {
+        ensure!(value > 0, "circuit config {} must be greater than 0", name);
+    }
+
+    ensure!(
+        config.num_wires >= MIN_NUM_WIRES,
+        "circuit config num_wires ({}) must be >= {} (Poseidon gate floor)",
+        config.num_wires,
+        MIN_NUM_WIRES,
+    );
+    ensure!(
+        config.num_routed_wires >= MIN_NUM_ROUTED_WIRES,
+        "circuit config num_routed_wires ({}) must be >= {} (recursion gate floor: the FRI \
+         coset-interpolation gate routes 37 wires, and narrower widths leave slot-packed gates \
+         with zero operation slots)",
+        config.num_routed_wires,
+        MIN_NUM_ROUTED_WIRES,
+    );
+    ensure!(
+        config.num_routed_wires <= config.num_wires,
+        "circuit config num_routed_wires ({}) must be <= num_wires ({}); routed wires are a \
+         prefix of the wire columns",
+        config.num_routed_wires,
+        config.num_wires,
+    );
+    ensure!(
+        config.max_quotient_degree_factor >= MIN_MAX_QUOTIENT_DEGREE_FACTOR,
+        "circuit config max_quotient_degree_factor ({}) must be >= {} (Poseidon constraint \
+         degree)",
+        config.max_quotient_degree_factor,
+        MIN_MAX_QUOTIENT_DEGREE_FACTOR,
+    );
+    ensure!(
+        config.fri_config.rate_bits <= MAX_RATE_BITS,
+        "circuit config fri_config.rate_bits ({}) must be <= {} (LDE memory doubles per bit: \
+         lde_size = 2^(degree_bits + rate_bits) per committed polynomial)",
+        config.fri_config.rate_bits,
+        MAX_RATE_BITS,
+    );
+    ensure!(
+        config.fri_config.cap_height <= MAX_CAP_HEIGHT,
+        "circuit config fri_config.cap_height ({}) must be <= {} (Merkle caps and recursive \
+         verifier-data allocations scale as 2^cap_height)",
+        config.fri_config.cap_height,
+        MAX_CAP_HEIGHT,
+    );
+
+    // Plonky2's prover asserts `ceil(log2(quotient_degree_factor)) <=
+    // rate_bits` only at proving time, after the full circuit build; reject
+    // the doomed pair up front. With the quotient floor of 7 (bits = 3) this
+    // also means rate_bits below 3 can never prove.
+    let quotient_degree_bits = log2_ceil(config.max_quotient_degree_factor);
+    ensure!(
+        config.fri_config.rate_bits >= quotient_degree_bits,
+        "circuit config fri_config.rate_bits ({}) must be >= \
+         ceil(log2(max_quotient_degree_factor = {})) = {}; plonky2's prover cannot compute \
+         quotient chunks of degree higher than the FRI rate and asserts this only at proving \
+         time, after the full circuit build",
+        config.fri_config.rate_bits,
+        config.max_quotient_degree_factor,
+        quotient_degree_bits,
+    );
+
+    Ok(())
+}
+
 pub trait CircuitFragment {
     /// The targets that the circuit operates on. These are constrained in the circuit definition
     /// and filled with [`Self::fill_targets`].
@@ -427,6 +584,94 @@ pub trait CircuitFragment {
         pw: &mut PartialWitness<F>,
         targets: Self::Targets,
     ) -> anyhow::Result<()>;
+}
+
+#[cfg(test)]
+mod validate_circuit_config_tests {
+    use super::*;
+
+    #[test]
+    fn canonical_wormhole_configs_pass() {
+        validate_circuit_config(&wormhole_leaf_circuit_config()).unwrap();
+        validate_circuit_config(&wormhole_private_batch_circuit_config()).unwrap();
+        validate_circuit_config(&wormhole_public_batch_circuit_config()).unwrap();
+        validate_circuit_config(&CircuitConfig::standard_recursion_config()).unwrap();
+        validate_circuit_config(&CircuitConfig::standard_recursion_zk_config()).unwrap();
+    }
+
+    #[test]
+    fn structural_floors_are_enforced() {
+        let mut cfg = wormhole_private_batch_circuit_config();
+        cfg.num_wires = MIN_NUM_WIRES - 1;
+        let err = validate_circuit_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("num_wires"), "got: {err}");
+
+        let mut cfg = wormhole_private_batch_circuit_config();
+        cfg.num_routed_wires = MIN_NUM_ROUTED_WIRES - 1;
+        let err = validate_circuit_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("num_routed_wires"), "got: {err}");
+
+        let mut cfg = wormhole_private_batch_circuit_config();
+        cfg.num_routed_wires = cfg.num_wires + 1;
+        let err = validate_circuit_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("prefix"), "got: {err}");
+
+        let mut cfg = wormhole_private_batch_circuit_config();
+        cfg.max_quotient_degree_factor = MIN_MAX_QUOTIENT_DEGREE_FACTOR - 1;
+        let err = validate_circuit_config(&cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("max_quotient_degree_factor"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn fri_exponent_ceilings_are_enforced() {
+        for bits in [MAX_RATE_BITS + 1, 20, 63, usize::MAX] {
+            let mut cfg = wormhole_private_batch_circuit_config();
+            cfg.fri_config.rate_bits = bits;
+            let err = validate_circuit_config(&cfg).unwrap_err();
+            assert!(err.to_string().contains("rate_bits"), "got: {err}");
+
+            let mut cfg = wormhole_private_batch_circuit_config();
+            cfg.fri_config.cap_height = bits;
+            let err = validate_circuit_config(&cfg).unwrap_err();
+            assert!(err.to_string().contains("cap_height"), "got: {err}");
+        }
+        // The ceilings themselves pass.
+        let mut cfg = wormhole_private_batch_circuit_config();
+        cfg.fri_config.rate_bits = MAX_RATE_BITS;
+        cfg.fri_config.cap_height = MAX_CAP_HEIGHT;
+        validate_circuit_config(&cfg).unwrap();
+    }
+
+    #[test]
+    fn rate_bits_below_quotient_degree_are_rejected() {
+        for bits in [1, 2] {
+            let mut cfg = wormhole_private_batch_circuit_config();
+            cfg.fri_config.rate_bits = bits;
+            let err = validate_circuit_config(&cfg).unwrap_err();
+            assert!(err.to_string().contains("proving time"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn zero_knobs_are_rejected() {
+        let mut cfg = wormhole_private_batch_circuit_config();
+        cfg.num_challenges = 0;
+        let err = validate_circuit_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("num_challenges"), "got: {err}");
+
+        let mut cfg = wormhole_private_batch_circuit_config();
+        cfg.fri_config.num_query_rounds = 0;
+        let err = validate_circuit_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("num_query_rounds"), "got: {err}");
+
+        let mut cfg = wormhole_private_batch_circuit_config();
+        cfg.security_bits = 0;
+        let err = validate_circuit_config(&cfg).unwrap_err();
+        assert!(err.to_string().contains("security_bits"), "got: {err}");
+    }
 }
 
 #[cfg(test)]

--- a/wormhole/aggregator/src/aggregator.rs
+++ b/wormhole/aggregator/src/aggregator.rs
@@ -78,7 +78,8 @@ use zk_circuits_common::{
 
 use crate::pool::{BatchKey, BucketStats, PoolLimits, ProofPool};
 use crate::public_batch::prover::{
-    verify_dummy_private_batch_template, PublicBatchInputs, PublicBatchProver,
+    preflight_private_batch_proofs, verify_dummy_private_batch_template, PublicBatchInputs,
+    PublicBatchProver,
 };
 use crate::{
     common::utils::{
@@ -184,6 +185,20 @@ impl ProvingContext {
     /// proving worker without holding whatever lock guards the aggregator —
     /// this context is owned, so nothing here needs the lock.
     pub fn prove_batch(&self, proofs: Vec<Proof>) -> Result<Proof> {
+        // Admission checks BEFORE the expensive circuit construction below:
+        // everything commit rejects that can be derived without circuit
+        // targets (count bounds, public-input shape, cryptographic
+        // verification, batch compatibility) runs here first, so a caller
+        // submitting a known-bad proof vector cannot force a full circuit
+        // build per request (audit finding: empty/oversized vectors were
+        // rejected only after PublicBatchProver::new).
+        preflight_private_batch_proofs(
+            &proofs,
+            self.num_private_batch_proofs,
+            &self.private_batch_verifier,
+        )
+        .context("private-batch proof vector rejected before building the public-batch prover")?;
+
         let prover = PublicBatchProver::new(
             wormhole_public_batch_circuit_config(),
             self.private_batch_verifier.common.clone(),

--- a/wormhole/aggregator/src/common/utils.rs
+++ b/wormhole/aggregator/src/common/utils.rs
@@ -263,7 +263,9 @@ pub fn ensure_config_is_canonical(
 }
 
 pub fn canonical_leaf_verifier_data() -> VerifierCircuitData<F, C, D> {
-    WormholeCircuit::new(wormhole_leaf_circuit_config()).build_verifier()
+    WormholeCircuit::new(wormhole_leaf_circuit_config())
+        .expect("canonical wormhole leaf circuit config is valid")
+        .build_verifier()
 }
 
 pub fn canonical_private_batch_verifier_data(

--- a/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/private_batch/circuit/circuit_logic.rs
@@ -50,7 +50,7 @@ use plonky2::{
 use qp_wormhole_inputs::validate_proof_count;
 
 use zk_circuits_common::{
-    circuit::{C, D, F},
+    circuit::{validate_circuit_config, C, D, F},
     gadgets::{bytes_digest_eq, limb1_at_offset, limbs4_at_offset, sort_digests4},
 };
 
@@ -80,13 +80,18 @@ impl PrivateBatchCircuit {
     /// Build a monolithic private-batch aggregation circuit that verifies `n_leaf` wormhole leaf proofs.
     ///
     /// The `leaf_verifier_only` is baked in as constants to prevent verifier key substitution.
-    /// Returns an error when `n_leaf` is outside the supported range.
+    /// Returns an error when `n_leaf` is outside the supported range or when
+    /// `config` fails the shared structural policy
+    /// ([`validate_circuit_config`]) — an unchecked config would otherwise
+    /// panic deep inside plonky2 mid-construction or drive exponential
+    /// allocations during the expensive build phase (audit finding).
     pub fn new(
         config: CircuitConfig,
         leaf_common: &CommonCircuitData<F, D>,
         leaf_verifier_only: &VerifierOnlyCircuitData<C, D>,
         n_leaf: usize,
     ) -> Result<Self> {
+        validate_circuit_config(&config)?;
         validate_proof_count(n_leaf, "n_leaf")?;
 
         // Runtime (not debug-only) shape check: the wrapper constraints index
@@ -1996,6 +2001,39 @@ mod tests {
         private_batch_data
             .verify(private_batch_proof)
             .expect("private-batch verify should succeed");
+    }
+
+    /// Audit finding: the constructor forwarded the caller-supplied
+    /// `CircuitConfig` to `CircuitBuilder::new` unchecked. Structurally
+    /// impossible configs (e.g. `num_wires` below the Poseidon gate floor)
+    /// panicked deep inside plonky2 mid-construction, and resource-pathological
+    /// configs (e.g. an oversized FRI rate driving `2^(degree_bits+rate_bits)`
+    /// LDE allocations) sailed through construction and only exploded during
+    /// the expensive build/prove phase. Both classes must be rejected with a
+    /// controlled error before any builder work.
+    #[test]
+    fn new_rejects_pathological_circuit_configs() {
+        let (leaf, _) = build_fake_leaf_circuit();
+
+        // Structurally impossible: below the Poseidon gate wire floor.
+        let mut narrow = wormhole_private_batch_circuit_config();
+        narrow.num_wires = 134;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            PrivateBatchCircuit::new(narrow, &leaf.common, &leaf.verifier_only, 1)
+        }));
+        let err = result
+            .expect("pathological num_wires must yield a controlled error, not a panic")
+            .err()
+            .expect("num_wires below the Poseidon gate floor must be rejected");
+        assert!(err.to_string().contains("num_wires"), "got: {err}");
+
+        // Resource-pathological: oversized FRI rate (exponential LDE size).
+        let mut huge_rate = wormhole_private_batch_circuit_config();
+        huge_rate.fri_config.rate_bits = 63;
+        let err = PrivateBatchCircuit::new(huge_rate, &leaf.common, &leaf.verifier_only, 1)
+            .err()
+            .expect("oversized rate_bits must be rejected before construction");
+        assert!(err.to_string().contains("rate_bits"), "got: {err}");
     }
 
     /// The constructor must reject inner circuits whose public-input length

--- a/wormhole/aggregator/src/private_batch/prover/mod.rs
+++ b/wormhole/aggregator/src/private_batch/prover/mod.rs
@@ -39,5 +39,5 @@ pub mod lib;
 pub(crate) mod witness;
 
 pub(crate) use lib::verify_dummy_leaf_template;
-pub(crate) use witness::fill_private_batch_witness;
 pub use lib::PrivateBatchProver;
+pub(crate) use witness::fill_private_batch_witness;

--- a/wormhole/aggregator/src/private_batch/prover/mod.rs
+++ b/wormhole/aggregator/src/private_batch/prover/mod.rs
@@ -1,6 +1,43 @@
+//! Private-batch aggregation prover.
+//!
+//! # Admission boundary
+//!
+//! [`PrivateBatchProver::commit`] is the untrusted-input boundary: it
+//! cryptographically verifies each leaf proof against the pinned leaf
+//! verifier, enforces batch metadata compatibility, rejects empty and
+//! all-dummy batches, and pads with the validated dummy template — all
+//! before the expensive recursive proving run. The low-level witness filler
+//! (`witness::fill_private_batch_witness`) performs only structural
+//! proof-shape checks and target assignment, assuming those invariants
+//! already hold, so it must not be reachable from outside the crate
+//! (audit finding: the exported helper let downstream services feed
+//! invalid, incompatible, or all-dummy proof vectors straight into the
+//! proving path, bypassing commit; mirrors the public-batch prover's
+//! `pub(crate)` stance):
+//!
+//! ```compile_fail
+//! use qp_wormhole_aggregator::private_batch::prover::witness::fill_private_batch_witness;
+//! ```
+//!
+//! A `compile_fail` test passes on ANY compile error, so on its own it
+//! would keep passing — for the wrong reason — if the crate or module were
+//! renamed. The passing companion below pins the same fully qualified path
+//! prefix, so only the `witness` segment's privacy can be what fails above:
+//!
+//! ```
+//! use qp_wormhole_aggregator::private_batch::prover::PrivateBatchProver;
+//! ```
+
 pub mod lib;
-pub mod witness;
+/// Low-level witness filler — not an untrusted-input boundary.
+///
+/// Cryptographic verification, metadata compatibility, dummy-padding, and the
+/// non-all-dummy admission check live in [`PrivateBatchProver::commit`]. This
+/// module is `pub(crate)` so downstream services cannot bypass those checks by
+/// calling [`witness::fill_private_batch_witness`] directly (see the module
+/// docs above and the public-batch analogue).
+pub(crate) mod witness;
 
 pub(crate) use lib::verify_dummy_leaf_template;
+pub(crate) use witness::fill_private_batch_witness;
 pub use lib::PrivateBatchProver;
-pub use witness::fill_private_batch_witness;

--- a/wormhole/aggregator/src/public_batch/circuit/circuit_logic.rs
+++ b/wormhole/aggregator/src/public_batch/circuit/circuit_logic.rs
@@ -27,7 +27,7 @@ use plonky2::{
 use qp_wormhole_inputs::validate_proof_count;
 
 use zk_circuits_common::{
-    circuit::{C, D, F},
+    circuit::{validate_circuit_config, C, D, F},
     gadgets::bytes_digest_eq,
 };
 
@@ -55,7 +55,11 @@ impl PublicBatchCircuit {
     /// Build a monolithic public-batch aggregation circuit that verifies `n_inner` private-batch aggregated proofs.
     ///
     /// The `private_batch_verifier_only` is baked in as constants to prevent verifier key substitution.
-    /// Returns an error for unsupported counts or an inconsistent private-batch PI shape.
+    /// Returns an error for unsupported counts, an inconsistent private-batch
+    /// PI shape, or a `config` failing the shared structural policy
+    /// ([`validate_circuit_config`]) — an unchecked config would otherwise
+    /// panic deep inside plonky2 mid-construction or drive exponential
+    /// allocations during the expensive build phase (audit finding).
     pub fn new(
         config: CircuitConfig,
         private_batch_common: CommonCircuitData<F, D>,
@@ -63,6 +67,7 @@ impl PublicBatchCircuit {
         n_inner: usize,
         private_batch_num_leaves: usize,
     ) -> Result<Self> {
+        validate_circuit_config(&config)?;
         validate_proof_count(n_inner, "n_inner")?;
         validate_proof_count(private_batch_num_leaves, "private_batch_num_leaves")?;
 
@@ -328,6 +333,62 @@ mod tests {
 
     const NUM_LEAVES: usize = 2; // 2 leaf proofs per private-batch batch (fast)
     const N_INNER: usize = 2; // 2 private-batch proofs aggregated into one public-batch proof
+
+    /// Audit finding: the constructor forwarded the caller-supplied
+    /// `CircuitConfig` to `CircuitBuilder::new` unchecked. Structurally
+    /// impossible configs (e.g. `num_wires` below the Poseidon gate floor)
+    /// panicked deep inside plonky2 mid-construction, and resource-pathological
+    /// configs (e.g. an oversized FRI rate driving `2^(degree_bits+rate_bits)`
+    /// LDE allocations) sailed through construction and only exploded during
+    /// the expensive build/prove phase. Both classes must be rejected with a
+    /// controlled error before any builder work. Mirrors the private-batch
+    /// constructor test one layer down.
+    #[test]
+    fn new_rejects_pathological_circuit_configs() {
+        use zk_circuits_common::circuit::wormhole_public_batch_circuit_config;
+
+        let (leaf, _) = build_fake_leaf_circuit();
+        let private_batch = PrivateBatchCircuit::new(
+            CircuitConfig::standard_recursion_config(),
+            &leaf.common,
+            &leaf.verifier_only,
+            1,
+        )
+        .unwrap()
+        .build_verifier();
+
+        // Structurally impossible: below the Poseidon gate wire floor.
+        let mut narrow = wormhole_public_batch_circuit_config();
+        narrow.num_wires = 134;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            PublicBatchCircuit::new(
+                narrow,
+                private_batch.common.clone(),
+                &private_batch.verifier_only,
+                1,
+                1,
+            )
+        }));
+        let err = result
+            .expect("pathological num_wires must yield a controlled error, not a panic")
+            .err()
+            .expect("num_wires below the Poseidon gate floor must be rejected");
+        assert!(err.to_string().contains("num_wires"), "got: {err}");
+
+        // Resource-pathological: oversized FRI rate (exponential LDE size).
+        let mut huge_rate = wormhole_public_batch_circuit_config();
+        huge_rate.fri_config.rate_bits = 63;
+        let err = PublicBatchCircuit::new(
+            huge_rate,
+            private_batch.common.clone(),
+            &private_batch.verifier_only,
+            1,
+            1,
+        )
+        .err()
+        .expect("oversized rate_bits must be rejected before construction");
+        assert!(err.to_string().contains("rate_bits"), "got: {err}");
+    }
 
     /// Build one leaf PI array in the Bitcoin-style 2-output layout.
     ///

--- a/wormhole/aggregator/src/public_batch/prover/lib.rs
+++ b/wormhole/aggregator/src/public_batch/prover/lib.rs
@@ -275,38 +275,11 @@ impl PublicBatchProver {
 
         let aggregator_address_felts = bytes_to_digest(aggregator_address);
 
-        if proofs.is_empty() {
-            bail!("no private-batch proofs to aggregate");
-        }
-        if proofs.len() > self.num_private_batch_proofs {
-            bail!(
-                "Expected at most {} private-batch proofs, but got {}",
-                self.num_private_batch_proofs,
-                proofs.len()
-            );
-        }
-
-        let expected_pi_len = targets
-            .private_batch_proofs
-            .first()
-            .map(|proof| proof.public_inputs.len())
-            .ok_or_else(|| anyhow!("public-batch circuit has no private-batch proof targets"))?;
-        for (index, proof) in proofs.iter().enumerate() {
-            ensure_proof_public_input_len(proof, expected_pi_len, "private-batch proof")
-                .with_context(|| format!("private-batch proof {} is malformed", index))?;
-            self.private_batch_verifier
-                .verify(proof.clone())
-                .map_err(|e| {
-                    anyhow!(
-                        "private-batch proof {} failed verification against the pinned \
-                         private-batch verifier: {}",
-                        index,
-                        e
-                    )
-                })?;
-        }
-
-        ensure_private_batch_compatible(&proofs)?;
+        preflight_private_batch_proofs(
+            &proofs,
+            self.num_private_batch_proofs,
+            &self.private_batch_verifier,
+        )?;
 
         // Pad partial batches with the dummy template. No shuffle: forwarding is
         // order-preserving by design (per-segment attribution on-chain).
@@ -330,6 +303,54 @@ impl PublicBatchProver {
             .prove(self.partial_witness)
             .map_err(|e| anyhow!("Failed to prove public-batch aggregation circuit: {}", e))
     }
+}
+
+/// Admission checks for a caller-supplied private-batch proof vector: count
+/// bounds (non-empty, at most `num_private_batch_proofs`), public-input
+/// shape, cryptographic verification against the pinned private-batch
+/// verifier, and cross-proof batch compatibility.
+///
+/// Everything here is derived from the verifier data alone — no circuit
+/// targets — so callers that build a [`PublicBatchProver`] per request (e.g.
+/// [`crate::aggregator::ProvingContext::prove_batch`]) can run it BEFORE the
+/// expensive circuit construction, and a known-bad request costs
+/// milliseconds instead of a circuit build (audit finding: commit's
+/// admission checks ran only after `PublicBatchProver::new`).
+/// [`PublicBatchProver::commit`] runs the same checks so direct prover users
+/// remain covered.
+pub(crate) fn preflight_private_batch_proofs(
+    proofs: &[ProofWithPublicInputs<F, C, D>],
+    num_private_batch_proofs: usize,
+    private_batch_verifier: &VerifierCircuitData<F, C, D>,
+) -> Result<()> {
+    if proofs.is_empty() {
+        bail!("no private-batch proofs to aggregate");
+    }
+    if proofs.len() > num_private_batch_proofs {
+        bail!(
+            "Expected at most {} private-batch proofs, but got {}",
+            num_private_batch_proofs,
+            proofs.len()
+        );
+    }
+
+    // The circuit's proof targets are allocated from this same common data,
+    // so this matches the shape commit used to read off the targets.
+    let expected_pi_len = private_batch_verifier.common.num_public_inputs;
+    for (index, proof) in proofs.iter().enumerate() {
+        ensure_proof_public_input_len(proof, expected_pi_len, "private-batch proof")
+            .with_context(|| format!("private-batch proof {} is malformed", index))?;
+        private_batch_verifier.verify(proof.clone()).map_err(|e| {
+            anyhow!(
+                "private-batch proof {} failed verification against the pinned \
+                 private-batch verifier: {}",
+                index,
+                e
+            )
+        })?;
+    }
+
+    ensure_private_batch_compatible(proofs)
 }
 
 /// Check that a set of private-batch proofs is mutually compatible under the

--- a/wormhole/aggregator/src/public_batch/prover/mod.rs
+++ b/wormhole/aggregator/src/public_batch/prover/mod.rs
@@ -9,5 +9,5 @@ pub mod lib;
 /// all-dummy batches occupy a proving window).
 pub(crate) mod witness;
 
-pub(crate) use lib::verify_dummy_private_batch_template;
+pub(crate) use lib::{preflight_private_batch_proofs, verify_dummy_private_batch_template};
 pub use lib::{PublicBatchInputs, PublicBatchProver};

--- a/wormhole/circuit-builder/src/lib.rs
+++ b/wormhole/circuit-builder/src/lib.rs
@@ -39,7 +39,7 @@ pub fn generate_circuit_binaries<P: AsRef<Path>>(output_dir: P) -> Result<()> {
         "Building wormhole leaf circuit (non-ZK by design; ZK lives at the private-batch layer)..."
     );
     let config = wormhole_leaf_circuit_config();
-    let circuit = WormholeCircuit::new(config);
+    let circuit = WormholeCircuit::new(config)?;
     let targets = circuit.targets();
     let circuit_data = circuit.build_circuit();
     println!("Circuit built.");

--- a/wormhole/circuit/src/circuit.rs
+++ b/wormhole/circuit/src/circuit.rs
@@ -22,11 +22,14 @@ pub mod circuit_logic {
     use crate::substrate_account::{DualExitAccount, DualExitAccountTargets};
     use crate::unspendable_account::{UnspendableAccount, UnspendableAccountTargets};
     use crate::zk_merkle_proof::{ZkMerkleProofData, ZkMerkleProofTargets};
+    use anyhow::Result;
     use plonky2::{
         plonk::circuit_data::{CircuitData, ProverCircuitData, VerifierCircuitData},
         plonk::{circuit_builder::CircuitBuilder, circuit_data::CircuitConfig},
     };
-    use zk_circuits_common::circuit::{wormhole_leaf_circuit_config, CircuitFragment, C, D, F};
+    use zk_circuits_common::circuit::{
+        validate_circuit_config, wormhole_leaf_circuit_config, CircuitFragment, C, D, F,
+    };
 
     #[derive(Debug, Clone)]
     pub struct CircuitTargets {
@@ -95,17 +98,28 @@ pub mod circuit_logic {
         /// in a trusted environment), not on-chain. Disabling ZK improves proving performance.
         fn default() -> Self {
             let config = wormhole_leaf_circuit_config();
-            Self::new(config)
+            Self::new(config).expect("canonical wormhole leaf circuit config is valid")
         }
     }
 
     impl WormholeCircuit {
-        pub fn new(config: CircuitConfig) -> Self {
+        /// Build the Wormhole leaf circuit from a caller-supplied config.
+        ///
+        /// The config is checked against the shared structural policy
+        /// ([`validate_circuit_config`]) BEFORE any builder work: an
+        /// unchecked config would otherwise panic deep inside plonky2
+        /// mid-construction (e.g. `num_wires` below the Poseidon gate floor)
+        /// or drive exponential allocations during the expensive build phase
+        /// (e.g. oversized FRI exponents) — see the audit finding on
+        /// unvalidated `CircuitConfig` in public constructors.
+        pub fn new(config: CircuitConfig) -> Result<Self> {
+            validate_circuit_config(&config)?;
+
             #[cfg(feature = "profile")]
-            return Self::new_profiled(config);
+            return Ok(Self::new_profiled(config));
 
             #[cfg(not(feature = "profile"))]
-            Self::new_internal(config)
+            Ok(Self::new_internal(config))
         }
 
         #[cfg(not(feature = "profile"))]

--- a/wormhole/circuit/src/profile.rs
+++ b/wormhole/circuit/src/profile.rs
@@ -99,7 +99,7 @@ mod tests {
         println!("========================================\n");
 
         let config = wormhole_private_batch_circuit_config();
-        let circuit = WormholeCircuit::new(config);
+        let circuit = WormholeCircuit::new(config).expect("valid profile config");
         let data = circuit.build_circuit_profiled();
         print_circuit_metrics(&data.common);
 
@@ -111,7 +111,7 @@ mod tests {
         println!("========================================\n");
 
         let config = CircuitConfig::standard_recursion_config();
-        let circuit = WormholeCircuit::new(config);
+        let circuit = WormholeCircuit::new(config).expect("valid profile config");
         let data = circuit.build_circuit_profiled();
         print_circuit_metrics(&data.common);
 
@@ -175,7 +175,7 @@ mod tests {
                 ..CircuitConfig::standard_recursion_zk_config()
             };
 
-            let circuit = WormholeCircuit::new(config);
+            let circuit = WormholeCircuit::new(config).expect("valid profile config");
             let data = circuit.build_circuit_profiled();
 
             println!(

--- a/wormhole/memprof/src/config.rs
+++ b/wormhole/memprof/src/config.rs
@@ -21,7 +21,8 @@
 use clap::{ArgGroup, Args, ValueEnum};
 use plonky2::plonk::circuit_data::CircuitConfig;
 use zk_circuits_common::circuit::{
-    wormhole_leaf_circuit_config, wormhole_private_batch_circuit_config,
+    wormhole_leaf_circuit_config, wormhole_private_batch_circuit_config, MAX_CAP_HEIGHT,
+    MAX_RATE_BITS, MIN_MAX_QUOTIENT_DEGREE_FACTOR, MIN_NUM_ROUTED_WIRES, MIN_NUM_WIRES,
 };
 
 #[derive(Copy, Clone, Debug, ValueEnum, PartialEq, Eq)]
@@ -114,53 +115,13 @@ pub struct AggConfigArgs {
     pub allow_weakening_security: bool,
 }
 
-/// The Poseidon gate needs 135 wire columns; a smaller `num_wires` panics
-/// deep inside plonky2's `check_gate_compatibility` mid-build instead of
-/// failing at the CLI boundary.
-const MIN_NUM_WIRES: usize = 135;
-
-/// Poseidon constraints have degree 7; a smaller quotient degree factor
-/// cannot express them and fails during circuit construction.
-const MIN_MAX_QUOTIENT_DEGREE_FACTOR: usize = 7;
-
-/// Structural routed-wire floor for the pinned plonky2 recursion stack.
-///
-/// Gates pack operations into the routed-wire prefix, and several derive
-/// their op count from `num_routed_wires`: base arithmetic uses 4 routed
-/// wires per op, extension arithmetic `4*D = 8`, and the FRI verifier's
-/// random-access gate `2 + 2^4 = 18` per copy (arity/cap lists are 16
-/// entries under the production `ConstantArityBits(4, 5)` / `cap_height=4`
-/// FRI shape). Below a gate's width it instantiates with ZERO operation
-/// slots: `find_slot`'s `num_ops - 1` underflows (debug panic; in release an
-/// under-constraining zero-op gate is added and the build only dies later on
-/// a routability assert). The binding floor is the 16-point
-/// coset-interpolation gate, which routes `1 + 16*D + D + D = 37` wires
-/// outright; plonky2's own `check_recursion_config` assert for it fires only
-/// mid-build, after the expensive leaf context already exists. Reject all of
-/// these at the CLI boundary — none is a sound or profitable circuit shape,
-/// so none should ever be profiled as a safe memory-saving configuration.
-const MIN_NUM_ROUTED_WIRES: usize = 37;
-
-/// Ceiling for `--rate-bits`. Both FRI exponent knobs drive exponential
-/// allocations deep inside plonky2 (`FriParams::lde_size` is
-/// `1 << (degree_bits + rate_bits)` per committed polynomial), so an
-/// oversized but syntactically valid value passes clap and then either
-/// makes massive allocations or trips asserts only after the expensive
-/// circuit build has started. Production is 3; 8 already means a
-/// 32x-production LDE, which is as far as any memory sweep meaningfully
-/// goes. Reject anything larger at the CLI boundary.
-const MAX_RATE_BITS: usize = 8;
-
-/// Ceiling for `--cap-height`. The Merkle cap is `1 << cap_height` hashes
-/// per oracle, and the recursive verifier allocates `1 << cap_height` hash
-/// targets for the verifier data (`add_virtual_cap`), all registered as
-/// public inputs — so this knob blows up circuit size exponentially, not
-/// just proof size. `MerkleTree::new` additionally asserts
-/// `cap_height <= degree_bits + rate_bits` only mid-build; with the cap
-/// bounded at 8 (16x the production cap of 4) that assert is unreachable
-/// for any real aggregation circuit (`degree_bits` >= 12), so the bound
-/// also serves as the cap/degree consistency guard.
-const MAX_CAP_HEIGHT: usize = 8;
+// The structural floors/ceilings (MIN_NUM_WIRES, MIN_NUM_ROUTED_WIRES,
+// MIN_MAX_QUOTIENT_DEGREE_FACTOR, MAX_RATE_BITS, MAX_CAP_HEIGHT) are imported
+// from `zk_circuits_common::circuit`, where they back the shared
+// `validate_circuit_config` policy that every public circuit constructor now
+// enforces. Sharing the constants keeps this CLI's flag validation in
+// lockstep with the constructor policy; see the constants' docs in
+// zk-circuits-common for the full rationale behind each bound.
 
 /// `ceil(log2(n))` for `n >= 1`, mirroring plonky2's `log2_ceil`.
 fn log2_ceil(n: usize) -> usize {

--- a/wormhole/memprof/src/workload.rs
+++ b/wormhole/memprof/src/workload.rs
@@ -38,7 +38,7 @@ pub fn build_leaf_context(
     report.phase_start("build_leaf_circuit")?;
 
     // Build circuit ONCE - extract all data from this single build
-    let circuit = WormholeCircuit::new(leaf_cfg);
+    let circuit = WormholeCircuit::new(leaf_cfg)?;
     let targets = circuit.targets();
     let circuit_data = circuit.build_circuit();
 

--- a/wormhole/prover/README.md
+++ b/wormhole/prover/README.md
@@ -41,7 +41,7 @@ fn main() -> anyhow::Result<()> {
   };
 
   let config = CircuitConfig::standard_recursion_config();
-  let prover = WormholeProver::new(config);
+  let prover = WormholeProver::new(config)?;
   let proof = prover.commit(&inputs)?.prove()?;
   Ok(())
 }

--- a/wormhole/prover/benches/prover.rs
+++ b/wormhole/prover/benches/prover.rs
@@ -16,7 +16,7 @@ fn create_proof_benchmark_zk(c: &mut Criterion) {
     c.bench_function("prover_create_proof_zk", |b| {
         b.iter_batched(
             // Setup: create a new prover for each iteration (not measured)
-            || WormholeProver::new(config.clone()),
+            || WormholeProver::new(config.clone()).expect("valid circuit config"),
             // Measured: commit and prove
             |prover| prover.commit(&inputs).unwrap().prove().unwrap(),
             // Use SmallInput since we're creating a new prover each time
@@ -33,7 +33,7 @@ fn create_proof_benchmark_no_zk(c: &mut Criterion) {
     c.bench_function("prover_create_proof_no_zk", |b| {
         b.iter_batched(
             // Setup: create a new prover for each iteration (not measured)
-            || WormholeProver::new(config.clone()),
+            || WormholeProver::new(config.clone()).expect("valid circuit config"),
             // Measured: commit and prove
             |prover| prover.commit(&inputs).unwrap().prove().unwrap(),
             // Use SmallInput since we're creating a new prover each time

--- a/wormhole/prover/src/lib.rs
+++ b/wormhole/prover/src/lib.rs
@@ -60,7 +60,7 @@
 //! };
 //!
 //! let config = CircuitConfig::standard_recursion_config();
-//! let prover = WormholeProver::new(config);
+//! let prover = WormholeProver::new(config)?;
 //! let prover_next = prover.commit(&inputs)?;
 //! let _proof = prover_next.prove()?;
 //! # Ok(())
@@ -122,22 +122,30 @@ impl core::fmt::Debug for WormholeProver {
 /// (not on-chain). This improves proving performance without compromising security.
 pub fn build_fresh() -> WormholeProver {
     WormholeProver::new(zk_circuits_common::circuit::wormhole_leaf_circuit_config())
+        .expect("canonical wormhole leaf circuit config is valid")
 }
 
 impl WormholeProver {
     /// Creates a new [`WormholeProver`].
-    pub fn new(config: CircuitConfig) -> Self {
-        let wormhole_circuit = WormholeCircuit::new(config);
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `config` fails the shared structural policy
+    /// (`zk_circuits_common::circuit::validate_circuit_config`): an unchecked
+    /// config would otherwise panic deep inside plonky2 mid-construction or
+    /// drive exponential allocations during the circuit build.
+    pub fn new(config: CircuitConfig) -> anyhow::Result<Self> {
+        let wormhole_circuit = WormholeCircuit::new(config)?;
         let partial_witness = PartialWitness::new();
 
         let targets = Some(wormhole_circuit.targets());
         let circuit_data = wormhole_circuit.build_prover();
 
-        Self {
+        Ok(Self {
             circuit_data,
             partial_witness,
             targets,
-        }
+        })
     }
 
     /// Commits the provided [`CircuitInputs`] to the circuit by filling relevant targets.

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -357,17 +357,20 @@ fn aggregate_proofs_from_separate_prover_instances_hex_serialized() {
     let (inputs_1, inputs_2) = two_real_leaves_same_block(0);
 
     // Proof 1 from prover A
-    let prover_a = WormholeProver::new(circuit_config());
+    let prover_a = WormholeProver::new(circuit_config()).expect("valid circuit config");
     let proof_1 = prover_a.commit(&inputs_1).unwrap().prove().unwrap();
     let proof_1_hex = hex::encode(proof_1.to_bytes());
 
     // Proof 2 from prover B (same block, distinct nullifier)
-    let prover_b = WormholeProver::new(circuit_config());
+    let prover_b = WormholeProver::new(circuit_config()).expect("valid circuit config");
     let proof_2 = prover_b.commit(&inputs_2).unwrap().prove().unwrap();
     let proof_2_hex = hex::encode(proof_2.to_bytes());
 
     // Use fresh common_data to deserialize like CLI would
-    let deser_common_data = WormholeProver::new(circuit_config()).circuit_data.common;
+    let deser_common_data = WormholeProver::new(circuit_config())
+        .expect("valid circuit config")
+        .circuit_data
+        .common;
 
     let proof_1_bytes = hex::decode(&proof_1_hex).expect("Failed to decode proof 1 hex");
     let proof_2_bytes = hex::decode(&proof_2_hex).expect("Failed to decode proof 2 hex");

--- a/wormhole/tests/src/aggregator/aggregator_tests.rs
+++ b/wormhole/tests/src/aggregator/aggregator_tests.rs
@@ -742,6 +742,67 @@ fn public_batch_aggregator_prove_batch_ignores_bins_dir_after_init() {
 }
 
 #[test]
+fn prove_batch_rejects_bad_proof_counts_before_building_the_prover() {
+    // Audit finding: ProvingContext::prove_batch built the PublicBatchProver
+    // (a full recursive circuit construction, seconds of CPU) before commit
+    // ran the cheap proof-count admission checks. A caller with access to the
+    // proving endpoint could thus submit empty or oversized proof vectors and
+    // burn a circuit-construction's worth of CPU and memory per request.
+    // Known-bad counts must be rejected in a preflight, before construction.
+    //
+    // Self-calibrating: one real prover construction is timed on this machine,
+    // and each rejection must come back at least an order of magnitude faster
+    // (the preflight is O(len) count checks — microseconds in practice).
+    use std::time::Instant;
+    use wormhole_aggregator::public_batch::prover::PublicBatchProver;
+
+    setup_public_test_binaries();
+    let dir = public_bins_dir();
+    let address = BytesDigest::try_from([1u8; 32]).expect("valid address");
+
+    let aggregator = PublicBatchAggregator::new(&dir, address).expect("public aggregator");
+    let batch_size = aggregator.batch_size();
+    let prover = aggregator.proving_context();
+    drop(aggregator);
+
+    let real_proof = make_private_batch_proof_in_public_dir();
+
+    // Calibrate: the cost prove_batch must NOT pay for a known-bad vector.
+    let build_started = Instant::now();
+    let _built = PublicBatchProver::new_from_binaries_dir(&dir)
+        .expect("baseline prover construction must succeed");
+    let build_time = build_started.elapsed();
+
+    // Empty vector: known-bad without looking at any proof. `{err:#}` prints
+    // the whole context chain; the admission-check message is the cause.
+    let rejected_at = Instant::now();
+    let err = prover.prove_batch(vec![]).unwrap_err();
+    let empty_reject_time = rejected_at.elapsed();
+    let chain = format!("{err:#}");
+    assert!(chain.contains("no private-batch proofs"), "got: {chain}");
+
+    // Oversized vector: known-bad from its length alone.
+    let oversized = vec![real_proof; batch_size + 1];
+    let rejected_at = Instant::now();
+    let err = prover.prove_batch(oversized).unwrap_err();
+    let oversized_reject_time = rejected_at.elapsed();
+    let chain = format!("{err:#}");
+    assert!(chain.contains("at most"), "got: {chain}");
+
+    for (label, reject_time) in [
+        ("empty", empty_reject_time),
+        ("oversized", oversized_reject_time),
+    ] {
+        assert!(
+            reject_time < build_time / 10,
+            "rejecting an {label} proof vector took {reject_time:?}, more than a tenth \
+             of a prover construction ({build_time:?}): prove_batch is paying for \
+             circuit construction before its admission checks"
+        );
+    }
+}
+
+#[test]
 fn pool_rejects_invalid_proofs_and_aggregates_by_bucket() {
     setup_public_test_binaries();
     let dir = public_bins_dir();

--- a/wormhole/tests/src/circuit/circuit_data_tests.rs
+++ b/wormhole/tests/src/circuit/circuit_data_tests.rs
@@ -26,8 +26,44 @@ fn full_circuit_data_loader_is_not_exposed() {
     // `wormhole_circuit::circuit` intentionally only exposes `circuit_logic`.
     // Building from source is the only way to obtain leaf CircuitData.
     let config = CircuitConfig::standard_recursion_config();
-    let circuit_data = WormholeCircuit::new(config).build_circuit();
+    let circuit_data = WormholeCircuit::new(config)
+        .expect("valid circuit config")
+        .build_circuit();
     assert_eq!(circuit_data.common.num_public_inputs, 21);
+}
+
+/// Audit finding: the leaf constructors accepted an arbitrary caller-supplied
+/// `CircuitConfig` and forwarded it to `CircuitBuilder::new` unchecked, so
+/// structurally impossible configs (e.g. `num_wires` below the Poseidon gate
+/// floor) panicked deep inside plonky2 mid-construction and
+/// resource-pathological configs (e.g. oversized FRI exponents driving
+/// `2^(degree_bits + rate_bits)` LDE allocations) only exploded during the
+/// expensive build phase. Both `WormholeCircuit::new` and
+/// `WormholeProver::new` must instead reject them with a controlled error
+/// before any builder work.
+#[test]
+fn leaf_constructors_reject_pathological_circuit_configs() {
+    // Structurally impossible: below the Poseidon gate wire floor.
+    let mut narrow = CircuitConfig::standard_recursion_config();
+    narrow.num_wires = 134;
+    let err = WormholeCircuit::new(narrow.clone())
+        .err()
+        .expect("num_wires below the Poseidon gate floor must be rejected");
+    assert!(err.to_string().contains("num_wires"), "got: {err}");
+    let err = wormhole_prover::WormholeProver::new(narrow)
+        .expect_err("prover must reject the same config");
+    assert!(err.to_string().contains("num_wires"), "got: {err}");
+
+    // Resource-pathological: oversized FRI rate (exponential LDE size).
+    let mut huge_rate = CircuitConfig::standard_recursion_config();
+    huge_rate.fri_config.rate_bits = 63;
+    let err = WormholeCircuit::new(huge_rate.clone())
+        .err()
+        .expect("oversized rate_bits must be rejected before construction");
+    assert!(err.to_string().contains("rate_bits"), "got: {err}");
+    let err = wormhole_prover::WormholeProver::new(huge_rate)
+        .expect_err("prover must reject the same config");
+    assert!(err.to_string().contains("rate_bits"), "got: {err}");
 }
 
 #[test]
@@ -38,7 +74,9 @@ fn test_prover_and_verifier_from_file_e2e() -> Result<()> {
 
     // Generate circuit and write component files to the temporary directory.
     let config = CircuitConfig::standard_recursion_config();
-    let circuit_data = WormholeCircuit::new(config).build_circuit();
+    let circuit_data = WormholeCircuit::new(config)
+        .expect("valid circuit config")
+        .build_circuit();
 
     let gate_serializer = DefaultGateSerializer;
 

--- a/wormhole/tests/src/prover/prover_tests.rs
+++ b/wormhole/tests/src/prover/prover_tests.rs
@@ -14,7 +14,7 @@ const CIRCUIT_CONFIG: CircuitConfig = CircuitConfig::standard_recursion_config()
 
 #[test]
 fn commit_and_prove() {
-    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     prover.commit(&inputs).unwrap().prove().unwrap();
 }
@@ -23,7 +23,7 @@ fn commit_and_prove() {
 fn commit_rejects_zk_merkle_proof_exceeding_max_depth() {
     use zk_circuits_common::zk_merkle::SIBLINGS_PER_LEVEL;
 
-    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
     let mut inputs = CircuitInputs::test_inputs_0();
 
     // Add siblings beyond the max depth (MAX_DEPTH = 16)
@@ -38,7 +38,7 @@ fn commit_rejects_zk_merkle_proof_exceeding_max_depth() {
 
 #[test]
 fn proof_can_be_deserialized() {
-    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
@@ -52,7 +52,7 @@ fn proof_can_be_deserialized() {
 
 #[test]
 fn get_public_inputs() {
-    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
     let public_inputs = proof.public_inputs;
@@ -66,7 +66,7 @@ fn export_test_proof() {
 
     let circuit_config = CircuitConfig::standard_recursion_config();
 
-    let prover = WormholeProver::new(circuit_config);
+    let prover = WormholeProver::new(circuit_config).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
     let proof_bytes = proof.to_bytes();
@@ -80,7 +80,7 @@ fn export_test_proof_zk() {
 
     let circuit_config = wormhole_private_batch_circuit_config();
 
-    let prover = WormholeProver::new(circuit_config);
+    let prover = WormholeProver::new(circuit_config).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
     let proof_bytes = proof.to_bytes();
@@ -94,7 +94,7 @@ fn export_hex_proof_for_pallet() {
 
     let circuit_config = CircuitConfig::standard_recursion_config();
 
-    let prover = WormholeProver::new(circuit_config);
+    let prover = WormholeProver::new(circuit_config).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
     let proof_bytes = proof.to_bytes();
@@ -384,7 +384,7 @@ fn test_random_tree_circuit_verification() {
     };
 
     // Run the circuit prover
-    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
     let result = prover.commit(&inputs);
     assert!(result.is_ok(), "Commit failed: {:?}", result.err());
 
@@ -489,7 +489,7 @@ fn test_depth_2_tree_circuit_verification() {
             },
         };
 
-        let prover = WormholeProver::new(CIRCUIT_CONFIG);
+        let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
         let _proof = prover.commit(&inputs).unwrap().prove().unwrap();
         println!("Leaf {} verified successfully!", leaf_index);
     }
@@ -606,7 +606,7 @@ fn test_depth_3_tree_circuit_verification() {
             },
         };
 
-        let prover = WormholeProver::new(CIRCUIT_CONFIG);
+        let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
         let _proof = prover.commit(&inputs).unwrap().prove().unwrap();
         println!("Leaf {} verified successfully!", leaf_index);
     }

--- a/wormhole/tests/src/verifier/verifier_tests.rs
+++ b/wormhole/tests/src/verifier/verifier_tests.rs
@@ -19,11 +19,15 @@ fn build_test_verifier() -> plonky2::plonk::circuit_data::VerifierCircuitData<
     zk_circuits_common::circuit::C,
     { zk_circuits_common::circuit::D },
 > {
-    WormholeCircuit::new(CIRCUIT_CONFIG).build_verifier()
+    WormholeCircuit::new(CIRCUIT_CONFIG)
+        .expect("valid circuit config")
+        .build_verifier()
 }
 
 fn build_verifier_bytes(config: CircuitConfig) -> (Vec<u8>, Vec<u8>) {
-    let verifier_data = WormholeCircuit::new(config).build_verifier();
+    let verifier_data = WormholeCircuit::new(config)
+        .expect("valid circuit config")
+        .build_verifier();
     let common_bytes = verifier_data
         .common
         .to_bytes(&plonky2::util::serialization::DefaultGateSerializer)
@@ -34,7 +38,7 @@ fn build_verifier_bytes(config: CircuitConfig) -> (Vec<u8>, Vec<u8>) {
 
 #[test]
 fn verify_simple_proof() {
-    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     let commitment = prover.commit(&inputs).unwrap();
     let proof = commitment.prove().unwrap();
@@ -45,7 +49,7 @@ fn verify_simple_proof() {
 
 #[test]
 fn borrowed_verify_keeps_proof_available() {
-    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
@@ -81,7 +85,7 @@ fn verifier_loader_rejects_same_profile_substituted_circuit() {
 
 #[test]
 fn cannot_verify_with_modified_exit_account() {
-    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     let mut proof = prover.commit(&inputs).unwrap().prove().unwrap();
 
@@ -105,7 +109,7 @@ fn cannot_verify_with_modified_exit_account() {
 
 #[test]
 fn cannot_verify_with_any_public_input_modification() {
-    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
     let verifier_data = build_test_verifier();
@@ -126,7 +130,7 @@ fn cannot_verify_with_any_public_input_modification() {
 #[ignore]
 #[test]
 fn cannot_verify_with_modified_proof() {
-    let prover = WormholeProver::new(CIRCUIT_CONFIG);
+    let prover = WormholeProver::new(CIRCUIT_CONFIG).expect("valid circuit config");
     let inputs = CircuitInputs::test_inputs_0();
     let proof = prover.commit(&inputs).unwrap().prove().unwrap();
     let verifier_data = build_test_verifier();

--- a/wormhole/verifier/README.md
+++ b/wormhole/verifier/README.md
@@ -44,7 +44,7 @@ fn main() -> anyhow::Result<()> {
 
   // Generate a proof
   let config = CircuitConfig::standard_recursion_config();
-  let prover = WormholeProver::new(config.clone());
+  let prover = WormholeProver::new(config.clone())?;
   let proof = prover.commit(&inputs)?.prove()?;
 
   // Verify the proof


### PR DESCRIPTION
# Security review fixes: preflight admission checks, config validation, witness-filler visibility

This PR addresses three findings from the security review. Each fix landed with a red test written first (where a runtime test applies) and verified green after the fix.

## 1. Public-batch admission checks now run before prover construction (`04a92d6`)

**Finding.** `ProvingContext::prove_batch` built a fresh `PublicBatchProver` — a full recursive circuit construction costing roughly a second of CPU — *before* `commit` ran the cheap admission checks (proof count bounds, public-input shape, cryptographic verification, batch compatibility). A caller with access to the proving endpoint could submit known-bad proof vectors (empty, oversized) and burn a circuit construction's worth of CPU and memory per request.

**Fix.** The admission checks that don't need circuit targets were extracted from `PublicBatchProver::commit` into a `pub(crate) fn preflight_private_batch_proofs`, and `prove_batch` now runs that preflight before constructing the prover. `commit` still runs the same checks, so direct prover users lose nothing.

**Test.** `prove_batch_rejects_bad_proof_counts_before_building_the_prover` (tests crate) is self-calibrating: it times one real prover construction on the host, then asserts that empty and oversized vectors are rejected at least 10x faster than that. Pre-fix it failed (rejection ~369 ms vs. ~911 ms build); post-fix rejection is microseconds.

## 2. `CircuitConfig` is validated in every public circuit constructor (`08fe14c`)

**Finding.** `WormholeCircuit::new`, `PrivateBatchCircuit::new`, and `PublicBatchCircuit::new` forwarded a caller-supplied `CircuitConfig` to `CircuitBuilder::new` unchecked. Structurally impossible configs (zero challenges, too-narrow wire counts) panicked deep inside plonky2 mid-construction, and pathological FRI parameters (large `rate_bits` / `cap_height`) drive exponential allocation during the expensive build phase. The safe structural minima existed only in memprof's CLI argument parsing, not at the library boundary.

**Fix.** A shared `validate_circuit_config` policy now lives in `zk-circuits-common` and is enforced at the top of all three constructors, returning a controlled `anyhow` error for rejected configurations. It checks:

- positive `num_challenges`, `security_bits`, `num_query_rounds`;
- `num_wires` / `num_routed_wires` floors (Poseidon and recursion gate requirements) and `num_routed_wires <= num_wires`;
- `max_quotient_degree_factor >= 7` (Poseidon constraint degree);
- ceilings on `fri_config.rate_bits` and `cap_height` (both drive exponential allocations);
- `rate_bits >= ceil(log2(max_quotient_degree_factor))`, a pair plonky2 otherwise only asserts at proving time, after the full build.

**API change.** `WormholeCircuit::new` and `WormholeProver::new` are now fallible (`Result<Self>`). All callers were updated; `WormholeProver::build_fresh` keeps its infallible signature (canonical config, `expect`). Memprof's duplicated constants were replaced with imports of the shared ones so the two policies cannot drift.

**Tests.** New rejection tests for all three constructors plus unit tests for the validator itself. Pre-fix, the constructor tests died in panics inside plonky2's `CircuitBuilder`; post-fix they get controlled errors naming the offending parameter.

## 3. Private-batch witness filler is no longer exported (`217bfcf`)

**Finding.** `private_batch::prover::witness::fill_private_batch_witness` was `pub` and re-exported. The function performs only structural shape checks and target assignment; the admission gate (pinned leaf verification, metadata compatibility, empty/all-dummy rejection, dummy-template padding) lives in `PrivateBatchProver::commit`. A downstream service calling the helper directly could bypass that gate and push invalid, incompatible, or all-dummy batches into the expensive recursive proving path. The public-batch analogue already kept its witness module `pub(crate)` for exactly this reason.

**Fix.** The `witness` module and the `fill_private_batch_witness` re-export are now `pub(crate)`, mirroring the public-batch prover, with the admission-boundary rationale documented on the module. All existing callers are inside the aggregator crate, so no legitimate consumer is affected (verified: no uses in the tests crate or downstream repos).

**Test.** A `compile_fail` doctest pins the boundary — it fails if the helper ever becomes externally reachable again — paired with a passing companion doctest that pins the same fully-qualified path prefix via the public `PrivateBatchProver`, so the compile failure can only come from the `witness` segment's privacy and not an unrelated rename.

## Verification

- All workspace test suites pass in `--release` (common, aggregator, prover, verifier, tests crate, memprof).
- `cargo clippy --release --workspace --all-targets` is clean.
- Each runtime-testable fix was demonstrated red before the fix and green after.