### PR TITLE
ci: Automate workspace version bump to v4.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ checksum = "5872607e25ea4ee5fb37e64bf1462168e1a36a4e719cdc8a105533c708253918"
 
 [[package]]
 name = "qp-wormhole-aggregator"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-circuit"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-circuit-builder"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -981,14 +981,14 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-inputs"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "qp-wormhole-prover"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "qp-wormhole-verifier"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "qp-zk-circuits-common"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "qp-plonky2",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "test-helpers"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "hex",
  "qp-plonky2",
@@ -1347,7 +1347,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "wormhole-memprof"
-version = "4.1.0"
+version = "4.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ edition = "2021"
 keywords = ["circuits", "plonky2", "quantus-network", "wormhole", "zk"]
 license = "MIT"
 repository = "https://github.com/Quantus-Network/qp-zk-circuits"
-version = "4.1.0"
+version = "4.2.0"
 
 [workspace.lints.clippy]
 uninlined_format_args = "allow"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 anyhow = { workspace = true, default-features = false }
 qp-plonky2 = { workspace = true, default-features = false }
 qp-poseidon-core = { workspace = true, default-features = false }
-qp-wormhole-inputs = { version = "=4.1.0", path = "../wormhole/inputs", default-features = false }
+qp-wormhole-inputs = { version = "=4.2.0", path = "../wormhole/inputs", default-features = false }
 rand = { version = "=0.8.6", default-features = false, features = ["alloc"], optional = true }
 serde = { workspace = true }
 serde_json = { version = "=1.0.150", default-features = false, features = ["alloc"] }

--- a/wormhole/aggregator/Cargo.toml
+++ b/wormhole/aggregator/Cargo.toml
@@ -11,14 +11,14 @@ version.workspace = true
 anyhow = { workspace = true }
 hex = "=0.4.3"
 qp-plonky2 = { workspace = true }
-qp-wormhole-inputs = { version = "=4.1.0", path = "../inputs" }
+qp-wormhole-inputs = { version = "=4.2.0", path = "../inputs" }
 rand = "=0.8.6"
 rayon = { version = "=1.12.0", optional = true }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.150"
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.1.0", path = "../circuit", default-features = false }
-wormhole-prover = { package = "qp-wormhole-prover", version = "=4.1.0", path = "../prover", default-features = false }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.1.0", path = "../../common" }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.2.0", path = "../circuit", default-features = false }
+wormhole-prover = { package = "qp-wormhole-prover", version = "=4.2.0", path = "../prover", default-features = false }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.2.0", path = "../../common" }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/wormhole/circuit-builder/Cargo.toml
+++ b/wormhole/circuit-builder/Cargo.toml
@@ -10,25 +10,25 @@ version.workspace = true
 
 [build-dependencies]
 qp-plonky2 = { workspace = true, features = ["default"] }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=4.1.0", path = "../aggregator", default-features = false, features = ["std"] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.1.0", path = "../circuit", default-features = false, features = ["std"] }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.1.0", path = "../../common" }
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=4.2.0", path = "../aggregator", default-features = false, features = ["std"] }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.2.0", path = "../circuit", default-features = false, features = ["std"] }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.2.0", path = "../../common" }
 
 [dependencies]
 anyhow = { workspace = true, features = ["std"] }
 clap = { version = "=4.6.1", features = ["derive"] }
 qp-plonky2 = { workspace = true, features = ["default"] }
 rand = "=0.8.6"
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=4.1.0", path = "../aggregator", default-features = false, features = [
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=4.2.0", path = "../aggregator", default-features = false, features = [
 	"std",
 ] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.1.0", path = "../circuit", default-features = false, features = [
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.2.0", path = "../circuit", default-features = false, features = [
 	"std",
 ] }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.1.0", path = "../../common" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.2.0", path = "../../common" }
 
 [dev-dependencies]
 test-helpers = { path = "../tests/test-helpers", default-features = false }
-wormhole-prover = { package = "qp-wormhole-prover", version = "=4.1.0", path = "../prover", default-features = false, features = [
+wormhole-prover = { package = "qp-wormhole-prover", version = "=4.2.0", path = "../prover", default-features = false, features = [
 	"std",
 ] }

--- a/wormhole/circuit/Cargo.toml
+++ b/wormhole/circuit/Cargo.toml
@@ -11,9 +11,9 @@ version.workspace = true
 anyhow = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 qp-plonky2 = { workspace = true }
-qp-wormhole-inputs = { version = "=4.1.0", path = "../inputs", default-features = false }
+qp-wormhole-inputs = { version = "=4.2.0", path = "../inputs", default-features = false }
 zeroize = { workspace = true }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.1.0", path = "../../common", default-features = false }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.2.0", path = "../../common", default-features = false }
 
 [features]
 default = ["std"]

--- a/wormhole/memprof/Cargo.toml
+++ b/wormhole/memprof/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { workspace = true, features = ["std"] }
 clap = { version = "=4.6.1", features = ["derive"] }
 qp-plonky2 = { workspace = true, features = ["default"] }
 rayon = "=1.12.0"
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=4.1.0", path = "../aggregator", default-features = false, features = [
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=4.2.0", path = "../aggregator", default-features = false, features = [
 	"std",
 ] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.1.0", path = "../circuit", default-features = false, features = [
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.2.0", path = "../circuit", default-features = false, features = [
 	"std",
 ] }
-wormhole-prover = { package = "qp-wormhole-prover", version = "=4.1.0", path = "../prover", default-features = false, features = [
+wormhole-prover = { package = "qp-wormhole-prover", version = "=4.2.0", path = "../prover", default-features = false, features = [
 	"std",
 ] }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.1.0", path = "../../common" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.2.0", path = "../../common" }
 
 [lints]
 workspace = true

--- a/wormhole/prover/Cargo.toml
+++ b/wormhole/prover/Cargo.toml
@@ -10,12 +10,12 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2 = { workspace = true }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.1.0", path = "../circuit" }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.1.0", path = "../../common" }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.2.0", path = "../circuit" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.2.0", path = "../../common" }
 
 [dev-dependencies]
 criterion = { workspace = true }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=4.1.0", path = "../aggregator" }
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=4.2.0", path = "../aggregator" }
 
 [features]
 default = ["std"]

--- a/wormhole/tests/Cargo.toml
+++ b/wormhole/tests/Cargo.toml
@@ -12,20 +12,20 @@ bench = []
 
 [dependencies]
 anyhow = { workspace = true }
-circuit-builder = { package = "qp-wormhole-circuit-builder", version = "=4.1.0", path = "../circuit-builder" }
+circuit-builder = { package = "qp-wormhole-circuit-builder", version = "=4.2.0", path = "../circuit-builder" }
 hex = { workspace = true }
 libc = "=0.2.186"
 qp-plonky2 = { workspace = true, default-features = true }
-qp-wormhole-inputs = { version = "=4.1.0", path = "../inputs" }
+qp-wormhole-inputs = { version = "=4.2.0", path = "../inputs" }
 rand = { version = "=0.9.4", default-features = false, features = [
 	"thread_rng",
 ] }
 test-helpers = { path = "./test-helpers" }
-wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=4.1.0", path = "../aggregator", features = ["no_zk"] }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.1.0", path = "../circuit", default-features = true }
-wormhole-prover = { package = "qp-wormhole-prover", version = "=4.1.0", path = "../prover", default-features = true }
-wormhole-verifier = { package = "qp-wormhole-verifier", version = "=4.1.0", path = "../verifier", default-features = true }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.1.0", path = "../../common" }
+wormhole-aggregator = { package = "qp-wormhole-aggregator", version = "=4.2.0", path = "../aggregator", features = ["no_zk"] }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.2.0", path = "../circuit", default-features = true }
+wormhole-prover = { package = "qp-wormhole-prover", version = "=4.2.0", path = "../prover", default-features = true }
+wormhole-verifier = { package = "qp-wormhole-verifier", version = "=4.2.0", path = "../verifier", default-features = true }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.2.0", path = "../../common" }
 
 [dev-dependencies]
 proptest = "=1.11.0"

--- a/wormhole/tests/test-helpers/Cargo.toml
+++ b/wormhole/tests/test-helpers/Cargo.toml
@@ -10,6 +10,6 @@ version.workspace = true
 [dependencies]
 hex = { workspace = true }
 qp-plonky2 = { workspace = true, default-features = true }
-qp-wormhole-inputs = { version = "=4.1.0", path = "../../inputs" }
-wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.1.0", path = "../../circuit" }
-zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.1.0", path = "../../../common" }
+qp-wormhole-inputs = { version = "=4.2.0", path = "../../inputs" }
+wormhole-circuit = { package = "qp-wormhole-circuit", version = "=4.2.0", path = "../../circuit" }
+zk-circuits-common = { package = "qp-zk-circuits-common", version = "=4.2.0", path = "../../../common" }

--- a/wormhole/verifier/Cargo.toml
+++ b/wormhole/verifier/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 qp-plonky2-verifier = { version = "=1.5.5", default-features = false }
-qp-wormhole-inputs = { version = "=4.1.0", path = "../inputs", default-features = false }
+qp-wormhole-inputs = { version = "=4.2.0", path = "../inputs", default-features = false }
 tiny-keccak = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Automated workspace version bump for release v4.2.0.

https://github.com/Quantus-Network/qp-zk-circuits/actions/runs/31248650912

Triggered by workflow run: minor

Type: 