### PR TITLE
chore: bump qp-plonky2 1.5.5 and qp-poseidon-core 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff530eb14bc9389c7c5dad8fc3b1a90a6a5784f34daf74a34b963a562b73b0d0"
+checksum = "8fd331d489a309f88e2d0e35a2b996932c7d92038b91ccc656a0a8e6b11b6977"
 dependencies = [
  "ahash",
  "anyhow",
@@ -996,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2-core"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da3052436ca37dbb0540280e37846da1e826bd026745798853b6ffbb3b5e798"
+checksum = "b81a3a9fce99f7bd45b8578f8d9b6a33507d34c2eb2c47c969b464db1ad601d3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2-field"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518a71f954222caa0d87fd331254a1651b5ee09d8e21881899478b0a1c2cc42e"
+checksum = "1630d418ddce9feba18d3364596711d07074851757301350de313eef0a31af4f"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "qp-plonky2-verifier"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d3c30ed97690849cf92eb0fdd1d4e6765ecc9e6be6b0a0e9b4dc4accb5145f"
+checksum = "944da5dec21ee476d561f6c38caddf45e829f3cc5fccbc76f6ece03660378dbe"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "qp-poseidon-core"
-version = "3.0.2"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e32db7b3a5d70086f82f198ecfc021f17cb7ec70a416512dba3488f4a116c1"
+checksum = "5872607e25ea4ee5fb37e64bf1462168e1a36a4e719cdc8a105533c708253918"
 
 [[package]]
 name = "qp-voting-circuit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-anyhow = { version = "=1.0.100", default-features = false }
+anyhow = { version = "=1.0.104", default-features = false }
 criterion = { version = "=0.5.1", default-features = false }
 hex = { version = "=0.4.3", default-features = false, features = ["alloc"] }
-qp-plonky2 = { version = "=1.5.4", default-features = false, features = ["std"] }
-qp-poseidon-core = { version = "=3.0.2", default-features = false }
+qp-plonky2 = { version = "=1.5.5", default-features = false, features = ["std"] }
+qp-poseidon-core = { version = "=3.1.0", default-features = false }
 serde = { version = "=1.0.228", default-features = false, features = ["derive"] }
 tiny-keccak = { version = "=2.0.2", default-features = false, features = ["keccak"] }
 zeroize = { version = "=1.8.2", default-features = false, features = ["alloc"] }

--- a/wormhole/verifier/Cargo.toml
+++ b/wormhole/verifier/Cargo.toml
@@ -9,7 +9,7 @@ version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-qp-plonky2-verifier = { version = "=1.5.4", default-features = false }
+qp-plonky2-verifier = { version = "=1.5.5", default-features = false }
 qp-wormhole-inputs = { version = "=4.1.0", path = "../inputs", default-features = false }
 tiny-keccak = { workspace = true }
 


### PR DESCRIPTION
Bump workspace crypto pins:

- `qp-plonky2` / `qp-plonky2-verifier` **1.5.4 → 1.5.5**
- `qp-poseidon-core` **3.0.2 → 3.1.0**
- `anyhow` **1.0.100 → 1.0.104** (required by plonky2 1.5.5)

Lockfile has a single version of each of these crates.

**Follow-up:** after merge, cut a release of the wormhole / common crates so chain, quantus-cli, and quantus-apps can resolve these pins without dual-version lockfiles.